### PR TITLE
feat: "smart" by default

### DIFF
--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -9,6 +9,7 @@
 | `QSV_TOGGLE_HEADERS` | if set to `1`, toggles header setting - i.e. inverts qsv header behavior, with no headers being the default, & setting `--no-headers` will actually mean headers will not be ignored. |
 | `QSV_ANTIMODES_LEN` | set to the maximum number of characters when listing "antimodes" in `stats`. Otherwise, the default is 100. Set to 0 to disable length limiting. |
 | `QSV_AUTOINDEX_SIZE` | if set, specifies the minimum file size (in bytes) of a CSV file before an index is automatically created. Note that stale indices are automatically updated regardless of this setting. |
+| `QSV_STATSCACHE_MODE` | Specifies how the stats cache is used by "smart" commands. Valid values are:<br />  * auto - use the stats cache if it's valid (the stats-jsonl file exists and is current) - default.<br />  * force - if the cache does not exist, create it by running stats.<br />  * none - do not use the stats cache, even if it exists. |
 | `QSV_CACHE_DIR` | The directory to use for caching downloaded lookup_table resources using the `luau` qsv_register_lookup() helper function. |
 | `QSV_CKAN_API` | The CKAN Action API endpoint to use with the `luau` qsv_register_lookup() helper function when using the "ckan://" scheme. |
 | `QSV_CKAN_TOKEN`| The CKAN token to use with the `luau` qsv_register_lookup() helper function when using the "ckan://" scheme. Only required to access private resources. |

--- a/dotenv.template
+++ b/dotenv.template
@@ -49,6 +49,13 @@ QSV_NO_HEADERS = False
 # updated regardless of this setting.
 # QSV_AUTOINDEX_SIZE = 1000000
 
+# Specifies how the stats cache is used by "smart" commands.
+# Valid values are:
+#   auto - use the stats cache if it's valid (the stats-jsonl file exists and is current) - default.
+#   force - if the cache does not exist, create it by running stats.
+#   none - do not use the stats cache, even if it exists.
+# QSV_STATSCACHE_MODE = auto
+
 # if set, add a BOM (Byte Order Mark) to the beginning of the output.
 # Note that this will also set the BOM for qsv's output to stdout.
 # This is useful when generating CSV files for Excel on Windows.

--- a/tests/test_frequency.rs
+++ b/tests/test_frequency.rs
@@ -460,17 +460,7 @@ fn frequency_all_unique() {
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
         svec!["field", "value", "count", "percentage"],
-        svec!["case_enquiry_id", "101004113298", "1", "1"],
-        svec!["case_enquiry_id", "101004113313", "1", "1"],
-        svec!["case_enquiry_id", "101004113348", "1", "1"],
-        svec!["case_enquiry_id", "101004113363", "1", "1"],
-        svec!["case_enquiry_id", "101004113371", "1", "1"],
-        svec!["case_enquiry_id", "101004113385", "1", "1"],
-        svec!["case_enquiry_id", "101004113386", "1", "1"],
-        svec!["case_enquiry_id", "101004113391", "1", "1"],
-        svec!["case_enquiry_id", "101004113394", "1", "1"],
-        svec!["case_enquiry_id", "101004113403", "1", "1"],
-        svec!["case_enquiry_id", "Other (90)", "90", "90"],
+        svec!["case_enquiry_id", "<ALL_UNIQUE>", "100", "100"],
     ];
     assert_eq!(got, expected);
 }
@@ -516,7 +506,6 @@ fn frequency_all_unique_with_stats_cache_alt_all_unique_text() {
     cmd.args(["--select", "1"])
         // "<ALL_UNIQUE>" in German
         .args(["--all-unique-text", "<ALLE EINZIGARTIG>"])
-        .args(["--stats-mode", "auto"])
         .arg(testdata);
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
@@ -528,14 +517,12 @@ fn frequency_all_unique_with_stats_cache_alt_all_unique_text() {
 }
 
 #[test]
-fn frequency_all_unique_force_stats_cache() {
-    let wrk = Workdir::new("frequency_all_unique_force_stats_cache");
+fn frequency_all_unique_stats_cache_default() {
+    let wrk = Workdir::new("frequency_all_unique_stats_cache_default");
     let testdata = wrk.load_test_file("boston311-100.csv");
 
     let mut cmd = wrk.command("frequency");
-    cmd.args(["--select", "1"])
-        .args(["--stats-mode", "force"])
-        .arg(testdata);
+    cmd.args(["--select", "1"]).arg(testdata);
 
     wrk.assert_success(&mut cmd);
 
@@ -563,8 +550,8 @@ fn frequency_all_unique_stats_mode_none() {
 
     // run frequency with stats-mode none, ignoring the stats cache
     let mut cmd = wrk.command("frequency");
-    cmd.args(["--select", "1"])
-        .args(["--stats-mode", "none"])
+    cmd.env("QSV_STATSCACHE_MODE", "None")
+        .args(["--select", "1"])
         .arg(testdata);
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
@@ -811,7 +798,8 @@ fn frequency_vis_whitespace() {
     wrk.create("in.csv", rows);
 
     let mut cmd = wrk.command("frequency");
-    cmd.arg("in.csv")
+    cmd.env("QSV_STATSCACHE_MODE", "none")
+        .arg("in.csv")
         .args(["--limit", "0"])
         .arg("--vis-whitespace");
 
@@ -905,7 +893,8 @@ fn frequency_vis_whitespace_ignore_case() {
     wrk.create("in.csv", rows);
 
     let mut cmd = wrk.command("frequency");
-    cmd.arg("in.csv")
+    cmd.env("QSV_STATSCACHE_MODE", "none")
+        .arg("in.csv")
         .args(["--limit", "0"])
         .arg("--vis-whitespace")
         .arg("--ignore-case");


### PR DESCRIPTION
Now that we have several "smart" commands, create a new envvar `QSV_STATSCACHE_MODE` environment variable. It has three settings:
* auto - use the stats cache if it's valid (the stats-jsonl file exists and is current) - default.
* force - if the cache does not exist, create it by running stats.
* none - do not use the stats cache even if it exists.

This ensures all smart-capable commands are smart by default.