### PR TITLE
`feat`: Better Polars Schema support

### DIFF
--- a/src/cmd/diff.rs
+++ b/src/cmd/diff.rs
@@ -321,6 +321,7 @@ fn check_stats_cache(args: &Args) -> Result<bool, CliError> {
         flag_no_headers:      false,
         flag_delimiter:       args.flag_delimiter,
         flag_jobs:            None,
+        flag_polars:          false,
         flag_memcheck:        false,
         flag_force:           args.flag_force,
         flag_prefer_dmy:      false,

--- a/src/cmd/frequency.rs
+++ b/src/cmd/frequency.rs
@@ -516,6 +516,7 @@ impl Args {
             flag_force:           false,
             flag_stdout:          false,
             flag_jobs:            Some(util::njobs(self.flag_jobs)),
+            flag_polars:          false,
             flag_no_headers:      self.flag_no_headers,
             flag_delimiter:       self.flag_delimiter,
             arg_input:            self.arg_input.clone(),

--- a/src/cmd/sample.rs
+++ b/src/cmd/sample.rs
@@ -342,6 +342,7 @@ fn check_stats_cache(
         flag_no_headers:      args.flag_no_headers,
         flag_delimiter:       args.flag_delimiter,
         flag_jobs:            None,
+        flag_polars:          false,
         flag_memcheck:        false,
         flag_force:           args.flag_force,
         flag_prefer_dmy:      false,

--- a/src/cmd/schema.rs
+++ b/src/cmd/schema.rs
@@ -1,6 +1,8 @@
 static USAGE: &str = r#"
-Generate JSON Schema from CSV data.
+Generate JSON Schema or Polars Schema (with the `--polars` option) from CSV data.
 
+JSON Schema Validation:
+=======================
 This command derives a JSON Schema Validation (Draft 7) file from CSV data, 
 including validation rules based on data type and input data domain/range.
 https://json-schema.org/draft/2020-12/json-schema-validation.html
@@ -26,6 +28,19 @@ To speed up generation, the `schema` command will reuse a `stats.csv.data.jsonl`
 exists and is current (i.e. stats generated with --cardinality and --infer-dates options).
 Otherwise, it will run the `stats` command to generate the `stats.csv.data.jsonl` file first,
 and then use that to generate the schema file.
+
+Polars Schema:
+==============
+The `--polars` option will generate a Polars schema instead of a JSON Schema.
+The generated Polars schema will be written to a file with the `.pschema.json` suffix appended
+to the input file stem.
+
+The Polars schema is a JSON object that describes the schema of a CSV file. When present,
+the `sqlp`, `joinp`, and `pivotp` commands will use the Polars schema to read the CSV file
+instead of inferring the schema from the CSV data. Not only does this allow these commands to
+skip schema inferencing which may fail when the inferencing sample is too low, it also allows 
+Polars to optimize the query and gives the user the option to tailor the schema to their specific
+query needs (e.g. using a Decimal type instead of a Float type).
 
 For examples, see https://github.com/dathere/qsv/blob/master/tests/test_schema.rs.
 
@@ -66,6 +81,11 @@ Schema options:
                                When not set, the number of jobs is set to the
                                number of CPUs detected.
 
+    --polars                   Infer a Polars schema instead of a JSON Schema.
+                               This option is only available if the `polars` feature is enabled.
+                               The generated Polars schema will be written to a file with the
+                               `.pschema.json` suffix appended to the input file stem.
+
 Common options:
     -h, --help                 Display this message
     -n, --no-headers           When set, the first row will not be interpreted
@@ -89,12 +109,38 @@ use rayon::slice::ParallelSliceMut;
 use serde_json::{Map, Value, json, value::Number};
 use stats::Frequencies;
 
-use crate::{CliResult, cmd::stats::StatsData, config::Config, util, util::StatsMode};
+use crate::{
+    CliResult,
+    cmd::{sqlp::infer_polars_schema, stats::StatsData},
+    config::Config,
+    util,
+    util::StatsMode,
+};
 
 const STDIN_CSV: &str = "stdin.csv";
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let mut args: util::SchemaArgs = util::get_args(USAGE, argv)?;
+
+    if args.flag_polars {
+        if let Some(input) = args.arg_input {
+            let input_path = Path::new(&input);
+            let schema_file = input_path.with_extension("pschema.json");
+            if infer_polars_schema(
+                args.flag_delimiter,
+                log::log_enabled!(log::Level::Debug),
+                input_path,
+                &schema_file,
+            )? {
+                return Ok(());
+            }
+            return fail_clierror!(
+                "Failed to infer Polars schema from {}",
+                input_path.display()
+            );
+        }
+        return fail_clierror!("Input file is required when using the --polars option.");
+    }
 
     // if using stdin, we create a stdin.csv file as stdin is not seekable and we need to
     // open the file multiple times to compile stats/unique values, etc.

--- a/src/cmd/schema.rs
+++ b/src/cmd/schema.rs
@@ -31,9 +31,9 @@ and then use that to generate the schema file.
 
 Polars Schema:
 ==============
-The `--polars` option will generate a Polars schema instead of a JSON Schema.
-The generated Polars schema will be written to a file with the `.pschema.json` suffix appended
-to the input file stem.
+When the "polars" feature is enabled, the `--polars` option will generate a Polars schema
+instead of a JSON Schema. The generated Polars schema will be written to a file with the
+`.pschema.json` suffix appended to the input file stem.
 
 The Polars schema is a JSON object that describes the schema of a CSV file. When present,
 the `sqlp`, `joinp`, and `pivotp` commands will use the Polars schema to read the CSV file
@@ -109,19 +109,16 @@ use rayon::slice::ParallelSliceMut;
 use serde_json::{Map, Value, json, value::Number};
 use stats::Frequencies;
 
-use crate::{
-    CliResult,
-    cmd::{sqlp::infer_polars_schema, stats::StatsData},
-    config::Config,
-    util,
-    util::StatsMode,
-};
+#[cfg(feature = "polars")]
+use crate::cmd::sqlp::infer_polars_schema;
+use crate::{CliResult, cmd::stats::StatsData, config::Config, util, util::StatsMode};
 
 const STDIN_CSV: &str = "stdin.csv";
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let mut args: util::SchemaArgs = util::get_args(USAGE, argv)?;
 
+    #[cfg(feature = "polars")]
     if args.flag_polars {
         if let Some(input) = args.arg_input {
             let input_path = Path::new(&input);

--- a/src/cmd/tojsonl.rs
+++ b/src/cmd/tojsonl.rs
@@ -147,6 +147,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         flag_force:           false,
         flag_stdout:          false,
         flag_jobs:            Some(util::njobs(args.flag_jobs)),
+        flag_polars:          false,
         flag_no_headers:      false,
         flag_delimiter:       args.flag_delimiter,
         arg_input:            Some(input_filename.clone()),

--- a/src/util.rs
+++ b/src/util.rs
@@ -91,6 +91,7 @@ pub struct SchemaArgs {
     pub flag_force:           bool,
     pub flag_stdout:          bool,
     pub flag_jobs:            Option<usize>,
+    pub flag_polars:          bool,
     pub flag_no_headers:      bool,
     pub flag_delimiter:       Option<Delimiter>,
     pub arg_input:            Option<String>,


### PR DESCRIPTION
- `schema`: add polars schema generation - resolves #2700 
- `sqlp`: major refactoring for better polars schema support
  - use pschema.json file when valid and available
  - more robust input processing that auto-retries
    - use pschema if available
    - if not available, use --infer-len to infer schema
    - if loading input fails, try to infer schema and load file with inferred schema
    - if it still fails, scan the whole file to infer the schema and try again
    - only fail, if all the above fails
  - removed fast path optimization where we automatically use the read_csv table function when there is only one input, as its prone to failure with real-world data as the read_csv table function only has a default infer-schema length of 100 rows
- `joinp`:  will now use an existing valid polars schema so long as
  - --cache-schema is not -1 or -2 and
  - --infer-len is not set to a non-default value (10000) 
- `pivotp` will now use an existing valid polars schema unless --infer-len is set to a non-default value (10000)