### PR TITLE
`contrib(completions)`: add joinp `--ignore-case` and slice `--invert`

### DIFF
--- a/contrib/completions/examples/qsv.bash
+++ b/contrib/completions/examples/qsv.bash
@@ -3034,7 +3034,7 @@ _qsv() {
             return 0
             ;;
         qsv__joinp)
-            opts="-h --left --left-anti --left-semi --right --full --cross --coalesce --filter-left --filter-right --validate --nulls --streaming --try-parsedates --infer-len --low-memory --no-optimizations --ignore-errors --decimal-comma --asof --left_by --right_by --strategy --tolerance --sql-filter --datetime-format --date-format --time-format --float-precision --null-value --output --delimiter --quiet --help"
+            opts="-h --ignore-case --left --left-anti --left-semi --right --full --cross --coalesce --filter-left --filter-right --validate --nulls --streaming --try-parsedates --infer-len --low-memory --no-optimizations --ignore-errors --decimal-comma --asof --left_by --right_by --strategy --tolerance --sql-filter --datetime-format --date-format --time-format --float-precision --null-value --output --delimiter --quiet --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3552,7 +3552,7 @@ _qsv() {
             return 0
             ;;
         qsv__slice)
-            opts="-h --start --end --len --index --json --output --no-headers --delimiter --help"
+            opts="-h --start --end --len --index --json --invert --output --no-headers --delimiter --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/contrib/completions/examples/qsv.elv
+++ b/contrib/completions/examples/qsv.elv
@@ -893,6 +893,7 @@ set edit:completion:arg-completer[qsv] = {|@words|
             cand --help 'Print help'
         }
         &'qsv;joinp'= {
+            cand --ignore-case 'ignore-case'
             cand --left 'left'
             cand --left-anti 'left-anti'
             cand --left-semi 'left-semi'
@@ -1258,6 +1259,7 @@ set edit:completion:arg-completer[qsv] = {|@words|
             cand --len 'len'
             cand --index 'index'
             cand --json 'json'
+            cand --invert 'invert'
             cand --output 'output'
             cand --no-headers 'no-headers'
             cand --delimiter 'delimiter'

--- a/contrib/completions/examples/qsv.fig.js
+++ b/contrib/completions/examples/qsv.fig.js
@@ -2106,6 +2106,9 @@ const completion: Fig.Spec = {
       name: "joinp",
       options: [
         {
+          name: "--ignore-case",
+        },
+        {
           name: "--left",
         },
         {
@@ -3052,6 +3055,9 @@ const completion: Fig.Spec = {
         },
         {
           name: "--json",
+        },
+        {
+          name: "--invert",
         },
         {
           name: "--output",

--- a/contrib/completions/examples/qsv.fish
+++ b/contrib/completions/examples/qsv.fish
@@ -712,6 +712,7 @@ complete -c qsv -n "__fish_qsv_using_subcommand join" -l output
 complete -c qsv -n "__fish_qsv_using_subcommand join" -l no-headers
 complete -c qsv -n "__fish_qsv_using_subcommand join" -l delimiter
 complete -c qsv -n "__fish_qsv_using_subcommand join" -s h -l help -d 'Print help'
+complete -c qsv -n "__fish_qsv_using_subcommand joinp" -l ignore-case
 complete -c qsv -n "__fish_qsv_using_subcommand joinp" -l left
 complete -c qsv -n "__fish_qsv_using_subcommand joinp" -l left-anti
 complete -c qsv -n "__fish_qsv_using_subcommand joinp" -l left-semi
@@ -978,6 +979,7 @@ complete -c qsv -n "__fish_qsv_using_subcommand slice" -l end
 complete -c qsv -n "__fish_qsv_using_subcommand slice" -l len
 complete -c qsv -n "__fish_qsv_using_subcommand slice" -l index
 complete -c qsv -n "__fish_qsv_using_subcommand slice" -l json
+complete -c qsv -n "__fish_qsv_using_subcommand slice" -l invert
 complete -c qsv -n "__fish_qsv_using_subcommand slice" -l output
 complete -c qsv -n "__fish_qsv_using_subcommand slice" -l no-headers
 complete -c qsv -n "__fish_qsv_using_subcommand slice" -l delimiter

--- a/contrib/completions/examples/qsv.nu
+++ b/contrib/completions/examples/qsv.nu
@@ -802,6 +802,7 @@ module completions {
   ]
 
   export extern "qsv joinp" [
+    --ignore-case
     --left
     --left-anti
     --left-semi
@@ -1167,6 +1168,7 @@ module completions {
     --len
     --index
     --json
+    --invert
     --output
     --no-headers
     --delimiter

--- a/contrib/completions/examples/qsv.ps1
+++ b/contrib/completions/examples/qsv.ps1
@@ -966,6 +966,7 @@ Register-ArgumentCompleter -Native -CommandName 'qsv' -ScriptBlock {
             break
         }
         'qsv;joinp' {
+            [CompletionResult]::new('--ignore-case', '--ignore-case', [CompletionResultType]::ParameterName, 'ignore-case')
             [CompletionResult]::new('--left', '--left', [CompletionResultType]::ParameterName, 'left')
             [CompletionResult]::new('--left-anti', '--left-anti', [CompletionResultType]::ParameterName, 'left-anti')
             [CompletionResult]::new('--left-semi', '--left-semi', [CompletionResultType]::ParameterName, 'left-semi')
@@ -1368,6 +1369,7 @@ Register-ArgumentCompleter -Native -CommandName 'qsv' -ScriptBlock {
             [CompletionResult]::new('--len', '--len', [CompletionResultType]::ParameterName, 'len')
             [CompletionResult]::new('--index', '--index', [CompletionResultType]::ParameterName, 'index')
             [CompletionResult]::new('--json', '--json', [CompletionResultType]::ParameterName, 'json')
+            [CompletionResult]::new('--invert', '--invert', [CompletionResultType]::ParameterName, 'invert')
             [CompletionResult]::new('--output', '--output', [CompletionResultType]::ParameterName, 'output')
             [CompletionResult]::new('--no-headers', '--no-headers', [CompletionResultType]::ParameterName, 'no-headers')
             [CompletionResult]::new('--delimiter', '--delimiter', [CompletionResultType]::ParameterName, 'delimiter')

--- a/contrib/completions/examples/qsv.zsh
+++ b/contrib/completions/examples/qsv.zsh
@@ -1006,6 +1006,7 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (joinp)
 _arguments "${_arguments_options[@]}" : \
+'--ignore-case[]' \
 '--left[]' \
 '--left-anti[]' \
 '--left-semi[]' \
@@ -1499,6 +1500,7 @@ _arguments "${_arguments_options[@]}" : \
 '--len[]' \
 '--index[]' \
 '--json[]' \
+'--invert[]' \
 '--output[]' \
 '--no-headers[]' \
 '--delimiter[]' \

--- a/contrib/completions/src/cmd/joinp.rs
+++ b/contrib/completions/src/cmd/joinp.rs
@@ -2,6 +2,7 @@ use clap::{arg, Command};
 
 pub fn joinp_cmd() -> Command {
     Command::new("joinp").args([
+        arg!(--"ignore-case"),
         arg!(--left),
         arg!(--"left-anti"),
         arg!(--"left-semi"),

--- a/contrib/completions/src/cmd/slice.rs
+++ b/contrib/completions/src/cmd/slice.rs
@@ -7,6 +7,7 @@ pub fn slice_cmd() -> Command {
         arg!(--len),
         arg!(--index),
         arg!(--json),
+        arg!(--invert),
         arg!(--output),
         arg!(--"no-headers"),
         arg!(--delimiter),


### PR DESCRIPTION
Adds shell completions:

- `--ignore-case` for qsv joinp
- `--invert` for qsv slice