### PR TITLE
feat: `split` add `--filter` options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1918,6 +1918,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5182,6 +5188,7 @@ dependencies = [
  "data-encoding",
  "directories",
  "dotenvy",
+ "dunce",
  "dynfmt2",
  "eudex",
  "ext-sort",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ csvs_convert = { version = "0.10", default-features = false, features = [
 data-encoding = { version = "2.8", optional = true }
 directories = "6.0"
 dotenvy = "0.15"
+dunce = "1"
 dynfmt2 = { version = "0.2", default-features = false, features = ["curly"] }
 eudex = { version = "0.1", optional = true }
 ext-sort = { version = "0.1", default-features = false }


### PR DESCRIPTION
patterned after GNU split's `--filter` option
https://www.gnu.org/software/coreutils/manual/html_node/split-invocation.html

resolves #2654 