### PR TITLE
feat: add qsv geoconvert prototype

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,6 +348,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1904,6 +1913,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
 
 [[package]]
+name = "dbase"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86bc97a72d9aca92b9a8095b3bfe8f691c54bb15eefaacec53882604062428bf"
+dependencies = [
+ "byteorder",
+ "time",
+]
+
+[[package]]
 name = "decimal"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2684,6 +2703,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "geo-types"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62ddb1950450d67efee2bbc5e429c68d052a822de3aad010d28b351fbb705224"
+dependencies = [
+ "approx",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "geojson"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e26f3c45b36fccc9cf2805e61d4da6bc4bbd5a3a9589b01afa3a40eff703bd79"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "geosuggest-core"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2712,6 +2754,23 @@ dependencies = [
  "serde",
  "tokio",
  "zip",
+]
+
+[[package]]
+name = "geozero"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5f28f34864745eb2f123c990c6ffd92c1584bd39439b3f27ff2a0f4ea5b309b"
+dependencies = [
+ "byteorder",
+ "csv",
+ "dbase",
+ "geo-types",
+ "geojson",
+ "log",
+ "serde_json",
+ "thiserror 1.0.69",
+ "wkt",
 ]
 
 [[package]]
@@ -5542,6 +5601,7 @@ dependencies = [
  "gender_guesser",
  "geosuggest-core",
  "geosuggest-utils",
+ "geozero",
  "governor 0.10.0",
  "grex",
  "gzp",
@@ -8616,6 +8676,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags 2.9.0",
+]
+
+[[package]]
+name = "wkt"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54f7f1ff4ea4c18936d6cd26a6fd24f0003af37e951a8e0e8b9e9a2d0bd0a46d"
+dependencies = [
+ "geo-types",
+ "log",
+ "num-traits",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -276,6 +276,7 @@ url = "2.5"
 whatlang = { version = "0.16", optional = true }
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 zip = "=2.5.0"
+geozero = { version = "0.14.0", features = ["with-csv", "with-shp"] }
 
 # enable parking_lot hardware lock elision on x86_64
 [target.'cfg(target_arch = "x86_64")'.dependencies]

--- a/src/cmd/geoconvert.rs
+++ b/src/cmd/geoconvert.rs
@@ -1,0 +1,75 @@
+static USAGE: &str = r#"
+Convert between various spatial formats and CSV including GeoJSON, SHP, and more.
+
+For example to convert a GeoJSON file into CSV data:
+
+qsv geoconvert file.geojson geojson csv
+
+Usage:
+    qsv geoconvert [options] [<input>] <input-format> <output-format>
+    qsv geoconvert --help
+
+Common options:
+    -h, --help             Display this message
+"#;
+
+use std::path::PathBuf;
+
+use geozero::{csv::CsvWriter, geojson::GeoJsonWriter, ProcessToCsv, ProcessToSvg};
+use serde::Deserialize;
+
+use crate::{CliResult, config::Config, util};
+
+#[derive(Deserialize)]
+struct Args {
+    arg_input: Option<String>,
+    arg_input_format: String,
+    arg_output_format: String,
+    // flag_output:   Option<String>,
+}
+
+pub fn run(argv: &[&str]) -> CliResult<()> {
+    let args: Args = util::get_args(USAGE, argv)?;
+
+    // TODO: Implement handling stdin
+    let input = args.arg_input;
+    let input_format = args.arg_input_format;
+    let output_format = args.arg_output_format;
+
+    // Construct a spatial geometry based on the input format
+    let output_string = match input_format.as_str() {
+        "geojson" => {
+            let input_string = match input.clone() {
+                Some(path) => std::fs::read_to_string(path).unwrap(),
+                _ => return fail_clierror!("Could not identify file path.")
+            };
+            let mut geometry = geozero::geojson::GeoJson(&input_string);
+            match output_format.as_str() {
+                "csv" => geometry.to_csv().unwrap(),
+                "svg" => geometry.to_svg().unwrap(),
+                _ => return fail_clierror!("Could not identify valid output format.")
+            }
+        },
+        "shp" => {
+            let reader = geozero::shp::ShpReader::from_path(input.unwrap()).unwrap();
+            match output_format.as_str() {
+                "geojson" => {
+                    let mut json: Vec<u8> = Vec::new();
+                    reader.iter_features(&mut GeoJsonWriter::new(&mut json)).unwrap();
+                    String::from_utf8(json).unwrap()
+                },
+                "csv" => {
+                    let mut csv: Vec<u8> = Vec::new();
+                    reader.iter_features(&mut CsvWriter::new(&mut csv)).unwrap();
+                    String::from_utf8(csv).unwrap()
+                },
+                _ => return fail_clierror!("Could not identify valid output format.")
+            }
+        },
+        _ => return fail_clierror!("Could not identify valid input format.")
+    };
+
+    print!("{output_string}");
+    
+    Ok(())
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -41,6 +41,8 @@ pub mod foreach;
 pub mod frequency;
 #[cfg(all(feature = "geocode", feature = "feature_capable"))]
 pub mod geocode;
+#[cfg(feature = "feature_capable")]
+pub mod geoconvert;
 pub mod headers;
 pub mod index;
 pub mod input;

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,7 +141,8 @@ fn main() -> QsvExitCode {
         .push_str("    geocode     Geocodes a location against the Geonames cities database.\n");
 
     enabled_commands.push_str(
-        "    headers     Show header names
+        "    geoconvert  Convert between spatial formats and CSV, including GeoJSON, SHP, and more
+    headers     Show header names
     help        Show this usage message
     index       Create CSV index for faster access
     input       Read CSVs w/ special quoting, skipping, trimming & transcoding rules
@@ -368,6 +369,7 @@ enum Command {
     Frequency,
     #[cfg(all(feature = "geocode", feature = "feature_capable"))]
     Geocode,
+    Geoconvert,
     Headers,
     Help,
     Index,
@@ -464,6 +466,7 @@ impl Command {
             Command::Frequency => cmd::frequency::run(argv),
             #[cfg(all(feature = "geocode", feature = "feature_capable"))]
             Command::Geocode => cmd::geocode::run(argv),
+            Command::Geoconvert => cmd::geoconvert::run(argv),
             Command::Headers => cmd::headers::run(argv),
             Command::Help => {
                 wout!("{USAGE}\n\n{SPONSOR_MESSAGE}");


### PR DESCRIPTION
One method to assist in supporting spatial formats (#2253) in qsv is conversion between spatial formats and also CSV. This PR introduces an early prototype of `qsv geoconvert` for further improvement/refactoring.

I haven't gotten decent results from reading `SHP` data yet in this implementation though the GeoJSON conversion seems to work fine so far.