### PR TITLE
refactor: `extdedup` to actually have memory-mapped file backing on-disk hash table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5215,6 +5215,7 @@ dependencies = [
  "jsonschema",
  "localzone",
  "log",
+ "memmap2",
  "mimalloc",
  "minijinja",
  "minijinja-contrib",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,7 @@ jsonschema = { version = "0.28", features = [
 ], default-features = false }
 localzone = { version = "0.3", features = ["auto_validation"] }
 log = "0.4"
+memmap2 = "0.9"
 mimalloc = { version = "0.1", default-features = false, optional = true }
 minijinja = { version = "2", features = [
     "json",
@@ -178,6 +179,7 @@ polars = { version = "0.45", features = [
     # "cloud",
     "coalesce",
     "cross_join",
+    "cse",
     "csv",
     "decompress",
     "diagonal_concat",


### PR DESCRIPTION
resolves #2462 