### PR TITLE
feat: setting QSV_DOTENV_PATH to sentinel value "<NONE>" disables doting processing

### DIFF
--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -2,7 +2,7 @@
 
 | Variable | Description |
 | --- | --- |
-| `QSV_DOTENV_PATH` | The full pathname of the dotenv file to load, OVERRIDING existing environment variables. This takes precedence over any other dotenv files in the filesystem. |
+| `QSV_DOTENV_PATH` | The full pathname of the dotenv file to load, OVERRIDING existing environment variables. This takes precedence over any other dotenv files in the filesystem. Set to "<NONE>" to disable dotenv processing. |
 | `QSV_DEFAULT_DELIMITER` | single ascii character to use as delimiter.  Overrides `--delimiter` option. Defaults to "," (comma) for CSV files & "\t" (tab) for TSV files when not set. Note that this will also set the delimiter for qsv's output to stdout.<br>However, using the `--output` option, regardless of this environment variable, will automatically change the delimiter used in the generated file based on the file extension - i.e. comma for `.csv`; tab for `.tsv` & `.tab` ; and semicolon for `.ssv` files |
 | `QSV_SNIFF_DELIMITER` | if set, the delimiter is automatically detected. Overrides `QSV_DEFAULT_DELIMITER` & `--delimiter` option. Note that this does not work with stdin. |
 | `QSV_NO_HEADERS` | if set, the first row will **NOT** be interpreted as headers. Supersedes `QSV_TOGGLE_HEADERS`. |

--- a/src/util.rs
+++ b/src/util.rs
@@ -1522,6 +1522,13 @@ pub fn load_dotenv() -> CliResult<()> {
     // whatever manually set environment variables are present.
 
     if let Ok(dotenv_path) = std::env::var("QSV_DOTENV_PATH") {
+
+        // <NONE> is a sentinel value to disable dotenv processing
+        if dotenv_path == "<NONE>" {
+            log::warn!("dotenv processing disabled with QSV_DOTENV_PATH=<NONE>");
+            return Ok(());
+        }
+
         let canonical_dotenv_path = std::fs::canonicalize(dotenv_path)?;
         if let Err(e) = dotenvy::from_filename_override(canonical_dotenv_path.clone()) {
             return fail_clierror!(

--- a/src/util.rs
+++ b/src/util.rs
@@ -1522,7 +1522,6 @@ pub fn load_dotenv() -> CliResult<()> {
     // whatever manually set environment variables are present.
 
     if let Ok(dotenv_path) = std::env::var("QSV_DOTENV_PATH") {
-
         // <NONE> is a sentinel value to disable dotenv processing
         if dotenv_path == "<NONE>" {
             log::warn!("dotenv processing disabled with QSV_DOTENV_PATH=<NONE>");


### PR DESCRIPTION
see https://github.com/dathere/qsv/discussions/2682#discussioncomment-12814350