### PR TITLE
feat: --latitude and --longitude for geoconvert

### DIFF
--- a/src/cmd/geoconvert.rs
+++ b/src/cmd/geoconvert.rs
@@ -13,6 +13,10 @@ To convert a CSV file into GeoJSON data, specify the WKT geometry column with th
 
 qsv geoconvert file.csv csv geojson --geometry geometry
 
+Alternatively specify the latitude and longitude columns with the --latitude and --longitude flags:
+
+qsv geoconvert file.csv csv geojson --latitude lat --longitude lon
+
 Usage:
     qsv geoconvert [options] (<input>) (<input-format>) (<output-format>)
     qsv geoconvert --help
@@ -24,11 +28,14 @@ geoconvert REQUIRED arguments:
     <output-format>   Valid values are:
                       - For GeoJSON input: "csv", "svg", and "geojsonl"
                       - For SHP input: "csv", "geojson", and "geojsonl"
-                      - For CSV input: "geojson", "geojsonl", and "svg"
+                      - For CSV input: "geojson", "geojsonl", "csv", and "svg"
 
 geoconvert options:
-                                 REQUIRED FOR CSV INPUT:
+                                 REQUIRED FOR CSV INPUT
     -g, --geometry <geometry>    The name of the column that has WKT geometry.
+                                 Alternative to --latitude and --longitude.
+    -y, --latitude <col>         The name of the column with northing values.
+    -x, --longitude <col>        The name of the column with easting values.
 
 Common options:
     -h, --help                   Display this message
@@ -73,11 +80,13 @@ enum OutputFormat {
 
 #[derive(Deserialize)]
 struct Args {
-    arg_input:         Option<String>,
-    arg_input_format:  InputFormat,
+    arg_input: Option<String>,
+    arg_input_format: InputFormat,
     arg_output_format: OutputFormat,
-    flag_geometry:     Option<String>,
-    flag_output:       Option<String>,
+    flag_latitude: Option<String>,
+    flag_longitude: Option<String>,
+    flag_geometry: Option<String>,
+    flag_output: Option<String>,
 }
 
 impl From<geozero::error::GeozeroError> for CliError {
@@ -211,6 +220,9 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             wtr.write_all(output_string.as_bytes())?;
         },
         InputFormat::Csv => {
+            if args.flag_geometry.is_some() && (args.flag_latitude.is_some() || args.flag_longitude.is_some()) {
+                return fail_clierror!("Cannot use --geometry flag with --latitude or --longitude.");
+            }
             if let Some(geometry_col) = args.flag_geometry {
                 let mut csv = geozero::csv::CsvReader::new(&geometry_col, buf_reader);
                 match args.arg_output_format {
@@ -231,8 +243,68 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                     },
                 }
             } else {
+                if let Some(y_col) = args.flag_latitude {
+                    if let Some(x_col) = args.flag_longitude {
+                        let mut rdr = csv::Reader::from_reader(buf_reader);
+                        let headers = rdr.headers()?.clone();
+                        let mut feature_collection = serde_json::json!({"type": "FeatureCollection", "features": []});
+                        
+                        for result in rdr.records() {
+                            let record = result?;
+                            let mut feature = serde_json::json!({"type": "Feature", "geometry": {}, "properties": {}});
+
+                            // Add lat/lon coordinates geometry
+                            let latitude_col_index = headers.iter().position(|y| y == y_col).unwrap();
+                            let longitude_col_index = headers.iter().position(|x| x == x_col).unwrap();
+                            let latitude_value = record.get(latitude_col_index).unwrap().parse::<f64>().unwrap();
+                            let longitude_value = record.get(longitude_col_index).unwrap().parse::<f64>().unwrap();
+                            let geometry = feature.get_mut("geometry").unwrap();
+                            let geometry_obj = geometry.as_object_mut().unwrap();
+                            geometry_obj.insert("type".to_string(), serde_json::Value::from("Point"));
+                            geometry_obj.insert("coordinates".to_string(), serde_json::Value::from(vec![latitude_value, longitude_value]));
+                            
+                            // Add properties
+                            for (index, value) in record.iter().enumerate() {
+                                if index != longitude_col_index && index != latitude_col_index {
+                                    let properties = feature.get_mut("properties").unwrap();
+                                    let properties_obj = properties.as_object_mut().unwrap();
+                                    let new_key = headers.get(index).unwrap().to_string();
+                                    let new_value = serde_json::Value::from(value);
+                                    properties_obj.insert(new_key, new_value);
+                                }
+                            }
+
+                            // Add Feature to FeatureCollection
+                            let features = feature_collection.get_mut("features").unwrap();
+                            let features_array = features.as_array_mut().unwrap();
+                            features_array.push(feature);
+                        }
+
+                        // Write FeatureCollection
+                        let fc_string = feature_collection.to_string();
+                        let mut geometry = geozero::geojson::GeoJson(&fc_string);
+                        match args.arg_output_format {
+                            OutputFormat::Csv => {
+                                let mut processor = CsvWriter::new(&mut wtr);
+                                geometry.process(&mut processor)?;
+                            },
+                            OutputFormat::Svg => {
+                                let mut processor = SvgWriter::new(&mut wtr, false);
+                                geometry.process(&mut processor)?;
+                            },
+                            OutputFormat::Geojsonl => {
+                                let mut processor = GeoJsonLineWriter::new(&mut wtr);
+                                geometry.process(&mut processor)?;
+                            },
+                            OutputFormat::Geojson => {
+                                wtr.write_all(fc_string.as_bytes())?;
+                            },
+                        }
+                        return Ok(wtr.flush()?);
+                    }
+                }
                 return fail_clierror!(
-                    "Please specify a geometry column with the --geometry option"
+                    "Please specify a geometry column with the --geometry option or longitude/latitude with the --latitude and --longitude options."
                 );
             }
         },


### PR DESCRIPTION
![qsv-geoconvert-lat-lon-demo](https://github.com/user-attachments/assets/286d19ae-2c40-4b6a-8bb8-011dae96cd39)

Adds `--latitude` and `--longitude` options for CSV input of `qsv geoconvert` to specify column names that have latitude (northing) and longitude (easting) values. These options combined are an alternative to `--geometry` if a user does not have a column with WKT geometries and instead uses the lat/lon columns to generate a `FeatureCollection` of `Feature`s where each `Feature` has a `Point` in its `geometry` with the corresponding `coordinates` along with `properties` for each `Feature` where the `properties` are a map of the header name for a non-lat/lon column and its value in that row.

If a user uses `--latitude` and `--longitude` and attempts to output in `CSV` format then they get a `geometry` column since the current implementation constructs GeoJSON which is then converted into the specified output format.

The current implementation has some `unwrap`s which could occur (e.g. empty value) and room for refactoring too. Also could add `--altitude` at some point for Z values.

Related to https://github.com/dathere/qsv/issues/2689.