### PR TITLE
feat: "smart" diff

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,7 +168,7 @@ mlua = { version = "0.10", features = [
 ], optional = true }
 num_cpus = "1"
 odht = "0.3"
-phf = { version = "0.11", features = ["macros"], optional = true }
+phf = { version = "0.11", features = ["macros"]}
 polars = { version = "0.46", features = [
     "asof_join",
     "avro",
@@ -396,7 +396,6 @@ geocode = [
     "cached",
     "geosuggest-core",
     "geosuggest-utils",
-    "phf",
     "sled",
 ]
 luau = ["mlua", "sanitize-filename"]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 | [datefmt](/src/cmd/datefmt.rs#L2)<br>📇🚀👆 | Formats recognized date fields ([19 formats recognized](https://docs.rs/qsv-dateparser/latest/qsv_dateparser/#accepted-date-formats)) to a specified date format using [strftime date format specifiers](https://docs.rs/chrono/latest/chrono/format/strftime/). |
 | [dedup](/src/cmd/dedup.rs#L2)<br>🤯🚀👆 | Remove duplicate rows (See also `extdedup`, `extsort`, `sort` & `sortcheck` commands). |
 | [describegpt](/src/cmd/describegpt.rs#L2)<br>🌐🤖🪄 | Infer extended metadata about a CSV using a GPT model from [OpenAI's API](https://platform.openai.com/docs/introduction) or an LLM from another API compatible with the OpenAI API specification such as [Ollama](https://ollama.com) or [Jan](https://jan.ai). |
-| [diff](/src/cmd/diff.rs#L2)<br>🚀 | Find the difference between two CSVs with ludicrous speed!<br/>e.g. _compare two CSVs with 1M rows x 9 columns in under 600ms!_ |
+| [diff](/src/cmd/diff.rs#L2)<br>🚀🪄 | Find the difference between two CSVs with ludicrous speed!<br/>e.g. _compare two CSVs with 1M rows x 9 columns in under 600ms!_ |
 | [edit](/src/cmd/edit.rs#L2) | Replace the value of a cell specified by its row and column. |
 | [enum](/src/cmd/enumerate.rs#L2)<br>👆 | Add a new column enumerating rows by adding a column of incremental or uuid identifiers. Can also be used to copy a column or fill a new column with a constant value.  |
 | [excel](/src/cmd/excel.rs#L2)<br>🚀 | Exports a specified Excel/ODS sheet to a CSV file. |

--- a/src/cmd/diff.rs
+++ b/src/cmd/diff.rs
@@ -3,7 +3,10 @@ Find the difference between two CSVs with ludicrous speed.
 
 NOTE: diff does not support stdin. A file path is required for both arguments.
       Further, PRIMARY KEY VALUES MUST BE UNIQUE WITHIN EACH CSV.
-      Otherwise, diff will produce an incorrect result.
+      When diffing CSVs with just a single --key column and a stats cache is
+      available, diff will automatically validate for primary key uniqueness.
+      If more than one --key column is specified, however, this auto-validation
+      is not done.
 
       To check if a CSV has unique primary key values, use `qsv extdedup`
       with the same key columns using the `--select` option:
@@ -76,7 +79,7 @@ diff options:
     --delimiter-output <arg>    The field delimiter for writing the CSV diff result.
                                 Must be a single character. (default: ,)
     -k, --key <arg...>          The column indices that uniquely identify a record
-                                as a comma separated list of indices, e.g. 0,1,2
+                                as a comma separated list of 0-based indices, e.g. 0,1,2
                                 or column names, e.g. name,age.
                                 Note that when selecting columns by name, only the 
                                 left CSV's headers are used to match the column names
@@ -101,6 +104,12 @@ diff options:
     -j, --jobs <arg>            The number of jobs to run in parallel.
                                 When not set, the number of jobs is set to the number
                                 of CPUs detected.
+    --force                     Force diff and ignore stats caches for the left & right CSVs.
+                                Otherwise, if available, the stats cache will be used to:
+                                 * short-circuit the diff if their fingerprint hashes are
+                                   identical.
+                                 * check for primary key uniqueness when only one --key
+                                   column is specified.
 
 Common options:
     -h, --help                  Display this message
@@ -123,7 +132,10 @@ use super::rename::rename_headers_all_generic;
 use crate::{
     clitypes::CliError,
     config::{Config, Delimiter},
-    util, CliResult,
+    select::SelectColumns,
+    util,
+    util::{get_stats_records, SchemaArgs, StatsMode},
+    CliResult,
 };
 
 #[derive(Deserialize)]
@@ -132,6 +144,7 @@ struct Args {
     arg_input_right:        Option<String>,
     flag_output:            Option<String>,
     flag_jobs:              Option<usize>,
+    flag_force:             bool,
     flag_no_headers_left:   bool,
     flag_no_headers_right:  bool,
     flag_no_headers_output: bool,
@@ -146,6 +159,139 @@ struct Args {
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let mut args: Args = util::get_args(USAGE, argv)?;
+
+    // ===== VALIDATION CHECKS =====
+
+    // If --force is not set and
+    // neither --no-headers-left nor --no-headers-right are set and
+    // the key is a just single column (or unspecified),
+    // perform validation checks on the input files using the stats cache.
+    if !args.flag_force
+        && (!args.flag_no_headers_left && !args.flag_no_headers_right)
+        && args
+            .flag_key
+            .as_ref()
+            .is_none_or(|k| k.split(',').count() == 0)
+    {
+        // ---- STATS CACHE VALIDATION CHECKS ----
+
+        // Get stats for left file
+        let left_schema_args = SchemaArgs {
+            arg_input:            args.arg_input_left.clone(),
+            flag_no_headers:      false,
+            flag_delimiter:       args.flag_delimiter,
+            flag_jobs:            None,
+            flag_memcheck:        false,
+            flag_force:           args.flag_force,
+            flag_prefer_dmy:      false,
+            flag_dates_whitelist: String::new(),
+            flag_enum_threshold:  0,
+            flag_ignore_case:     false,
+            flag_strict_dates:    false,
+            flag_pattern_columns: SelectColumns::parse("")?,
+            flag_stdout:          false,
+        };
+
+        // Get stats for right file using same args
+        let right_schema_args = SchemaArgs {
+            arg_input: args.arg_input_right.clone(),
+            ..left_schema_args.clone()
+        };
+
+        // Get stats records for both files
+        if let (
+            Ok((left_csv_fields, left_stats, left_dataset_stats)),
+            Ok((_, right_stats, right_dataset_stats)),
+        ) = (
+            get_stats_records(&left_schema_args, StatsMode::FrequencyForceStats),
+            get_stats_records(&right_schema_args, StatsMode::FrequencyForceStats),
+        ) {
+            // If both files fingerprint hashes match, files are identical short-circuit diff
+            if left_dataset_stats.get("qsv__fingerprint_hash")
+                == right_dataset_stats.get("qsv__fingerprint_hash")
+            {
+                return Ok(());
+            }
+
+            // Check if row counts match
+            let left_dataset_rowcount = left_dataset_stats
+                .get("qsv__rowcount")
+                .unwrap()
+                .parse::<f64>()
+                .unwrap_or_default() as u64;
+            let right_dataset_rowcount = right_dataset_stats
+                .get("qsv__rowcount")
+                .unwrap()
+                .parse::<f64>()
+                .unwrap_or_default() as u64;
+
+            if left_dataset_rowcount != right_dataset_rowcount {
+                return fail_incorrectusage_clierror!(
+                    "The number of rows in the left ({left_dataset_rowcount}) and right \
+                     ({right_dataset_rowcount}) CSVs do not match."
+                );
+            }
+
+            // If key column specified, check if it has all unique values in both files
+            let mut colname_used_for_key = false;
+            if let Some(key_col) = &args.flag_key {
+                let idx = if key_col.chars().all(char::is_numeric) {
+                    key_col
+                        .parse::<usize>()
+                        .map_err(|err| CliError::Other(err.to_string()))?
+                } else {
+                    // Handle column name case...
+                    colname_used_for_key = true;
+                    left_csv_fields
+                        .iter()
+                        .position(|field| field == key_col.as_bytes())
+                        .unwrap_or_default()
+                };
+
+                // Check cardinality equals row count for key column in left file
+                if let Some(left_col) = left_stats.get(idx) {
+                    if left_col.cardinality != left_dataset_rowcount {
+                        return fail_incorrectusage_clierror!(
+                            "Primary key values in left CSV are not unique in column {colname} \
+                             (cardinality: {left_cardinality} != rowcount: {left_rowcount}). Use \
+                             `qsv extdedup --select {colname} {left_input} --no-output` to check \
+                             duplicates.",
+                            colname = if colname_used_for_key {
+                                key_col.to_string()
+                            } else {
+                                idx.to_string()
+                            },
+                            left_cardinality = left_col.cardinality,
+                            left_rowcount = left_dataset_rowcount,
+                            left_input = args.arg_input_left.as_ref().unwrap()
+                        );
+                    }
+                }
+
+                // Check cardinality equals row count for key column in right file
+                if let Some(right_col) = right_stats.get(idx) {
+                    if right_col.cardinality != right_dataset_rowcount {
+                        return fail_incorrectusage_clierror!(
+                            "Primary key values in right CSV are not unique in column {colname} \
+                             (cardinality: {right_cardinality} != rowcount: {right_rowcount}). \
+                             Use `qsv extdedup --select {colname} {right_input} --no-output` to \
+                             check duplicates.",
+                            colname = if colname_used_for_key {
+                                key_col.to_string()
+                            } else {
+                                idx.to_string()
+                            },
+                            right_cardinality = right_col.cardinality,
+                            right_rowcount = right_dataset_rowcount,
+                            right_input = args.arg_input_right.as_ref().unwrap()
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- SETUP and OTHER VALIDATION CHECKS ----
 
     if let Some(delim) = args.flag_delimiter {
         [
@@ -240,6 +386,8 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         .writer()?;
 
     util::njobs(args.flag_jobs);
+
+    // ===== DIFF PROCESSING =====
 
     let Ok(csv_diff) = CsvByteDiffBuilder::new()
         .primary_key_columns(primary_key_cols.clone())

--- a/src/cmd/joinp.rs
+++ b/src/cmd/joinp.rs
@@ -887,7 +887,7 @@ impl Args {
                 flag_memcheck:        false,
             };
 
-            let (csv_fields, csv_stats) =
+            let (csv_fields, csv_stats, _) =
                 get_stats_records(&schema_args, util::StatsMode::PolarsSchema)?;
 
             let mut schema = Schema::with_capacity(csv_stats.len());

--- a/src/cmd/schema.rs
+++ b/src/cmd/schema.rs
@@ -213,7 +213,7 @@ pub fn infer_schema_from_stats(
     quiet: bool,
 ) -> CliResult<Map<String, Value>> {
     // invoke cmd::stats
-    let (csv_fields, csv_stats) = util::get_stats_records(args, StatsMode::Schema)?;
+    let (csv_fields, csv_stats, _) = util::get_stats_records(args, StatsMode::Schema)?;
 
     // amortize memory allocation
     let mut low_cardinality_column_indices: Vec<u64> =

--- a/src/cmd/sqlp.rs
+++ b/src/cmd/sqlp.rs
@@ -805,7 +805,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                         arg_input:            Some(table.to_string_lossy().into_owned()),
                         flag_memcheck:        false,
                     };
-                    let (csv_fields, csv_stats) =
+                    let (csv_fields, csv_stats, _) =
                         get_stats_records(&schema_args, util::StatsMode::PolarsSchema)?;
 
                     let mut schema = Schema::with_capacity(csv_stats.len());

--- a/tests/test_diff.rs
+++ b/tests/test_diff.rs
@@ -92,6 +92,8 @@ fn diff_diff_left_and_original_right_sort_diff_result_by_lines_by_default() {
     let mut cmd = wrk.command("diff");
     cmd.arg(test_file).arg(test_file2);
 
+    wrk.assert_success(&mut *&mut cmd);
+
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
 
     let diff_result_file_name = "diff_result_diff_left_original_right.csv";
@@ -145,6 +147,8 @@ fn diff_sort_diff_result_by_lines_by_default_modified_rows_interleaved() {
 
     let mut cmd = wrk.command("diff");
     cmd.args(["left.csv", "right.csv"]);
+
+    wrk.assert_success(&mut cmd);
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected: Vec<Vec<String>> = vec![
@@ -265,6 +269,8 @@ fn diff_different_delimiters_sort_diff_result_by_first_column() {
         ";",
     ]);
 
+    wrk.assert_success(&mut cmd);
+
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
 
     let diff_result_file_name = "diff_result_original_left_diff_right_sort_columns.csv";
@@ -364,6 +370,8 @@ fn diff_key_sort_by_column_name() {
         "h1,h3,h2",
     ]);
 
+    wrk.assert_success(&mut cmd);
+
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected: Vec<Vec<String>> = vec![
         svec!["diffresult", "h1", "h2", "h3"],
@@ -445,6 +453,8 @@ fn diff_only_left_has_headers_headers_in_result() {
     let mut cmd = wrk.command("diff");
     cmd.args(["left.csv", "right.csv", "--no-headers-right"]);
 
+    wrk.assert_success(&mut cmd);
+
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
         svec!["diffresult", "h1", "h2", "h3"],
@@ -467,6 +477,8 @@ fn diff_only_right_has_headers_headers_in_result() {
 
     let mut cmd = wrk.command("diff");
     cmd.args(["left.csv", "right.csv", "--no-headers-left"]);
+
+    wrk.assert_success(&mut cmd);
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
@@ -551,6 +563,8 @@ fn diff_no_diff_with_generic_headers_in_result() {
         "--no-headers-left",
         "--no-headers-right",
     ]);
+
+    wrk.assert_success(&mut cmd);
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![svec!["diffresult", "_col_1", "_col_2", "_col_3",]];
@@ -665,6 +679,8 @@ fn diff_drop_equal_fields_flag_on_modified_rows_one_row_modified() {
     let mut cmd = wrk.command("diff");
     cmd.args(["left.csv", "right.csv", "--drop-equal-fields"]);
 
+    wrk.assert_success(&mut cmd);
+
     let got: String = wrk.stdout(&mut cmd);
     let expected = "\
 diffresult,h1,h2,h3
@@ -772,6 +788,8 @@ fn diff_drop_equal_fields_flag_on_modified_rows_multiple_key_fields_far_apart() 
     // here, first and last columns are our key fields
     cmd.args(["left.csv", "right.csv", "--drop-equal-fields", "-k", "0,3"]);
 
+    wrk.assert_success(&mut cmd);
+
     let got: String = wrk.stdout(&mut cmd);
     let expected = "\
 diffresult,h1,h2,h3,h4
@@ -869,6 +887,8 @@ fn diff_with_mixed_delimiters() {
         "left.csv",
         "right.csv",
     ]);
+
+    wrk.assert_success(&mut cmd);
 
     let got: String = wrk.stdout(&mut cmd);
     let expected = "\

--- a/tests/test_frequency.rs
+++ b/tests/test_frequency.rs
@@ -455,6 +455,8 @@ fn frequency_all_unique() {
     let mut cmd = wrk.command("frequency");
     cmd.args(["--select", "1"]).arg(testdata);
 
+    wrk.assert_success(&mut cmd);
+
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
         svec!["field", "value", "count", "percentage"],


### PR DESCRIPTION
if the stats cache is available for both CSVs, it will use the cache to:
- compare fingerprint hashes, and if identical, short-circuit the diff
- fetch cardinality from stats cache
- fetch rowcount from dataset cache
- ensuring that cardinality == rowcount (ALL UNIQUE values) implementing #2514.  However, this validation is only done when there is only a single --key column

`pivotp` and `frequency` now also use the dataset stats cache to get the row count, instead of calculating the row count.

resolves #2493 