### PR TITLE
`diff`: Fix name to index conversion

### DIFF
--- a/tests/test_diff.rs
+++ b/tests/test_diff.rs
@@ -339,7 +339,7 @@ fn diff_key_sort_by_column_name() {
 
 #[test]
 fn diff_key_by_column_name_columns_have_different_order_error() {
-    let wrk = Workdir::new("diff_key_sort_by_column_name");
+    let wrk = Workdir::new("diff_key_by_column_name_columns_have_different_order_error");
 
     let left = vec![
         svec!["h1", "h2", "h3"],


### PR DESCRIPTION
This fixes the conversion from column name -> index for `diff` options
`--key` and `--sort-columns`, which is part of #2443.

The issue was that `enumeration idx` and `1` had been added to the already
correct result (obtained via `.position` iterator method).
So now, only `.position` is used to get the correct idx of a column name.

Before this change, one test has tried to validate the logic of providing
column names instead of indices, but the _test itself was wrong_, as the
diff result that was validated did not have the correct sort order.
This test is now also fixed.

Additionally, this provides some more tests for error conditions
regarding name -> index conversion.