### PR TITLE
docs: fix typo in apply operations replace example

### DIFF
--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -123,7 +123,7 @@ Trim parentheses & brackets from the description field.
 
 Replace ' and ' with ' & ' in the description field.
 
-  $ qsv apply replace description --comparand ' and ' --replacement ' & ' file.csv
+  $ qsv apply operations replace description --comparand ' and ' --replacement ' & ' file.csv
 
 Extract the numeric value of the Salary column in a new column named Salary_num.
 


### PR DESCRIPTION
The provided example did not work. It was missing the "operations" subcommand.