### PR TITLE
fix: `apply` `currencytonum` operation by adding parsing strictness control with  `--formatstr` option

### DIFF
--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -70,7 +70,9 @@ It has 40 supported operations:
       The decimal separator can be specified with --replacement (default: '.')
   * currencytonum: Gets the numeric value of a currency. Supports currency symbols
       (e.g. $,¥,£,€,֏,₱,₽,₪,₩,ƒ,฿,₫) and strings (e.g. USD, EUR, RMB, JPY, etc.). 
-      Recognizes point, comma and space separators.
+      Recognizes point, comma and space separators. Is "permissive" by default, meaning it
+      will allow no or non-ISO currency symbols. To enforce strict parsing, which will require
+      a valid ISO currency symbol, set the --formatstr to "strict".
   * numtocurrency: Convert a numeric value to a currency. Specify the currency symbol
       with --comparand. Automatically rounds values to two decimal places. Specify
       "euro" formatting (e.g. 1.000,00 instead of 1,000.00 ) by setting --formatstr to "euro".
@@ -267,7 +269,14 @@ apply options:
                                 Also used with numtocurrency operation to conversion rate.
     -f, --formatstr=<string>    This option is used by several subcommands:
 
-                                OPERATIONS: 
+                                OPERATIONS:
+                                  currencytonum
+                                    If set to "strict", will require a valid ISO currency symbol,
+                                    with the currency symbol at the beginning of the string.
+                                    Otherwise, only parse the numeric part of the string and ignore
+                                    the currency symbol altogether.
+                                    (default: permissive)
+
                                   numtocurrency
                                     If set to "euro", will format the currency to use "." instead of ","
                                     as separators (e.g. 1.000,00 instead of 1,000.00 )
@@ -1140,11 +1149,11 @@ fn apply_operations(
                 }
             },
             Operations::Currencytonum => {
-                // this is a workaround around current limitation of qsv-currency
+                // Handle currency strings with 3 decimal places by appending a 0
+                // to make it 4 decimal places without affecting the value
+                // This is a workaround around current limitation of qsv-currency
                 // and also of upstream currency-rs, that it cannot
                 // handle currency amounts properly with three decimal places
-                // to get around this limitation, we append a 0 at the end to make it four
-                // decimal places without affecting the value
                 let fract_3digits: &'static Regex = regex_oncelock!(r"\.\d\d\d$");
                 let cell_val = if fract_3digits.is_match(cell) {
                     format!("{cell}0")
@@ -1153,16 +1162,57 @@ fn apply_operations(
                 };
 
                 if let Ok(currency_val) = Currency::from_str(&cell_val) {
-                    // currency is stored as a BigInt, with
-                    // 1 currency unit being 100 coins
-                    let currency_coins = currency_val.value();
-                    let coins = format!("{:03}", &currency_coins);
-                    let coinlen = coins.len();
-                    if coinlen > 2 && coins != "000" {
-                        let decpoint = coinlen - 2;
-                        let coin_num = &coins[..decpoint];
-                        let coin_frac = &coins[decpoint..];
-                        *cell = format!("{coin_num}.{coin_frac}");
+                    if formatstr == "strict" {
+                        // Process ISO currency values
+                        let currency_coins = currency_val.value();
+                        let coins = format!("{:03}", &currency_coins);
+
+                        if currency_val.is_iso_currency() {
+                            if coins == "000" {
+                                *cell = "0.00".to_string();
+                            } else {
+                                let coinlen = coins.len();
+                                if coinlen > 2 {
+                                    let decpoint = coinlen - 2;
+                                    let coin_num = &coins[..decpoint];
+                                    let coin_frac = &coins[decpoint..];
+                                    *cell = format!("{coin_num}.{coin_frac}");
+                                }
+                            }
+                        }
+                    } else {
+                        // For non-strict mode, extract numeric parts from currency strings
+                        // using regex that handles various formats including thousand separators
+                        // we ignore the currency symbol altogether
+                        let numparts_re: &'static Regex =
+                            regex_oncelock!(r"-?(?:\d{1,3}(?:[,. ]\d{3})+|(?:\d+))(?:[,.]\d+)?");
+
+                        if let Some(numparts) = numparts_re.find(cell) {
+                            // use the same workaround as above to handle 3 decimal places
+                            let numparts_str = numparts.as_str();
+                            let numparts_val = if fract_3digits.is_match(numparts_str) {
+                                format!("{}0", numparts_str)
+                            } else {
+                                numparts_str.to_string()
+                            };
+
+                            if let Ok(extracted_currency) = Currency::from_str(&numparts_val) {
+                                let currency_coins = extracted_currency.value();
+                                let coins = format!("{:03}", &currency_coins);
+
+                                if coins == "000" {
+                                    *cell = "0.00".to_string();
+                                } else {
+                                    let coinlen = coins.len();
+                                    if coinlen > 2 {
+                                        let decpoint = coinlen - 2;
+                                        let coin_num = &coins[..decpoint];
+                                        let coin_frac = &coins[decpoint..];
+                                        *cell = format!("{coin_num}.{coin_frac}");
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             },
@@ -1178,7 +1228,7 @@ fn apply_operations(
                 if let Ok(currency_value) = Currency::from_str(&cell_val) {
                     let currency_wrk = currency_value
                         .convert(replacement.parse::<f64>().unwrap_or(1.0_f64), comparand);
-                    *cell = if formatstr.contains("euro") {
+                    *cell = if formatstr == "euro" {
                         format!("{currency_wrk:e}")
                     } else {
                         format!("{currency_wrk}")

--- a/tests/test_apply.rs
+++ b/tests/test_apply.rs
@@ -1891,6 +1891,10 @@ fn apply_ops_currencytonum() {
             svec!["1,250,000"],
             svec!["$5"],
             svec!["0"],
+            svec!["$ 0.00"],
+            svec!["USD 0"],
+            svec!["USD 0.00"],
+            svec!["0.00 $"],
             svec!["5"],
             svec!["$0.25"],
             svec!["$ 10.05"],
@@ -1912,6 +1916,8 @@ fn apply_ops_currencytonum() {
             svec!["USD 10,000"],
             svec!["EUR 1234.50"],
             svec!["JPY 9,999,999.99"],
+            // RMB is not a valid ISO currency code
+            // but we handle it anyway
             svec!["RMB 6543.21"],
             svec!["$10.0099"],
             svec!["$10.0777"],
@@ -1936,7 +1942,11 @@ fn apply_ops_currencytonum() {
         svec!["12500.00"],
         svec!["1250000.00"],
         svec!["5.00"],
-        svec!["0"],
+        svec!["0.00"],
+        svec!["0.00"],
+        svec!["0.00"],
+        svec!["0.00"],
+        svec!["0.00"],
         svec!["5.00"],
         svec!["0.25"],
         svec!["10.05"],
@@ -1959,6 +1969,112 @@ fn apply_ops_currencytonum() {
         svec!["1234.50"],
         svec!["9999999.99"],
         svec!["6543.21"],
+        svec!["10.01"],
+        svec!["10.08"],
+        svec!["10.07"],
+        svec!["10.87"],
+        svec!["10.78"],
+        svec!["10.78"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn apply_ops_currencytonum_strict() {
+    let wrk = Workdir::new("apply_currencytonum_strict");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["money"],
+            svec!["$10.00"],
+            svec!["$-10.00"],
+            svec!["$ 12 500.00"],
+            svec!["12,500.00"],
+            svec!["1,250,000"],
+            svec!["$5"],
+            svec!["0"],
+            svec!["$ 0.00"],
+            svec!["USD 0"],
+            svec!["USD 0.00"],
+            // in strict mode this will be ignored
+            // because you can't have a trailing currency symbol
+            svec!["0.00 $"],
+            svec!["5"],
+            svec!["$0.25"],
+            svec!["$ 10.05"],
+            svec!["¥10,000,000.00"],
+            svec!["£423.56"],
+            svec!["€120.00"],
+            svec!["֏99,999.50"],
+            svec!["€300 999,55"],
+            svec!["This is not money. Leave untouched."],
+            svec!["₱1,234,567.89"],
+            svec!["₽234,567.89"],
+            svec!["₪ 567.89"],
+            svec!["₩ 567.89"],
+            svec!["₩ 89,123.0"],
+            svec!["ƒ 123,456.00"],
+            svec!["฿ 789,123"],
+            svec!["₫ 456"],
+            svec!["123,456.00 $"],
+            svec!["USD 10,000"],
+            svec!["EUR 1234.50"],
+            svec!["JPY 9,999,999.99"],
+            // RMB is not a valid ISO currency code
+            // so in strict mode it will be ignored
+            svec!["RMB 6543.21"],
+            svec!["$10.0099"],
+            svec!["$10.0777"],
+            svec!["$10.0723"],
+            svec!["$10.8723"],
+            svec!["$10.77777"],
+            svec!["$10.777"],
+        ],
+    );
+    let mut cmd = wrk.command("apply");
+    cmd.arg("operations")
+        .arg("currencytonum")
+        .arg("money")
+        .arg("--formatstr")
+        .arg("strict")
+        .arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["money"],
+        svec!["10.00"],
+        svec!["-10.00"],
+        svec!["12500.00"],
+        svec!["12,500.00"],
+        svec!["1,250,000"],
+        svec!["5.00"],
+        svec!["0"],
+        svec!["0.00"],
+        svec!["0.00"],
+        svec!["0.00"],
+        svec!["0.00 $"],
+        svec!["5"],
+        svec!["0.25"],
+        svec!["10.05"],
+        svec!["10000000.00"],
+        svec!["423.56"],
+        svec!["120.00"],
+        svec!["99999.50"],
+        svec!["300999.55"],
+        svec!["This is not money. Leave untouched."],
+        svec!["1234567.89"],
+        svec!["234567.89"],
+        svec!["567.89"],
+        svec!["567.89"],
+        svec!["89123.00"],
+        svec!["123456.00"],
+        svec!["789123.00"],
+        svec!["456.00"],
+        svec!["123,456.00 $"],
+        svec!["10000.00"],
+        svec!["1234.50"],
+        svec!["9999999.99"],
+        svec!["RMB 6543.21"],
         svec!["10.01"],
         svec!["10.08"],
         svec!["10.07"],


### PR DESCRIPTION
fixes #2584 