### PR TITLE
docs: add conda install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,9 @@ scoop install qsv
 
 # Void Linux (https://voidlinux.org/packages/?arch=x86_64&q=qsv)
 sudo xbps-install qsv
+
+# Conda-forge
+conda install conda-forge::qsv
 ```
 
 Note that qsv provided by these package managers/distros enable different features (Homebrew, for instance, only enables the `apply` and `luau` features. However, it does automatically install shell completion for `bash`, `fish` and `zsh` shells).


### PR DESCRIPTION
Adds `conda install conda-forge::qsv` command to installation by package manager section.

```console
qsv 4.0.0-mimalloc-apply;fetch;foreach;geocode;Luau 0.663;prompt;python-3.12.2 | packaged by conda-forge | (main, Feb 16 2024, 21:10:00) [GCC 12.3.0];to;polars-0.46.0:py-1.27.1;self_update-2-2;10.14 GiB-0 B-11.76 GiB-12.67 GiB (x86_64-unknown-linux-gnu compiled with Rust 1.86) compiled
```