### PR TITLE
`contrib(completions)`: add `--quiet` to `tojsonl`

### DIFF
--- a/contrib/completions/examples/qsv.bash
+++ b/contrib/completions/examples/qsv.bash
@@ -3986,7 +3986,7 @@ _qsv() {
             return 0
             ;;
         qsv__tojsonl)
-            opts="-h --trim --no-boolean --jobs --batch --delimiter --output --memcheck --help"
+            opts="-h --trim --no-boolean --jobs --batch --delimiter --output --memcheck --quiet --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/contrib/completions/examples/qsv.elv
+++ b/contrib/completions/examples/qsv.elv
@@ -1584,6 +1584,7 @@ set edit:completion:arg-completer[qsv] = {|@words|
             cand --delimiter 'delimiter'
             cand --output 'output'
             cand --memcheck 'memcheck'
+            cand --quiet 'quiet'
             cand -h 'Print help'
             cand --help 'Print help'
         }

--- a/contrib/completions/examples/qsv.fig.js
+++ b/contrib/completions/examples/qsv.fig.js
@@ -3891,6 +3891,9 @@ const completion: Fig.Spec = {
           name: "--memcheck",
         },
         {
+          name: "--quiet",
+        },
+        {
           name: ["-h", "--help"],
           description: "Print help",
         },

--- a/contrib/completions/examples/qsv.fish
+++ b/contrib/completions/examples/qsv.fish
@@ -1223,6 +1223,7 @@ complete -c qsv -n "__fish_qsv_using_subcommand tojsonl" -l batch
 complete -c qsv -n "__fish_qsv_using_subcommand tojsonl" -l delimiter
 complete -c qsv -n "__fish_qsv_using_subcommand tojsonl" -l output
 complete -c qsv -n "__fish_qsv_using_subcommand tojsonl" -l memcheck
+complete -c qsv -n "__fish_qsv_using_subcommand tojsonl" -l quiet
 complete -c qsv -n "__fish_qsv_using_subcommand tojsonl" -s h -l help -d 'Print help'
 complete -c qsv -n "__fish_qsv_using_subcommand transpose" -l multipass
 complete -c qsv -n "__fish_qsv_using_subcommand transpose" -l output

--- a/contrib/completions/examples/qsv.nu
+++ b/contrib/completions/examples/qsv.nu
@@ -1489,6 +1489,7 @@ module completions {
     --delimiter
     --output
     --memcheck
+    --quiet
     --help(-h)                # Print help
   ]
 

--- a/contrib/completions/examples/qsv.ps1
+++ b/contrib/completions/examples/qsv.ps1
@@ -1725,6 +1725,7 @@ Register-ArgumentCompleter -Native -CommandName 'qsv' -ScriptBlock {
             [CompletionResult]::new('--delimiter', '--delimiter', [CompletionResultType]::ParameterName, 'delimiter')
             [CompletionResult]::new('--output', '--output', [CompletionResultType]::ParameterName, 'output')
             [CompletionResult]::new('--memcheck', '--memcheck', [CompletionResultType]::ParameterName, 'memcheck')
+            [CompletionResult]::new('--quiet', '--quiet', [CompletionResultType]::ParameterName, 'quiet')
             [CompletionResult]::new('-h', '-h', [CompletionResultType]::ParameterName, 'Print help')
             [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, 'Print help')
             break

--- a/contrib/completions/examples/qsv.zsh
+++ b/contrib/completions/examples/qsv.zsh
@@ -1915,6 +1915,7 @@ _arguments "${_arguments_options[@]}" : \
 '--delimiter[]' \
 '--output[]' \
 '--memcheck[]' \
+'--quiet[]' \
 '-h[Print help]' \
 '--help[Print help]' \
 && ret=0

--- a/contrib/completions/src/cmd/tojsonl.rs
+++ b/contrib/completions/src/cmd/tojsonl.rs
@@ -9,5 +9,6 @@ pub fn tojsonl_cmd() -> Command {
         arg!(--delimiter),
         arg!(--output),
         arg!(--memcheck),
+        arg!(--quiet),
     ])
 }


### PR DESCRIPTION
Adds the `--quiet` flag to the shell completions for `qsv tojsonl`.