### PR TITLE
`ci`: attempt using files-folder instead of files

### DIFF
--- a/.github/workflows/publish-wix-installer.yml
+++ b/.github/workflows/publish-wix-installer.yml
@@ -81,7 +81,8 @@ jobs:
             endpoint: ${{ secrets.AZURE_ENDPOINT }}
             trusted-signing-account-name: ${{ secrets.AZURE_TRUSTED_SIGNING_NAME }}
             certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
-            files: qsv-${{ needs.analyze-tags.outputs.previous-tag }}.msi
+            files-folder: ${{ github.workspace }}
+            files-folder-filter: msi
             file-digest: SHA256
             timestamp-rfc3161: http://timestamp.acs.microsoft.com
             timestamp-digest: SHA256


### PR DESCRIPTION
Attempt using another method to find the MSI file in the action.