### PR TITLE
feat: addl `luau` helper functions

### DIFF
--- a/src/cmd/luau.rs
+++ b/src/cmd/luau.rs
@@ -2313,8 +2313,8 @@ fn setup_helpers(
         };
 
         CUMALLS.with(|ca| {
-            let mut alls = ca.borrow_mut();
-            let all = alls.entry(name).or_insert(true);
+            let mut all_vals = ca.borrow_mut();
+            let all = all_vals.entry(name).or_insert(true);
             *all = *all && is_truthy;
             Ok(*all)
         })


### PR DESCRIPTION
feat(luau): add cumulative and lag helper functions

Implements additional helper functions for qsv's Lua DSL as suggested in #1782:

qsv_loadjson - load a JSON file into a Luau table

- Cumulative functions:
  - qsv_cumsum: cumulative sum
  - qsv_cumprod: cumulative product 
  - qsv_cumany: cumulative OR
  - qsv_cumall: cumulative AND
  - qsv_cummax: cumulative maximum
  - qsv_cummin: cumulative minimum

- Lag/diff functions:
  - qsv_lag(col, k, default): Access previous values with configurable offset
  - qsv_diff(col, k, default): Difference between current and lagged values

qsv_loadjson is designed to work in CKAN so we can send package and resource info to DP+, so it can infer suggested metadata for the DRUF workflow, as we use the `luau` command for complex inferencing beyond the capabilities of MiniJinja.

This effectively gives us two DSLs for the DRUF workflow. MiniJinja for simple metadata inferences, and Luau for complex ones. Both MiniJinja and Luau are purpose-built as DSLs, so we don't need to use Python `eval` which leaves a gaping security hole.

The cumulative and lag/diff helpers enhances qsv's data analysis capabilities with R-like functionality.

Closes #1782

cc @ggrothendieck