### PR TITLE
feat: `stats` add `--dataset-stats` option

### DIFF
--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -218,6 +218,9 @@ stats options:
     --vis-whitespace          Visualize whitespace characters in the output.
                               See https://github.com/dathere/qsv/wiki/Supplemental#whitespace-markers
                               for the list of whitespace markers.
+    --dataset-stats           Compute dataset statistics (e.g. row count, column count, file size and
+                              fingerprint hash) and add them as additional rows to the output, with
+                              the qsv__ prefix and an additional qsv__value column.
 
 Common options:
     -h, --help             Display this message
@@ -307,6 +310,7 @@ pub struct Args {
     pub flag_delimiter:       Option<Delimiter>,
     pub flag_memcheck:        bool,
     pub flag_vis_whitespace:  bool,
+    pub flag_dataset_stats:   bool,
 }
 
 // this struct is used to serialize/deserialize the stats to
@@ -842,73 +846,75 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                 stats_br_vec.push(work_br);
             }
 
-            // Add dataset-level stats as additional rows ====================
-            let num_stats_fields = stats_headers_sr.len();
-            let mut dataset_stats_br = csv::ByteRecord::with_capacity(128, num_stats_fields);
+            if args.flag_dataset_stats {
+                // Add dataset-level stats as additional rows ====================
+                let num_stats_fields = stats_headers_sr.len();
+                let mut dataset_stats_br = csv::ByteRecord::with_capacity(128, num_stats_fields);
 
-            // Helper closure to write a dataset stat row
-            let mut write_dataset_stat = |name: &[u8], value: u64| -> CliResult<()> {
+                // Helper closure to write a dataset stat row
+                let mut write_dataset_stat = |name: &[u8], value: u64| -> CliResult<()> {
+                    dataset_stats_br.clear();
+                    dataset_stats_br.push_field(name);
+                    // Fill middle columns with empty strings
+                    for _ in 2..num_stats_fields {
+                        dataset_stats_br.push_field(b"");
+                    }
+                    // write qsv__value as last column
+                    dataset_stats_br.push_field(itoa::Buffer::new().format(value).as_bytes());
+                    wtr.write_byte_record(&dataset_stats_br)
+                        .map_err(std::convert::Into::into)
+                };
+
+                // Write qsv__rowcount
+                write_dataset_stat(b"qsv__rowcount", record_count)?;
+
+                // Write qsv__columncount
+                let ds_column_count = headers.len() as u64;
+                write_dataset_stat(b"qsv__columncount", ds_column_count)?;
+
+                // Write qsv__filesize_bytes
+                let ds_filesize_bytes = fs::metadata(&path)?.len();
+                write_dataset_stat(b"qsv__filesize_bytes", ds_filesize_bytes)?;
+
+                // Compute hash of stats for data fingerprinting
+                let stats_hash = {
+                    // the first FINGERPRINT_HASH_COLUMNS are used for the fingerprint hash
+                    let mut hash_input = Vec::with_capacity(FINGERPRINT_HASH_COLUMNS);
+
+                    // First, create a stable representation of the stats
+                    for record in &stats_br_vec {
+                        // Take FINGERPRINT_HASH_COLUMNS columns only
+                        for field in record.iter().take(FINGERPRINT_HASH_COLUMNS) {
+                            let s = String::from_utf8_lossy(field);
+                            // Standardize number format
+                            if let Ok(f) = s.parse::<f64>() {
+                                hash_input.extend_from_slice(format!("{f:.10}").as_bytes());
+                            } else {
+                                hash_input.extend_from_slice(field);
+                            }
+                            hash_input.push(0x1F); // field separator
+                        }
+                        hash_input.push(b'\n');
+                    }
+
+                    // Add dataset stats
+                    hash_input.extend_from_slice(
+                        format!("{record_count}\x1F{ds_column_count}\x1F{ds_filesize_bytes}\n")
+                            .as_bytes(),
+                    );
+                    sha256::digest(hash_input.as_slice())
+                };
+
                 dataset_stats_br.clear();
-                dataset_stats_br.push_field(name);
+                dataset_stats_br.push_field(b"qsv__fingerprint_hash");
                 // Fill middle columns with empty strings
                 for _ in 2..num_stats_fields {
                     dataset_stats_br.push_field(b"");
                 }
                 // write qsv__value as last column
-                dataset_stats_br.push_field(itoa::Buffer::new().format(value).as_bytes());
-                wtr.write_byte_record(&dataset_stats_br)
-                    .map_err(std::convert::Into::into)
-            };
-
-            // Write qsv__rowcount
-            write_dataset_stat(b"qsv__rowcount", record_count)?;
-
-            // Write qsv__columncount
-            let ds_column_count = headers.len() as u64;
-            write_dataset_stat(b"qsv__columncount", ds_column_count)?;
-
-            // Write qsv__filesize_bytes
-            let ds_filesize_bytes = fs::metadata(&path)?.len();
-            write_dataset_stat(b"qsv__filesize_bytes", ds_filesize_bytes)?;
-
-            // Compute hash of stats for data fingerprinting
-            let stats_hash = {
-                // the first FINGERPRINT_HASH_COLUMNS are used for the fingerprint hash
-                let mut hash_input = Vec::with_capacity(FINGERPRINT_HASH_COLUMNS);
-
-                // First, create a stable representation of the stats
-                for record in &stats_br_vec {
-                    // Take FINGERPRINT_HASH_COLUMNS columns only
-                    for field in record.iter().take(FINGERPRINT_HASH_COLUMNS) {
-                        let s = String::from_utf8_lossy(field);
-                        // Standardize number format
-                        if let Ok(f) = s.parse::<f64>() {
-                            hash_input.extend_from_slice(format!("{f:.10}").as_bytes());
-                        } else {
-                            hash_input.extend_from_slice(field);
-                        }
-                        hash_input.push(0x1F); // field separator
-                    }
-                    hash_input.push(b'\n');
-                }
-
-                // Add dataset stats
-                hash_input.extend_from_slice(
-                    format!("{record_count}\x1F{ds_column_count}\x1F{ds_filesize_bytes}\n")
-                        .as_bytes(),
-                );
-                sha256::digest(hash_input.as_slice())
-            };
-
-            dataset_stats_br.clear();
-            dataset_stats_br.push_field(b"qsv__fingerprint_hash");
-            // Fill middle columns with empty strings
-            for _ in 2..num_stats_fields {
-                dataset_stats_br.push_field(b"");
+                dataset_stats_br.push_field(stats_hash.as_bytes());
+                wtr.write_byte_record(&dataset_stats_br)?;
             }
-            // write qsv__value as last column
-            dataset_stats_br.push_field(stats_hash.as_bytes());
-            wtr.write_byte_record(&dataset_stats_br)?;
 
             // update the stats args json metadata ===============
             // if the stats run took longer than the cache threshold and the threshold > 0,

--- a/src/util.rs
+++ b/src/util.rs
@@ -2198,6 +2198,7 @@ pub fn get_stats_records(
             flag_delimiter:       args.flag_delimiter,
             flag_memcheck:        args.flag_memcheck,
             flag_vis_whitespace:  false,
+            flag_dataset_stats:   true,
         };
 
         let tempfile = tempfile::Builder::new()

--- a/tests/test_index.rs
+++ b/tests/test_index.rs
@@ -60,7 +60,7 @@ fn index_outdated_stats() {
     // even if the index is stale, stats should succeed
     // as the index is automatically updated
     let mut cmd = wrk.command("stats");
-    cmd.arg("in.csv");
+    cmd.args(&["--dataset-stats", "in.csv"]);
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![

--- a/tests/test_stats.rs
+++ b/tests/test_stats.rs
@@ -621,8 +621,8 @@ fn stats_prefer_dmy() {
     let mut cmd = wrk.command("stats");
     cmd.arg("--infer-dates")
         .arg("--prefer-dmy")
-        .arg("--dates-whitelist")
-        .arg("_dT")
+        .arg(&"--dataset-stats")
+        .args(&["--dates-whitelist", "_dT"])
         .arg(test_file);
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
@@ -648,8 +648,8 @@ fn stats_prefer_mdy() {
 
     let mut cmd = wrk.command("stats");
     cmd.arg("--infer-dates")
-        .arg("--dates-whitelist")
-        .arg("_dt")
+        .arg(&"--dataset-stats")
+        .args(&["--dates-whitelist", "_dt"])
         .arg(test_file);
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
@@ -675,8 +675,8 @@ fn stats_rounding() {
     let test_file = wrk.load_test_file("boston311-100.csv");
 
     let mut cmd = wrk.command("stats");
-    cmd.arg("--everything")
-        .args(["--round", "8"])
+    cmd.args(&["--everything", "--dataset-stats"])
+        .args(&["--round", "8"])
         .arg(test_file);
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
@@ -722,7 +722,8 @@ fn stats_no_date_inference() {
     let test_file = wrk.load_test_file("boston311-100.csv");
 
     let mut cmd = wrk.command("stats");
-    cmd.arg("--everything").arg(test_file);
+    cmd.args(&["--everything", "--dataset-stats"])
+        .arg(test_file);
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
 
@@ -749,8 +750,8 @@ fn stats_with_date_inference() {
     cmd.arg("--everything")
         .arg(test_file)
         .arg("--infer-dates")
-        .arg("--dates-whitelist")
-        .arg("all");
+        .arg(&"--dataset-stats")
+        .args(&["--dates-whitelist", "all"]);
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
 
@@ -774,7 +775,9 @@ fn stats_with_date_inference_default_whitelist() {
     let test_file = wrk.load_test_file("boston311-100.csv");
 
     let mut cmd = wrk.command("stats");
-    cmd.arg("--everything").arg(test_file).arg("--infer-dates");
+    cmd.args(&["--everything", "--dataset-stats"])
+        .arg(test_file)
+        .arg("--infer-dates");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
 
@@ -802,8 +805,8 @@ fn stats_with_date_inference_variance_stddev() {
     cmd.arg("--everything")
         .arg(test_file)
         .arg("--infer-dates")
-        .arg("--dates-whitelist")
-        .arg("aLL");
+        .args(&["--dates-whitelist", "all"])
+        .arg(&"--dataset-stats");
 
     wrk.assert_success(&mut cmd);
 
@@ -827,8 +830,8 @@ fn stats_with_date_type() {
     cmd.arg("--everything")
         .arg(test_file)
         .arg("--infer-dates")
-        .arg("--dates-whitelist")
-        .arg("all");
+        .args(&["--dates-whitelist", "all"])
+        .arg(&"--dataset-stats");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
 
@@ -852,7 +855,7 @@ fn stats_typesonly() {
     let test_file = wrk.load_test_file("boston311-100.csv");
 
     let mut cmd = wrk.command("stats");
-    cmd.arg("--typesonly").arg(test_file);
+    cmd.args(&["--typesonly", "--dataset-stats"]).arg(test_file);
 
     let got: String = wrk.stdout(&mut cmd);
 
@@ -867,10 +870,9 @@ fn stats_typesonly_with_dates() {
     let test_file = wrk.load_test_file("boston311-100.csv");
 
     let mut cmd = wrk.command("stats");
-    cmd.arg("--typesonly")
+    cmd.args(&["--typesonly", "--dataset-stats"])
         .arg("--infer-dates")
-        .arg("--dates-whitelist")
-        .arg("all")
+        .args(&["--dates-whitelist", "all"])
         .arg(test_file);
 
     let got: String = wrk.stdout(&mut cmd);
@@ -888,11 +890,10 @@ fn stats_typesonly_cache_threshold_zero() {
     let test_file = wrk.load_test_file("boston311-100.csv");
 
     let mut cmd = wrk.command("stats");
-    cmd.arg("--typesonly")
+    cmd.args(&["--typesonly", "--dataset-stats"])
         .arg("--infer-dates")
-        .arg("--dates-whitelist")
-        .arg("all")
-        .args(["--cache-threshold", "0"])
+        .args(&["--dates-whitelist", "all"])
+        .args(&["--cache-threshold", "0"])
         .arg(test_file);
 
     let got: String = wrk.stdout(&mut cmd);
@@ -912,10 +913,9 @@ fn stats_typesonly_cache() {
     let test_file = wrk.load_test_file("boston311-100.csv");
 
     let mut cmd = wrk.command("stats");
-    cmd.arg("--typesonly")
+    cmd.args(&["--typesonly", "--dataset-stats"])
         .arg("--infer-dates")
-        .arg("--dates-whitelist")
-        .arg("all")
+        .args(&["--dates-whitelist", "all"])
         .arg(test_file);
 
     let got: String = wrk.stdout(&mut cmd);
@@ -934,10 +934,10 @@ fn stats_cache() {
 
     let mut cmd = wrk.command("stats");
     cmd.arg("--infer-dates")
-        .arg("--dates-whitelist")
-        .arg("all")
+        .args(&["--dates-whitelist", "all"])
+        .arg(&"--dataset-stats")
         // set cache threshold to 1 to force cache creation
-        .args(["--cache-threshold", "1"])
+        .args(&["--cache-threshold", "1"])
         .arg(test_file);
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
@@ -1007,11 +1007,11 @@ fn stats_cache_negative_threshold_unmet() {
 
     let mut cmd = wrk.command("stats");
     cmd.arg("--infer-dates")
-        .arg("--dates-whitelist")
-        .arg("all")
+        .args(&["--dates-whitelist", "all"])
+        .arg(&"--dataset-stats")
         // set cache threshold to -51200 to set autoindex_size to 50 kb
         // and to force cache creation
-        .args(["--cache-threshold", "-51200"])
+        .args(&["--cache-threshold", "-51200"])
         .arg(test_file.clone());
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
@@ -1084,7 +1084,7 @@ fn stats_antimodes_len_500() {
 
     let mut cmd = wrk.command("stats");
     cmd.env("QSV_ANTIMODES_LEN", "500")
-        .arg("--everything")
+        .args(&["--everything", "--dataset-stats"])
         .arg(test_file);
 
     let got: String = wrk.stdout(&mut cmd);
@@ -1100,7 +1100,9 @@ fn stats_infer_boolean_1_0() {
     let test_file = wrk.load_test_file("boston311-10-boolean-1or0.csv");
 
     let mut cmd = wrk.command("stats");
-    cmd.arg("--infer-boolean").arg(test_file);
+    cmd.arg("--infer-boolean")
+        .arg(&"--dataset-stats")
+        .arg(test_file);
 
     let got: String = wrk.stdout(&mut cmd);
 
@@ -1115,7 +1117,9 @@ fn stats_infer_boolean_t_f() {
     let test_file = wrk.load_test_file("boston311-10-boolean-tf.csv");
 
     let mut cmd = wrk.command("stats");
-    cmd.arg("--infer-boolean").arg(test_file);
+    cmd.arg("--infer-boolean")
+        .arg(&"--dataset-stats")
+        .arg(test_file);
 
     let got: String = wrk.stdout(&mut cmd);
 
@@ -1130,7 +1134,10 @@ fn stats_typesonly_infer_boolean_t_f() {
     let test_file = wrk.load_test_file("boston311-10-boolean-tf.csv");
 
     let mut cmd = wrk.command("stats");
-    cmd.arg("--typesonly").arg("--infer-boolean").arg(test_file);
+    cmd.arg("--typesonly")
+        .arg("--infer-boolean")
+        .arg(&"--dataset-stats")
+        .arg(test_file);
 
     let got: String = wrk.stdout(&mut cmd);
 
@@ -1144,7 +1151,7 @@ fn stats_is_ascii() {
     let wrk = Workdir::new("stats_is_ascii");
     let test_file = wrk.load_test_file("boston311-100-with-nonascii.csv");
     let mut cmd = wrk.command("stats");
-    cmd.arg(test_file).arg("--force");
+    cmd.arg(test_file).arg(&"--dataset-stats").arg("--force");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
 
@@ -1197,7 +1204,9 @@ fn stats_leading_zero_handling() {
     );
 
     let mut cmd = wrk.command("stats");
-    cmd.arg("--typesonly").arg("data.csv");
+    cmd.arg("--typesonly")
+        .arg(&"--dataset-stats")
+        .arg("data.csv");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
@@ -1234,7 +1243,7 @@ fn stats_zero_cv() {
     );
 
     let mut cmd = wrk.command("stats");
-    cmd.arg("data.csv");
+    cmd.arg("data.csv").arg(&"--dataset-stats");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
@@ -1498,7 +1507,9 @@ fn stats_output_tab_delimited() {
     let out_file = wrk.path("output.tab").to_string_lossy().to_string();
 
     let mut cmd = wrk.command("stats");
-    cmd.arg("data.csv").args(["--output", &out_file]);
+    cmd.arg("data.csv")
+        .args(&["--output", &out_file])
+        .arg(&"--dataset-stats");
 
     wrk.assert_success(&mut cmd);
 
@@ -1534,7 +1545,9 @@ fn stats_output_ssv_delimited() {
     let out_file = wrk.path("output.ssv").to_string_lossy().to_string();
 
     let mut cmd = wrk.command("stats");
-    cmd.arg("data.csv").args(["--output", &out_file]);
+    cmd.arg("data.csv")
+        .args(&["--output", &out_file])
+        .arg(&"--dataset-stats");
 
     wrk.assert_success(&mut cmd);
 
@@ -1570,7 +1583,9 @@ fn stats_output_csvsz_delimited() {
     let out_file = wrk.path("output.csv.sz").to_string_lossy().to_string();
 
     let mut cmd = wrk.command("stats");
-    cmd.arg("data.csv").args(["--output", &out_file]);
+    cmd.arg("data.csv")
+        .args(&["--output", &out_file])
+        .arg(&"--dataset-stats");
 
     wrk.assert_success(&mut cmd);
 
@@ -1658,6 +1673,7 @@ fn stats_vis_whitespace() {
     let mut cmd = wrk.command("stats");
     cmd.arg("--vis-whitespace")
         .arg("--everything")
+        .arg(&"--dataset-stats")
         .arg("data.csv");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);


### PR DESCRIPTION
Previously, dataset-stats were produced by default as it was used by DP+ and the smart commands to skip having to run `count`, `headers` and `diff` commands separately.

However, it was causing confusion from CLI users, so just making it an option.