### PR TITLE
Migrate from dynfmt to dynfmt2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1963,15 +1963,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
-name = "dynfmt"
-version = "0.1.5"
-source = "git+https://github.com/jqnatividad/dynfmt?branch=2021-clippy_ptr_as_ptr-bumpdeps#0dec5eaceba58e294283d8ebc6333b421220c186"
+name = "dynfmt2"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3f751b50a0b1cc5fe99b537638ac47c0e2702758cfcd323d8b1a8d97d700fa"
 dependencies = [
  "erased-serde",
- "lazy_static",
  "regex",
  "serde",
- "thiserror 1.0.69",
+ "thiserror 2.0.9",
 ]
 
 [[package]]
@@ -5228,7 +5228,7 @@ dependencies = [
  "csvs_convert",
  "data-encoding",
  "dotenvy",
- "dynfmt",
+ "dynfmt2",
  "eudex",
  "ext-sort",
  "fast-float2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ csvs_convert = { version = "0.9.0", default-features = false, features = [
 ], optional = true }
 data-encoding = { version = "2.6", optional = true }
 dotenvy = "0.15"
-dynfmt = { version = "0.1", default-features = false, features = ["curly"] }
+dynfmt2 = { version = "0.2", default-features = false, features = ["curly"] }
 eudex = { version = "0.1", optional = true }
 ext-sort = { version = "0.1", default-features = false }
 fast-float2 = "0.2"
@@ -308,10 +308,6 @@ calamine = { git = "https://github.com/jqnatividad/calamine", branch = "qsv-2-op
 
 # use our fork of csvlens with unreleased fixes, bumped dependencies, and new clap-less API
 csvlens = { git = "https://github.com/jqnatividad/csvlens", branch = "116-clap-optional-dependency-cli-feature" }
-
-# needed as dynfmt doesn't work in release mode without this
-# see https://github.com/jan-auer/dynfmt/pull/9
-dynfmt = { git = "https://github.com/jqnatividad/dynfmt", branch = "2021-clippy_ptr_as_ptr-bumpdeps" }
 
 # needed to get latest dependencies and unreleased fixes
 grex = { git = "https://github.com/pemistahl/grex", rev = "cb71c10" }

--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -308,7 +308,7 @@ use censor::{Censor, Sex, Zealous};
 use cpc::{eval, units::Unit};
 use crc32fast;
 use data_encoding::BASE64;
-use dynfmt::Format;
+use dynfmt2::Format;
 use eudex::Hash;
 use gender_guesser::Gender;
 use indicatif::{ProgressBar, ProgressDrawTarget};
@@ -643,7 +643,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                                 record_vec.push(field.to_string());
                             }
                             if let Ok(formatted) =
-                                dynfmt::SimpleCurlyFormat.format(&dynfmt_template, record_vec)
+                                dynfmt2::SimpleCurlyFormat.format(&dynfmt_template, record_vec)
                             {
                                 cell = formatted.to_string();
                             }
@@ -664,7 +664,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                                 record_vec.push(field.to_string());
                             }
                             if let Ok(formatted) =
-                                dynfmt::SimpleCurlyFormat.format(&dynfmt_template, record_vec)
+                                dynfmt2::SimpleCurlyFormat.format(&dynfmt_template, record_vec)
                             {
                                 cell = formatted.to_string();
                             }

--- a/src/cmd/applydp.rs
+++ b/src/cmd/applydp.rs
@@ -185,7 +185,7 @@ Common options:
 
 use std::{str::FromStr, sync::OnceLock};
 
-use dynfmt::Format;
+use dynfmt2::Format;
 use log::debug;
 use rayon::{
     iter::{IndexedParallelIterator, ParallelIterator},
@@ -460,7 +460,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                                 record_vec.push(field.to_string());
                             }
                             if let Ok(formatted) =
-                                dynfmt::SimpleCurlyFormat.format(&dynfmt_template, record_vec)
+                                dynfmt2::SimpleCurlyFormat.format(&dynfmt_template, record_vec)
                             {
                                 cell = formatted.to_string();
                             }

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -239,7 +239,7 @@ use cached::{
     stores::DiskCacheBuilder,
     Cached, IOCached, RedisCache, Return, SizedCache,
 };
-use dynfmt::Format;
+use dynfmt2::Format;
 use governor::{
     clock::DefaultClock,
     middleware::NoOpMiddleware,
@@ -780,7 +780,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                 );
             }
             if let Ok(formatted) =
-                dynfmt::SimpleCurlyFormat.format(&dynfmt_url_template, &*record_vec)
+                dynfmt2::SimpleCurlyFormat.format(&dynfmt_url_template, &*record_vec)
             {
                 url = formatted.into_owned();
             }

--- a/src/cmd/geocode.rs
+++ b/src/cmd/geocode.rs
@@ -370,7 +370,7 @@ use std::{
 
 use ahash::RandomState;
 use cached::{proc_macro::cached, SizedCache};
-use dynfmt::Format;
+use dynfmt2::Format;
 use geosuggest_core::{
     storage::{self, IndexStorage},
     CitiesRecord, CountryRecord, Engine,
@@ -1933,7 +1933,7 @@ fn format_result(
             };
         }
 
-        if let Ok(formatted) = dynfmt::SimpleCurlyFormat.format(formatstr, cityrecord_map) {
+        if let Ok(formatted) = dynfmt2::SimpleCurlyFormat.format(formatstr, cityrecord_map) {
             formatted.to_string()
         } else {
             INVALID_DYNFMT.to_string()
@@ -2047,7 +2047,7 @@ fn get_countryinfo(
             };
         }
 
-        if let Ok(formatted) = dynfmt::SimpleCurlyFormat.format(formatstr, countryrecord_map) {
+        if let Ok(formatted) = dynfmt2::SimpleCurlyFormat.format(formatstr, countryrecord_map) {
             Some(formatted.to_string())
         } else {
             Some(INVALID_DYNFMT.to_string())

--- a/src/cmd/pseudo.rs
+++ b/src/cmd/pseudo.rs
@@ -67,7 +67,7 @@ Common options:
 "#;
 
 use ahash::AHashMap;
-use dynfmt::Format;
+use dynfmt2::Format;
 use serde::Deserialize;
 
 use crate::{
@@ -130,7 +130,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let mut overflowed = false;
 
     if args.flag_formatstr == "{}" {
-        // we don't need to use dynfmt::SimpleCurlyFormat if the format string is "{}"
+        // we don't need to use dynfmt2::SimpleCurlyFormat if the format string is "{}"
         let mut values_num = ValuesNum::with_capacity(1000);
 
         while rdr.read_record(&mut record)? {
@@ -152,11 +152,11 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             wtr.write_record(&record)?;
         }
     } else {
-        // we need to use dynfmt::SimpleCurlyFormat if the format string is not "{}"
+        // we need to use dynfmt2::SimpleCurlyFormat if the format string is not "{}"
 
         // first, validate the format string
         if !args.flag_formatstr.contains("{}")
-            || dynfmt::SimpleCurlyFormat
+            || dynfmt2::SimpleCurlyFormat
                 .format(&args.flag_formatstr, [0])
                 .is_err()
         {
@@ -175,7 +175,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             let new_value = values.entry(value.clone()).or_insert_with(|| {
                 curr_counter = counter;
                 (counter, overflowed) = counter.overflowing_add(increment);
-                dynfmt::SimpleCurlyFormat
+                dynfmt2::SimpleCurlyFormat
                     .format(&args.flag_formatstr, [curr_counter])
                     .unwrap()
                     .to_string()


### PR DESCRIPTION
dynfmt has not been maintained since Mar 2021. Repeated attempts to reach the maintainer has been unsuccessful.

Creating renamed fork - dynfmt2, and migrating to it instead.