### PR TITLE
refactor: `geoconvert`

### DIFF
--- a/.github/workflows/macOS-arm64-selfhosted-publish-nightly.yml
+++ b/.github/workflows/macOS-arm64-selfhosted-publish-nightly.yml
@@ -38,7 +38,7 @@ jobs:
             addl-build-args: --features=apply,fetch,foreach,self_update,luau,polars,to,geocode,lens
             default-features: --no-default-features
             addl-qsvlite-features:
-            addl-qsvdp-features: luau
+            addl-qsvdp-features: luau,geocode
 
     steps:
     - name: Installing Rust toolchain

--- a/.github/workflows/macOS-arm64-selfhosted-publish-qsvpy.yml
+++ b/.github/workflows/macOS-arm64-selfhosted-publish-qsvpy.yml
@@ -37,7 +37,7 @@ jobs:
             addl-build-args: --features=apply,fetch,foreach,self_update,luau,polars,to,geocode,python,lens
             default-features:
             addl-qsvlite-features:
-            addl-qsvdp-features: luau
+            addl-qsvdp-features: luau,geocode
 
     steps:
     - name: Installing Rust toolchain

--- a/.github/workflows/macOS-arm64-selfhosted-publish.yml
+++ b/.github/workflows/macOS-arm64-selfhosted-publish.yml
@@ -38,7 +38,7 @@ jobs:
             addl-build-args: --features=apply,fetch,foreach,self_update,luau,polars,to,geocode,lens
             default-features:
             addl-qsvlite-features:
-            addl-qsvdp-features: luau
+            addl-qsvdp-features: luau,geocode
 
     steps:
     - name: Installing Rust toolchain

--- a/.github/workflows/publish-linux-glibc-231-musl-123.yml
+++ b/.github/workflows/publish-linux-glibc-231-musl-123.yml
@@ -36,7 +36,7 @@ jobs:
             addl-build-args: --features=apply,luau,fetch,foreach,self_update,polars,geocode,lens,prompt
             default-features:
             addl-qsvlite-features:
-            addl-qsvdp-features: luau
+            addl-qsvdp-features: luau,geocode
             name-suffix: glibc-2.31
           - os: ubuntu-20.04
             os-name: linux
@@ -55,7 +55,7 @@ jobs:
             addl-build-args: --features=apply,luau,fetch,foreach,self_update,polars,geocode
             default-features:
             addl-qsvlite-features:
-            addl-qsvdp-features: luau
+            addl-qsvdp-features: luau,geocode
             name-suffix: glibc-2.31-headless
     steps:
     - name: Installing Rust toolchain

--- a/.github/workflows/publish-macOS-x86_64.yml
+++ b/.github/workflows/publish-macOS-x86_64.yml
@@ -40,7 +40,7 @@ jobs:
             addl-build-args: --features=apply,fetch,foreach,self_update,luau,polars,to,geocode,lens,prompt
             default-features: --no-default-features
             addl-qsvlite-features:
-            addl-qsvdp-features: luau
+            addl-qsvdp-features: luau,geocode
             addl-rustflags: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+fma
 
     steps:

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -36,7 +36,7 @@ jobs:
             addl-build-args: --features=apply,luau,fetch,foreach,nightly,self_update,geocode,polars,to,lens,prompt
             default-features:
             addl-qsvlite-features:
-            addl-qsvdp-features: luau
+            addl-qsvdp-features: luau,geocode
             addl-rustflags: -C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+avx2,+fma,+bmi1,+bmi2,+lzcnt,+pclmulqdq
           # - os: ubuntu-22.04
           #   os-name: linux
@@ -52,7 +52,7 @@ jobs:
             addl-build-args: --features=apply,luau,fetch,nightly,self_update,polars,geocode,to,lens,prompt
             default-features:
             addl-qsvlite-features:
-            addl-qsvdp-features: luau
+            addl-qsvdp-features: luau,geocode
             addl-rustflags: -C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+avx2,+fma,+bmi1,+bmi2,+lzcnt,+pclmulqdq
           # - os: windows-latest
           #   os-name: windows
@@ -61,7 +61,7 @@ jobs:
           #   addl-build-args: --features=apply,luau,fetch,nightly,self_update,polars
           #   default-features: --no-default-features 
           #   addl-qsvlite-features:
-          #   addl-qsvdp-features: luau
+          #   addl-qsvdp-features: luau,geocode
           #   addl-rustflags: -C target-feature=+fxsr,+sse,+sse2,+sse3,+sse4.1,+sse4.2
           - os: macos-latest
             os-name: macos
@@ -70,7 +70,7 @@ jobs:
             addl-build-args: --features=apply,luau,fetch,foreach,nightly,to,self_update,polars,geocode,lens,prompt
             default-features:
             addl-qsvlite-features:
-            addl-qsvdp-features: luau
+            addl-qsvdp-features: luau,geocode
             addl-rustflags: -C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+avx2,+fma,+bmi1,+bmi2,+lzcnt,+pclmulqdq
 
     steps:

--- a/.github/workflows/publish-portable.yml
+++ b/.github/workflows/publish-portable.yml
@@ -39,7 +39,7 @@ jobs:
             addl-build-args: --features=apply,luau,fetch,foreach,self_update,geocode,polars,to,lens,prompt
             default-features:
             addl-qsvlite-features:
-            addl-qsvdp-features: luau
+            addl-qsvdp-features: luau,geocode
             addl-rustflags: 
           - os: ubuntu-22.04
             os-name: linux
@@ -70,7 +70,7 @@ jobs:
             addl-build-args: --features=apply,luau,fetch,self_update,geocode,polars,to,lens,prompt,foreach
             default-features:
             addl-qsvlite-features:
-            addl-qsvdp-features: luau
+            addl-qsvdp-features: luau,geocode
             addl-rustflags: 
           # - os: windows-latest
           #   os-name: windows
@@ -90,7 +90,7 @@ jobs:
             addl-build-args: --features=apply,luau,fetch,self_update,geocode,polars,to,lens,prompt
             default-features: --no-default-features
             addl-qsvlite-features:
-            addl-qsvdp-features: luau
+            addl-qsvdp-features: luau,geocode
             addl-rustflags: 
           # - os: macos-12
           #   os-name: macos
@@ -100,7 +100,7 @@ jobs:
           #   addl-build-args: --features=apply,luau,fetch,foreach,self_update,polars
           #   default-features: --no-default-features
           #   addl-qsvlite-features:
-          #   addl-qsvdp-features: luau
+          #   addl-qsvdp-features: luau,geocode
           # - os: macos-12
           #   os-name: macos
           #   target: aarch64-apple-darwin

--- a/.github/workflows/publish-qsvpy.yml
+++ b/.github/workflows/publish-qsvpy.yml
@@ -36,7 +36,7 @@ jobs:
             addl-build-args: --features=apply,luau,fetch,foreach,self_update,geocode,polars,to,python,lens,prompt
             default-features:
             addl-qsvlite-features:
-            addl-qsvdp-features: luau
+            addl-qsvdp-features: luau,geocode
             addl-rustflags: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+fma
           # - os: ubuntu-22.04
           #   os-name: linux
@@ -52,7 +52,7 @@ jobs:
             addl-build-args: --features=apply,luau,fetch,self_update,polars,geocode,to,python,lens,foreach,prompt
             default-features:
             addl-qsvlite-features:
-            addl-qsvdp-features: luau
+            addl-qsvdp-features: luau,geocode
             addl-rustflags: -C target-feature=+fxsr,+sse,+sse2,+sse3,+sse4.1,+sse4.2
           # - os: windows-latest
           #   os-name: windows
@@ -61,7 +61,7 @@ jobs:
           #   addl-build-args: --features=apply,luau,fetch,nightly,self_update,polars
           #   default-features: --no-default-features 
           #   addl-qsvlite-features:
-          #   addl-qsvdp-features: luau
+          #   addl-qsvdp-features: luau,geocode
           #   addl-rustflags: -C target-feature=+fxsr,+sse,+sse2,+sse3,+sse4.1,+sse4.2
           - os: macos-latest
             os-name: macos
@@ -70,7 +70,7 @@ jobs:
             addl-build-args: --features=apply,luau,fetch,foreach,to,self_update,polars,geocode,python,lens,prompt
             default-features:
             addl-qsvlite-features:
-            addl-qsvdp-features: luau
+            addl-qsvdp-features: luau,geocode
             addl-rustflags: -C target-feature=+fxsr,+sse,+sse2,+sse3,+sse4.1,+sse4.2
 
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
             addl-build-args: --features=apply,luau,fetch,foreach,self_update,geocode,polars,to,lens,prompt
             default-features:
             addl-qsvlite-features:
-            addl-qsvdp-features: luau
+            addl-qsvdp-features: luau,geocode
             addl-rustflags: -C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+avx2,+fma,+bmi1,+bmi2,+lzcnt,+pclmulqdq
           - os: ubuntu-24.04
             os-name: linux
@@ -73,7 +73,7 @@ jobs:
             addl-build-args: --features=apply,luau,fetch,self_update,geocode,polars,to,lens,foreach,prompt
             default-features:
             addl-qsvlite-features:
-            addl-qsvdp-features: luau
+            addl-qsvdp-features: luau,geocode
             addl-rustflags: -C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+avx2,+fma,+bmi1,+bmi2,+lzcnt,+pclmulqdq
           # - os: windows-latest
           #   os-name: windows
@@ -93,7 +93,7 @@ jobs:
             addl-build-args: --features=apply,luau,fetch,self_update,geocode,polars,to,lens,foreach,prompt
             default-features: --no-default-features
             addl-qsvlite-features:
-            addl-qsvdp-features: luau
+            addl-qsvdp-features: luau,geocode
             addl-rustflags: -C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+avx2,+fma,+bmi1,+bmi2,+lzcnt,+pclmulqdq
           # - os: macos-12
           #   os-name: macos
@@ -103,7 +103,7 @@ jobs:
           #   addl-build-args: --features=apply,luau,fetch,foreach,self_update,polars
           #   default-features: --no-default-features
           #   addl-qsvlite-features:
-          #   addl-qsvdp-features: luau
+          #   addl-qsvdp-features: luau,geocode
           # - os: macos-12
           #   os-name: macos
           #   target: aarch64-apple-darwin

--- a/.github/workflows/test-publish-nightly.yml
+++ b/.github/workflows/test-publish-nightly.yml
@@ -20,7 +20,7 @@ jobs:
             architecture: x86_64
             addl-build-args: --features=apply,luau,fetch,foreach,nightly,to,self_update,polars
             default-features:
-            addl-qsvdp-features: luau
+            addl-qsvdp-features: luau,geocode
           # - os: ubuntu-latest
           #   os-name: linux
           #   target: x86_64-unknown-linux-musl
@@ -34,21 +34,21 @@ jobs:
             architecture: x86_64
             addl-build-args: --features=apply,luau,fetch,nightly,to,self_update,polars
             default-features:
-            addl-qsvdp-features: luau
+            addl-qsvdp-features: luau,geocode
           - os: windows-latest
             os-name: windows
             target: x86_64-pc-windows-gnu
             architecture: x86_64
             addl-build-args: --features=apply,luau,fetch,nightly,self_update,polars
             default-features: --no-default-features 
-            addl-qsvdp-features: luau
+            addl-qsvdp-features: luau,geocode
           - os: macos-latest
             os-name: macos
             target: x86_64-apple-darwin
             architecture: x86_64
             addl-build-args: --features=apply,luau,fetch,foreach,nightly,to,self_update
             default-features:
-            addl-qsvdp-features: luau
+            addl-qsvdp-features: luau,geocode
 
     steps:
     - name: Installing Rust toolchain

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -22,7 +22,7 @@ jobs:
             addl-build-args: --features=apply,luau,fetch,foreach,self_update,geocode,polars,to
             default-features:
             addl-qsvlite-features:
-            addl-qsvdp-features: luau
+            addl-qsvdp-features: luau,geocode
             addl-rustflags: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+fma
           # - os: ubuntu-latest
           #   os-name: linux
@@ -31,7 +31,7 @@ jobs:
           #   use-cross: false
           #   addl-build-args:  --features=apply,luau,fetch,foreach,self_update,geocode,polars
           #   default-features:
-          #   addl-qsvdp-features: luau
+          #   addl-qsvdp-features: luau,geocode
           # - os: ubuntu-latest
           #   os-name: linux
           #   target: x86_64-unknown-linux-musl
@@ -57,7 +57,7 @@ jobs:
           #   use-cross: false
           #   addl-build-args: --features=apply,luau,fetch,self_update,to,polars
           #   default-features:
-          #   addl-qsvdp-features: luau
+          #   addl-qsvdp-features: luau,geocode
           # - os: windows-latest
           #   os-name: windows
           #   target: i686-pc-windows-msvc
@@ -73,7 +73,7 @@ jobs:
           #   use-cross: false
           #   addl-build-args: --features=apply,luau,fetch,self_update,polars
           #   default-features: --no-default-features
-          #   addl-qsvdp-features: luau
+          #   addl-qsvdp-features: luau,geocode
           # - os: macos-latest
           #   os-name: macos
           #   target: x86_64-apple-darwin
@@ -81,7 +81,7 @@ jobs:
           #   use-cross: false
           #   addl-build-args: --features=apply,luau,fetch,foreach,self_update,to,polars
           #   default-features: --no-default-features
-          #   addl-qsvdp-features: luau
+          #   addl-qsvdp-features: luau,geocode
           # - os: macos-latest
           #   os-name: macos
           #   target: aarch64-apple-darwin

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,7 @@ futures-util = "0.3"
 gender_guesser = { version = "0.2", optional = true }
 geosuggest-core = { version = "0.6", optional = true }
 geosuggest-utils = { version = "0.6", optional = true }
+geozero = { version = "0.14.0", features = ["with-csv", "with-shp"], optional = true }
 governor = { version = "0.10", optional = true }
 grex = { version = "1.4", default-features = false }
 gzp = { version = "1", default-features = false, features = [
@@ -276,7 +277,6 @@ url = "2.5"
 whatlang = { version = "0.16", optional = true }
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 zip = "=2.5.0"
-geozero = { version = "0.14.0", features = ["with-csv", "with-shp"] }
 
 # enable parking_lot hardware lock elision on x86_64
 [target.'cfg(target_arch = "x86_64")'.dependencies]
@@ -400,6 +400,7 @@ geocode = [
     "cached",
     "geosuggest-core",
     "geosuggest-utils",
+    "geozero",
     "sled",
 ]
 luau = ["mlua", "sanitize-filename"]

--- a/src/cmd/geocode.rs
+++ b/src/cmd/geocode.rs
@@ -732,7 +732,11 @@ async fn geocode_main(args: Args) -> CliResult<()> {
         .delimiter(args.flag_delimiter)
         .select(SelectColumns::parse(&args.arg_column)?);
 
+    #[cfg(feature = "datapusher_plus")]
+    let show_progress = false;
+
     // prep progress bar
+    #[cfg(any(feature = "feature_capable", feature = "lite"))]
     let show_progress =
         (args.flag_progressbar || util::get_envvar_flag("QSV_PROGRESSBAR")) && !rconfig.is_stdin();
 

--- a/src/cmd/geoconvert.rs
+++ b/src/cmd/geoconvert.rs
@@ -1,75 +1,135 @@
 static USAGE: &str = r#"
-Convert between various spatial formats and CSV including GeoJSON, SHP, and more.
+Convert between various spatial formats and CSV/SVG including GeoJSON, SHP, and more.
 
 For example to convert a GeoJSON file into CSV data:
 
 qsv geoconvert file.geojson geojson csv
 
 Usage:
-    qsv geoconvert [options] [<input>] <input-format> <output-format>
+    qsv geoconvert [options] (<input>) (<input-format>) (<output-format>)
     qsv geoconvert --help
+
+geoconvert REQUIRED arguments:
+    <input>           The spatial file to convert. Does not support stdin.
+    <input-format>    Valid values are "geojson" and "shp"
+    <output-format>   Valid values are:
+                      - For GeoJSON input: "csv" and "svg"
+                      - For SHP input: "csv" and "geojson"
 
 Common options:
     -h, --help             Display this message
+    -o, --output <file>    Write output to <file> instead of stdout.
 "#;
+
+use std::{
+    fs::File,
+    io::{self, BufWriter, Write},
+    path::Path,
+};
 
 use geozero::{ProcessToCsv, ProcessToSvg, csv::CsvWriter, geojson::GeoJsonWriter};
 use serde::Deserialize;
 
-use crate::{CliResult, util};
+use crate::{CliError, CliResult, util};
+
+/// Supported input formats for spatial data conversion
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+enum InputFormat {
+    Geojson,
+    Shp,
+}
+
+/// Supported output formats for spatial data conversion
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+enum OutputFormat {
+    Csv,
+    Svg,
+    Geojson,
+}
 
 #[derive(Deserialize)]
 struct Args {
     arg_input:         Option<String>,
-    arg_input_format:  String,
-    arg_output_format: String,
-    // flag_output:   Option<String>,
+    arg_input_format:  InputFormat,
+    arg_output_format: OutputFormat,
+    flag_output:       Option<String>,
+}
+
+impl From<geozero::error::GeozeroError> for CliError {
+    fn from(err: geozero::error::GeozeroError) -> CliError {
+        CliError::Other(format!("Geozero error: {err:?}"))
+    }
+}
+
+impl From<geozero::shp::Error> for CliError {
+    fn from(err: geozero::shp::Error) -> CliError {
+        CliError::Other(format!("Geozero SHP error: {err:?}"))
+    }
+}
+
+/// Validates that the input file exists and is readable
+fn validate_input_file(path: &str) -> CliResult<()> {
+    if !Path::new(path).exists() {
+        return fail_clierror!("Input file '{}' does not exist", path);
+    }
+    Ok(())
 }
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
 
-    // TODO: Implement handling stdin
-    let input = args.arg_input;
-    let input_format = args.arg_input_format;
-    let output_format = args.arg_output_format;
+    let input_path = args
+        .arg_input
+        .ok_or_else(|| CliError::Other("No input file specified".to_string()))?;
 
-    // Construct a spatial geometry based on the input format
-    let output_string = match input_format.as_str() {
-        "geojson" => {
-            let input_string = match input {
-                Some(path) => std::fs::read_to_string(path).unwrap(),
-                _ => return fail_clierror!("Could not identify file path."),
-            };
-            let mut geometry = geozero::geojson::GeoJson(&input_string);
-            match output_format.as_str() {
-                "csv" => geometry.to_csv().unwrap(),
-                "svg" => geometry.to_svg().unwrap(),
-                _ => return fail_clierror!("Could not identify valid output format."),
-            }
-        },
-        "shp" => {
-            let reader = geozero::shp::ShpReader::from_path(input.unwrap()).unwrap();
-            match output_format.as_str() {
-                "geojson" => {
-                    let mut json: Vec<u8> = Vec::new();
-                    reader
-                        .iter_features(&mut GeoJsonWriter::new(&mut json))
-                        .unwrap();
-                    String::from_utf8(json).unwrap()
-                },
-                "csv" => {
-                    let mut csv: Vec<u8> = Vec::new();
-                    reader.iter_features(&mut CsvWriter::new(&mut csv)).unwrap();
-                    String::from_utf8(csv).unwrap()
-                },
-                _ => return fail_clierror!("Could not identify valid output format."),
-            }
-        },
-        _ => return fail_clierror!("Could not identify valid input format."),
+    validate_input_file(&input_path)?;
+
+    // Create buffered writer for output
+    let stdout = io::stdout();
+    let mut wtr: Box<dyn Write> = if let Some(output_path) = args.flag_output {
+        Box::new(BufWriter::new(File::create(output_path)?))
+    } else {
+        Box::new(BufWriter::new(stdout.lock()))
     };
 
-    print!("{output_string}");
+    // Construct a spatial geometry based on the input format
+    let output_string = match args.arg_input_format {
+        InputFormat::Geojson => {
+            let input_string = std::fs::read_to_string(&input_path)?;
+            let mut geometry = geozero::geojson::GeoJson(&input_string);
+            match args.arg_output_format {
+                OutputFormat::Csv => geometry.to_csv()?,
+                OutputFormat::Svg => geometry.to_svg()?,
+                OutputFormat::Geojson => {
+                    return fail_clierror!("Converting GeoJSON to GeoJSON is not supported");
+                },
+            }
+        },
+        InputFormat::Shp => {
+            let reader = geozero::shp::ShpReader::from_path(&input_path)
+                .map_err(|e| CliError::Other(format!("Failed to read SHP file: {e}")))?;
+            match args.arg_output_format {
+                OutputFormat::Geojson => {
+                    let mut json: Vec<u8> = Vec::new();
+                    reader.iter_features(&mut GeoJsonWriter::new(&mut json))?;
+                    String::from_utf8(json)
+                        .map_err(|e| CliError::Other(format!("Invalid UTF-8 in output: {e}")))?
+                },
+                OutputFormat::Csv => {
+                    let mut csv: Vec<u8> = Vec::new();
+                    reader.iter_features(&mut CsvWriter::new(&mut csv))?;
+                    String::from_utf8(csv)
+                        .map_err(|e| CliError::Other(format!("Invalid UTF-8 in output: {e}")))?
+                },
+                OutputFormat::Svg => {
+                    return fail_clierror!("Converting SHP to SVG is not supported");
+                },
+            }
+        },
+    };
 
-    Ok(())
+    wtr.write_all(output_string.as_bytes())?;
+    Ok(wtr.flush()?)
 }

--- a/src/cmd/geoconvert.rs
+++ b/src/cmd/geoconvert.rs
@@ -13,12 +13,10 @@ Common options:
     -h, --help             Display this message
 "#;
 
-use std::path::PathBuf;
-
 use geozero::{ProcessToCsv, ProcessToSvg, csv::CsvWriter, geojson::GeoJsonWriter};
 use serde::Deserialize;
 
-use crate::{CliResult, config::Config, util};
+use crate::{CliResult, util};
 
 #[derive(Deserialize)]
 struct Args {

--- a/src/cmd/geoconvert.rs
+++ b/src/cmd/geoconvert.rs
@@ -39,7 +39,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     // Construct a spatial geometry based on the input format
     let output_string = match input_format.as_str() {
         "geojson" => {
-            let input_string = match input.clone() {
+            let input_string = match input {
                 Some(path) => std::fs::read_to_string(path).unwrap(),
                 _ => return fail_clierror!("Could not identify file path."),
             };

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -39,9 +39,9 @@ pub mod fmt;
 #[cfg(all(feature = "foreach", not(feature = "lite")))]
 pub mod foreach;
 pub mod frequency;
-#[cfg(all(feature = "geocode", feature = "feature_capable"))]
+#[cfg(feature = "geocode")]
 pub mod geocode;
-#[cfg(feature = "feature_capable")]
+#[cfg(feature = "geocode")]
 pub mod geoconvert;
 pub mod headers;
 pub mod index;

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,12 +137,13 @@ fn main() -> QsvExitCode {
     enabled_commands.push_str("    frequency   Show frequency tables\n");
 
     #[cfg(all(feature = "geocode", not(feature = "lite")))]
-    enabled_commands
-        .push_str("    geocode     Geocodes a location against the Geonames cities database.\n");
+    enabled_commands.push_str(
+        "    geocode     Geocodes a location against the Geonames cities database.
+    geoconvert  Convert between spatial formats & CSV, including GeoJSON, SHP & more\n",
+    );
 
     enabled_commands.push_str(
-        "    geoconvert  Convert between spatial formats and CSV, including GeoJSON, SHP, and more
-    headers     Show header names
+        "    headers     Show header names
     help        Show this usage message
     index       Create CSV index for faster access
     input       Read CSVs w/ special quoting, skipping, trimming & transcoding rules
@@ -369,6 +370,7 @@ enum Command {
     Frequency,
     #[cfg(all(feature = "geocode", feature = "feature_capable"))]
     Geocode,
+    #[cfg(all(feature = "geocode", feature = "feature_capable"))]
     Geoconvert,
     Headers,
     Help,
@@ -466,6 +468,7 @@ impl Command {
             Command::Frequency => cmd::frequency::run(argv),
             #[cfg(all(feature = "geocode", feature = "feature_capable"))]
             Command::Geocode => cmd::geocode::run(argv),
+            #[cfg(all(feature = "geocode", feature = "feature_capable"))]
             Command::Geoconvert => cmd::geoconvert::run(argv),
             Command::Headers => cmd::headers::run(argv),
             Command::Help => {

--- a/src/maindp.rs
+++ b/src/maindp.rs
@@ -62,13 +62,15 @@ static COMMAND_LIST: &str = r#"
     exclude     Excludes the records in one CSV from another
     extdedup    Remove duplicates rows from an arbitrarily large text file
     frequency   Show frequency tables
+    geocode     Geocodes a location against the Geonames cities database 🌐
+    geoconvert  Convert between spatial formats & CSV, including GeoJSON, SHP & more 🌐
     headers     Show header names
     help        Show this usage message
     index       Create CSV index for faster access
     input       Read CSVs w/ special quoting, skipping, trimming & transcoding rules
-    joinp       Join CSV files using the Pola.rs engine
+    joinp       Join CSV files using the Pola.rs engine 🐻‍❄️
     luau        Execute Luau script on CSV data
-    pivotp      Pivot CSV data
+    pivotp      Pivot CSV data 🐻‍❄️
     pseudo      Pseudonymise the values of a column
     rename      Rename the columns of CSV data efficiently
     replace     Replace patterns in CSV data
@@ -83,12 +85,14 @@ static COMMAND_LIST: &str = r#"
     sniff       Quickly sniff CSV metadata
     sort        Sort CSV data in alphabetical, numerical, reverse or random order
     sortcheck   Check if a CSV is sorted
-    sqlp        Run a SQL query against several CSVs using the Pola.rs engine
+    sqlp        Run a SQL query against several CSVs using the Pola.rs engine 🐻‍❄️
     stats       Infer data types and compute summary statistics
     template    Render templates using CSV data
     validate    Validate CSV data for RFC4180-compliance or with JSON Schema
 
-    NOTE: qsvdp ignores the --progressbar option for all commands."#;
+    NOTE: qsvdp ignores the --progressbar option for all commands.
+          🐻‍❄️ - available with polars feature
+          🌐 - available with the geocode feature"#;
 
 mod clitypes;
 mod cmd;
@@ -252,6 +256,10 @@ enum Command {
     Exclude,
     ExtDedup,
     Frequency,
+    #[cfg(feature = "geocode")]
+    Geocode,
+    #[cfg(feature = "geocode")]
+    Geoconvert,
     Headers,
     Help,
     Index,
@@ -308,6 +316,10 @@ impl Command {
             Command::Exclude => cmd::exclude::run(argv),
             Command::ExtDedup => cmd::extdedup::run(argv),
             Command::Frequency => cmd::frequency::run(argv),
+            #[cfg(feature = "geocode")]
+            Command::Geocode => cmd::geocode::run(argv),
+            #[cfg(feature = "geocode")]
+            Command::Geoconvert => cmd::geoconvert::run(argv),
             Command::Headers => cmd::headers::run(argv),
             Command::Help => {
                 wout!("{USAGE}\n\n{SPONSOR_MESSAGE}");

--- a/src/util.rs
+++ b/src/util.rs
@@ -20,7 +20,6 @@ use csv::ByteRecord;
 use docopt::Docopt;
 use filetime::FileTime;
 use human_panic::setup_panic;
-#[cfg(any(feature = "feature_capable", feature = "lite"))]
 use indicatif::{HumanCount, ProgressBar, ProgressDrawTarget, ProgressStyle};
 use log::{info, log_enabled};
 #[cfg(feature = "polars")]
@@ -583,7 +582,6 @@ pub fn count_lines_in_file(file: &str) -> Result<u64, CliError> {
     Ok(line_count)
 }
 
-#[cfg(any(feature = "feature_capable", feature = "lite"))]
 pub fn prep_progress(progress: &ProgressBar, record_count: u64) {
     progress.set_style(
         ProgressStyle::default_bar()
@@ -598,7 +596,6 @@ pub fn prep_progress(progress: &ProgressBar, record_count: u64) {
     log::info!("Progress started... {record_count} records");
 }
 
-#[cfg(any(feature = "feature_capable", feature = "lite"))]
 pub fn finish_progress(progress: &ProgressBar) {
     progress.set_style(
         ProgressStyle::default_bar()

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -77,7 +77,7 @@ mod test_fmt;
 #[cfg(all(feature = "foreach"))]
 mod test_foreach;
 mod test_frequency;
-#[cfg(all(feature = "feature_capable", feature = "geocode"))]
+#[cfg(feature = "geocode")]
 mod test_geocode;
 mod test_headers;
 mod test_index;


### PR DESCRIPTION
- took advantage of docopt to make args required
- validated existence of input file
- expanded usage text
- use enums instead of strings for input and output formats
- removed unwraps and added error-handling
- enabled --output option
- use buffered writer instead of print!
- gated geoconvert behind geocode feature
- make geocode/geoconvert available in qsvdp binary variant

cc @rzmk 
