### PR TITLE
feat: "smart" sample

### DIFF
--- a/src/cmd/sample.rs
+++ b/src/cmd/sample.rs
@@ -366,6 +366,18 @@ fn check_stats_cache(
 
                     if let Some(idx) = idx {
                         if let Some(col_stats) = stats.get(idx) {
+                            let min_weight = col_stats
+                                .min
+                                .clone()
+                                .unwrap()
+                                .parse::<f64>()
+                                .unwrap_or_default();
+                            if min_weight < 0.0 {
+                                return fail_incorrectusage_clierror!(
+                                    "Weights must be non-negative. Lowest weight: {min_weight}"
+                                );
+                            }
+
                             col_stats.max.clone().unwrap().parse::<f64>().ok()
                         } else {
                             None
@@ -1014,7 +1026,7 @@ fn sample_weighted<R: io::Read, W: io::Write>(
             .unwrap_or(0.0);
 
             if weight < 0.0 {
-                return fail_incorrectusage_clierror!("Weights must be non-negative");
+                return fail_incorrectusage_clierror!("Weights must be non-negative: ({weight})");
             }
             max_weight_scan = max_weight_scan.max(weight);
         }
@@ -1106,7 +1118,7 @@ fn do_weighted_sampling<T: Rng + ?Sized>(
             .unwrap_or(0.0);
 
             if weight < 0.0 {
-                return fail_incorrectusage_clierror!("Weights must be non-negative");
+                return fail_incorrectusage_clierror!("Weights must be non-negative: ({weight})");
             }
 
             // Modified acceptance-rejection method to handle zero weights


### PR DESCRIPTION
Use stats cache to:
- get rowcount to enable percentage sampling even when there is no index, without having to count the rows separately 
- get max weight from stats cache for weighted sampling, skipping first pass to get max weight
- use cardinality from stats cache for cluster sampling, to prealloc clusters
- added --force to skip using stats cache

Also fixed infinite loop when doing weighted sampling when it runs out of records before requested sample size is met

resolves #2524 