### PR TITLE
refactor: standardize -q and -Q shortcut options

### DIFF
--- a/src/cmd/dedup.rs
+++ b/src/cmd/dedup.rs
@@ -46,7 +46,7 @@ Common options:
                                appear as the header row in the output.
     -d, --delimiter <arg>      The field delimiter for reading CSV data.
                                Must be a single character. (default: ,)
-    -Q, --quiet                Do not print duplicate count to stderr.
+    -q, --quiet                Do not print duplicate count to stderr.
     --memcheck                 Check if there is enough memory to load the entire
                                CSV into memory using CONSERVATIVE heuristics.
 "#;

--- a/src/cmd/describegpt.rs
+++ b/src/cmd/describegpt.rs
@@ -51,7 +51,7 @@ describegpt options:
 Common options:
     -h, --help             Display this message
     -o, --output <file>    Write output to <file> instead of stdout.
-    -Q, --quiet            Do not print status messages to stderr.
+    -q, --quiet            Do not print status messages to stderr.
 "#;
 
 use std::{env, fs, io::Write, path::PathBuf, process::Command, time::Duration};

--- a/src/cmd/excel.rs
+++ b/src/cmd/excel.rs
@@ -155,7 +155,7 @@ Common options:
     -o, --output <file>        Write output to <file> instead of stdout.
     -d, --delimiter <arg>      The delimiter to use when writing CSV data.
                                Must be a single character. [default: ,]
-    -Q, --quiet                Do not display export summary message.
+    -q, --quiet                Do not display export summary message.
 "#;
 
 use std::{cmp, fmt::Write, io::Read, path::PathBuf};

--- a/src/cmd/extdedup.rs
+++ b/src/cmd/extdedup.rs
@@ -50,7 +50,7 @@ Common options:
                                Must be a single character. (default: ,)
 
     -h, --help                 Display this message
-    -Q, --quiet                Do not print duplicate count to stderr.
+    -q, --quiet                Do not print duplicate count to stderr.
 "#;
 
 use std::{

--- a/src/cmd/fixlengths.rs
+++ b/src/cmd/fixlengths.rs
@@ -34,7 +34,7 @@ Common options:
     -o, --output <file>    Write output to <file> instead of stdout.
     -d, --delimiter <arg>  The field delimiter for reading CSV data.
                            Must be a single character. (default: ,)
-    -Q, --quiet            Don't print removed column information.
+    -q, --quiet            Don't print removed column information.
 "#;
 
 use std::cmp;

--- a/src/cmd/joinp.rs
+++ b/src/cmd/joinp.rs
@@ -242,7 +242,7 @@ Common options:
     -o, --output <file>    Write output to <file> instead of stdout.
     -d, --delimiter <arg>  The field delimiter for reading/writing CSV data.
                            Must be a single character. (default: ,)
-    -Q, --quiet            Do not return join shape to stderr.
+    -q, --quiet            Do not return join shape to stderr.
 "#;
 
 use std::{

--- a/src/cmd/pivotp.rs
+++ b/src/cmd/pivotp.rs
@@ -59,7 +59,7 @@ Common options:
     -o, --output <file>     Write output to <file> instead of stdout.
     -d, --delimiter <arg>   The field delimiter for reading/writing CSV data.
                             Must be a single character. (default: ,)
-    -Q, --quiet             Do not return smart aggregation chosen nor pivot result shape to stderr.
+    -q, --quiet             Do not return smart aggregation chosen nor pivot result shape to stderr.
 "#;
 
 use std::{fs::File, io, io::Write, path::Path, sync::OnceLock};

--- a/src/cmd/prompt.rs
+++ b/src/cmd/prompt.rs
@@ -44,7 +44,7 @@ Common options:
     -h, --help             Display this message
     -o, --output <file>    Write output to <file> without showing a save dialog.
                            Mutually exclusive with --fd-output.
-    -Q, --quiet            Do not print --fd-output message to stderr.
+    -q, --quiet            Do not print --fd-output message to stderr.
 
 "#;
 

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -53,7 +53,7 @@ Common options:
     -d, --delimiter <arg>  The field delimiter for reading CSV data.
                            Must be a single character. (default: ,)
     -p, --progressbar      Show progress bars. Not valid for stdin.
-    -Q, --quiet            Do not print number of replacements to stderr.
+    -q, --quiet            Do not print number of replacements to stderr.
 
 "#;
 

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -43,7 +43,7 @@ search options:
                            of the matched rows and 0 for the non-matched rows.
                            If column is named M, only the M column will be written
                            to the output, and only matched rows are returned.
-    -q, --quick            Return on first match with an exitcode of 0, returning
+    -Q, --quick            Return on first match with an exitcode of 0, returning
                            the row number of the first match to stderr.
                            Return exit code 1 if no match is found.
                            No output is produced.
@@ -77,7 +77,7 @@ Common options:
     -d, --delimiter <arg>  The field delimiter for reading CSV data.
                            Must be a single character. (default: ,)
     -p, --progressbar      Show progress bars. Not valid for stdin.
-    -Q, --quiet            Do not return number of matches to stderr.
+    -q, --quiet            Do not return number of matches to stderr.
 "#;
 
 #[cfg(any(feature = "feature_capable", feature = "lite"))]

--- a/src/cmd/searchset.rs
+++ b/src/cmd/searchset.rs
@@ -55,7 +55,7 @@ searchset options:
     --unmatched-output <file>  When --flag-matches-only is enabled, output the rows
                                that did not match to <file>.
 
-    -q, --quick                Return on first match with an exitcode of 0, returning
+    -Q, --quick                Return on first match with an exitcode of 0, returning
                                the row number of the first match to stderr.
                                Return exit code 1 if no match is found.
                                No output is produced. Ignored if --json is enabled.
@@ -83,7 +83,7 @@ Common options:
     -d, --delimiter <arg>      The field delimiter for reading CSV data.
                                Must be a single character. (default: ,)
     -p, --progressbar          Show progress bars. Not valid for stdin.
-    -Q, --quiet                Do not return number of matches to stderr.
+    -q, --quiet                Do not return number of matches to stderr.
 "#;
 
 use std::{

--- a/src/cmd/snappy.rs
+++ b/src/cmd/snappy.rs
@@ -49,7 +49,7 @@ Common options:
     -o, --output <file>   Write output to <output> instead of stdout.
     -j, --jobs <arg>      The number of jobs to run in parallel when compressing.
                           When not set, its set to the number of CPUs - 1
-    -Q, --quiet           Suppress status messages to stderr.
+    -q, --quiet           Suppress status messages to stderr.
     -p, --progressbar     Show download progress bars. Only valid for URL input.
 "#;
 

--- a/src/cmd/sniff.rs
+++ b/src/cmd/sniff.rs
@@ -65,7 +65,7 @@ sniff options:
                              Specify this when the delimiter is known beforehand,
                              as the delimiter inferencing algorithm can sometimes fail.
                              Must be a single ascii character.
-    -q, --quote <arg>        The quote character for reading CSV data.
+    --quote <arg>        The quote character for reading CSV data.
                              Specify this when the quote character is known beforehand,
                              as the quote char inferencing algorithm can sometimes fail.
                              Must be a single ascii character - typically, double quote ("),
@@ -88,7 +88,7 @@ sniff options:
                              in this mode.
     --just-mime              Only return the file's mime type. Use this to use sniff as a general
                              mime type detector. Synonym for --no-infer.
-    --quick                  When sniffing a non-CSV remote file, only download the first chunk of the file
+    -Q, --quick              When sniffing a non-CSV remote file, only download the first chunk of the file
                              before attempting to detect the mime type. This is faster but less accurate as
                              some mime types cannot be detected with just the first downloaded chunk.
     --harvest-mode           This is a convenience flag when using sniff in CKAN harvesters. 

--- a/src/cmd/split.rs
+++ b/src/cmd/split.rs
@@ -97,7 +97,7 @@ Common options:
                            appear in all chunks as the header row.
     -d, --delimiter <arg>  The field delimiter for reading CSV data.
                            Must be a single character. (default: ,)
-    -Q, --quiet            Do not display an output summary to stderr.
+    -q, --quiet            Do not display an output summary to stderr.
 "#;
 
 use std::{fs, io, path::Path};

--- a/src/cmd/sqlp.rs
+++ b/src/cmd/sqlp.rs
@@ -265,7 +265,7 @@ Common options:
     -o, --output <file>    Write output to <file> instead of stdout.
     -d, --delimiter <arg>  The field delimiter for reading and writing CSV data.
                            Must be a single character. [default: ,]
-    -Q, --quiet            Do not return result shape to stderr.
+    -q, --quiet            Do not return result shape to stderr.
 "#;
 
 use std::{

--- a/src/cmd/tojsonl.rs
+++ b/src/cmd/tojsonl.rs
@@ -41,7 +41,7 @@ Common options:
     -o, --output <file>    Write output to <file> instead of stdout.
     --memcheck             Check if there is enough memory to load the entire
                            CSV into memory using CONSERVATIVE heuristics.
-    -Q, --quiet            Do not display enum/const list inferencing messages.
+    -q, --quiet            Do not display enum/const list inferencing messages.
 "#;
 
 use std::{fmt::Write, path::PathBuf, str::FromStr};

--- a/src/cmd/validate.rs
+++ b/src/cmd/validate.rs
@@ -183,7 +183,7 @@ Common options:
     -d, --delimiter <arg>      The field delimiter for reading CSV data.
                                Must be a single character.
     -p, --progressbar          Show progress bars. Not valid for stdin.
-    -Q, --quiet                Do not display validation summary message.
+    -q, --quiet                Do not display validation summary message.
 "#;
 
 use std::{


### PR DESCRIPTION
`-q` is a shortcut for `--quiet`
`-Q` is a shortcut for `--quick` (used in `search`, `searchset` & `sniff` commands)

also removed `-Q, --quote` shortcut from `sniff` and using it for `--quick` instead

resolves #2466 