### PR TITLE
fix: correct link to qsv-dateparser accepted date formats

### DIFF
--- a/src/cmd/datefmt.rs
+++ b/src/cmd/datefmt.rs
@@ -2,7 +2,7 @@ static USAGE: &str = r#"
 Formats recognized date fields (19 formats recognized) to a specified date format
 using strftime date format specifiers.
 
-See https://github.com/dathere/belt/tree/main/dateparser#accepted-date-formats for
+See https://github.com/jqnatividad/belt/tree/main/dateparser#accepted-date-formats for
 recognized date formats.
 See https://docs.rs/chrono/latest/chrono/format/strftime/ for 
 accepted date format specifiers for --formatstr.


### PR DESCRIPTION
fixes #2630 

[skip ci]