### PR TITLE
feat: `edit` add `--in-place` (and test) which uses tempfile

### DIFF
--- a/src/cmd/edit.rs
+++ b/src/cmd/edit.rs
@@ -19,6 +19,7 @@ flashlight,gray
 
 You may also choose to specify the column name by its index (in this case 1).
 Specifying a column as a number is prioritized by index rather than name.
+If there is no newline (\n) at the end of the input data, it may be added to the output.
 
 Usage:
     qsv edit [options] <input> <column> <row> <value>
@@ -32,13 +33,18 @@ edit arguments:
     row                    The cell's row index. Indices start from the first non-header row as 0.
     value                  The new value to replace the old cell content with.
 
+edit options:
+    -i, --in-place         Overwrite the input file data with the output.
+
 Common options:
     -h, --help             Display this message
     -o, --output <file>    Write output to <file> instead of stdout.
     -n, --no-headers       Start row indices from the header row as 0 (allows editing the header row).
 "#;
 
+use csv::Writer;
 use serde::Deserialize;
+use tempfile::NamedTempFile;
 
 use crate::{CliResult, config::Config, util};
 
@@ -49,6 +55,7 @@ struct Args {
     arg_column:      String,
     arg_row:         usize,
     arg_value:       String,
+    flag_in_place:   bool,
     flag_output:     Option<String>,
     flag_no_headers: bool,
 }
@@ -59,13 +66,19 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let input = args.arg_input;
     let column = args.arg_column;
     let row = args.arg_row;
+    let in_place = args.flag_in_place;
     let value = args.arg_value;
     let no_headers = args.flag_no_headers;
+    let mut tempfile = NamedTempFile::new()?;
 
     // Build the CSV reader and iterate over each record.
     let conf = Config::new(input.as_ref()).no_headers(true);
     let mut rdr = conf.reader()?;
-    let mut wtr = Config::new(args.flag_output.as_ref()).writer()?;
+    let mut wtr: Writer<Box<dyn std::io::Write>> = if in_place {
+        csv::Writer::from_writer(Box::new(tempfile.as_file_mut()))
+    } else {
+        Config::new(args.flag_output.as_ref()).writer()?
+    };
 
     let headers = rdr.headers()?;
     let mut column_index: Option<usize> = None;
@@ -104,5 +117,14 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         current_row += 1;
     }
 
-    Ok(wtr.flush()?)
+    wtr.flush()?;
+    drop(wtr);
+
+    if in_place {
+        if let Some(input_path) = input {
+            std::fs::copy(tempfile, std::path::Path::new(&input_path))?;
+        }
+    }
+
+    Ok(())
 }

--- a/src/cmd/edit.rs
+++ b/src/cmd/edit.rs
@@ -35,6 +35,7 @@ edit arguments:
 
 edit options:
     -i, --in-place         Overwrite the input file data with the output.
+                           The input file is renamed to a .bak file in the same directory.
 
 Common options:
     -h, --help             Display this message
@@ -121,8 +122,14 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     drop(wtr);
 
     if in_place {
-        if let Some(input_path) = input {
-            std::fs::copy(tempfile, std::path::Path::new(&input_path))?;
+        if let Some(input_path_string) = input {
+            let input_path = std::path::Path::new(&input_path_string);
+            if let Some(input_extension_osstr) = input_path.extension() {
+                let mut backup_extension = input_extension_osstr.to_string_lossy().to_string();
+                backup_extension.push_str(".bak");
+                std::fs::rename(input_path, input_path.with_extension(backup_extension))?;
+                std::fs::copy(tempfile, input_path)?;
+            }
         }
     }
 

--- a/tests/test_edit.rs
+++ b/tests/test_edit.rs
@@ -133,11 +133,19 @@ fn edit_in_place() {
     cmd.output().unwrap();
 
     let test_file = wrk.path("data.csv");
+    let backup_file = wrk.path("data.csv.bak");
     let got = std::fs::read_to_string(test_file).unwrap();
+    let got_backup = std::fs::read_to_string(backup_file).unwrap();
     let expected = "letter,number
 a,3
 b,2
 "
     .to_string();
+    let expected_backup = "letter,number
+a,1
+b,2
+"
+    .to_string();
     similar_asserts::assert_eq!(got, expected);
+    similar_asserts::assert_eq!(got_backup, expected_backup);
 }

--- a/tests/test_edit.rs
+++ b/tests/test_edit.rs
@@ -114,3 +114,30 @@ b,2"
     .to_string();
     similar_asserts::assert_eq!(got, expected);
 }
+
+#[test]
+fn edit_in_place() {
+    let wrk = Workdir::new("edit_in_place");
+    wrk.create(
+        "data.csv",
+        vec![svec!["letter", "number"], svec!["a", "1"], svec!["b", "2"]],
+    );
+
+    let mut cmd = wrk.command("edit");
+    cmd.arg("data.csv");
+    cmd.arg("number");
+    cmd.arg("0");
+    cmd.arg("3");
+    cmd.arg("--in-place");
+
+    cmd.output().unwrap();
+
+    let test_file = wrk.path("data.csv");
+    let got = std::fs::read_to_string(test_file).unwrap();
+    let expected = "letter,number
+a,3
+b,2
+"
+    .to_string();
+    similar_asserts::assert_eq!(got, expected);
+}


### PR DESCRIPTION
Adds `--in-place` (and a test) to `qsv edit` which generates the output as a file at the input location after renaming the input file with an appended `.bak` extension (as per #2109).

![edit-in-place-demo](https://github.com/user-attachments/assets/984bc039-a7c3-4aef-ba87-91287c17a90c)
