### PR TITLE
chore: temporarily use qsv-calamine until a new calamine is released

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1297,23 +1297,6 @@ version = "0.1.1"
 source = "git+https://github.com/jqnatividad/cached?branch=bump-redis-to-0.32-hashbrown-to-0.15#6e7eb046b4c5c846f46b7d8a2e824a390ffbbbc0"
 
 [[package]]
-name = "calamine"
-version = "0.27.0"
-source = "git+https://github.com/prophittcorey/calamine?branch=fix%2Fzip-3.0#18629d465f3166c03ab5b454dd5d72851ed99141"
-dependencies = [
- "atoi_simd",
- "byteorder",
- "chrono",
- "codepage",
- "encoding_rs",
- "fast-float2",
- "log",
- "quick-xml",
- "serde",
- "zip",
-]
-
-[[package]]
 name = "cassowary"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5879,7 +5862,6 @@ dependencies = [
  "byteorder",
  "bytes",
  "cached",
- "calamine",
  "censor",
  "chrono",
  "chrono-tz",
@@ -5946,6 +5928,7 @@ dependencies = [
  "polars-ops",
  "publicsuffix",
  "pyo3",
+ "qsv-calamine",
  "qsv-dateparser",
  "qsv-sniffer",
  "qsv-stats",
@@ -5991,6 +5974,24 @@ dependencies = [
  "uuid",
  "whatlang",
  "xxhash-rust",
+ "zip",
+]
+
+[[package]]
+name = "qsv-calamine"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65a1c3f598565334a9fae50d47b1ce7df45322fdefb6d2d6fb4500f9de736004"
+dependencies = [
+ "atoi_simd",
+ "byteorder",
+ "chrono",
+ "codepage",
+ "encoding_rs",
+ "fast-float2",
+ "log",
+ "quick-xml",
+ "serde",
  "zip",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,10 @@ cached = { version = "0.55", features = [
     "disk_store",
     "redis_ahash",
 ], optional = true }
-calamine = { version = "0.27", features = ["dates"] }
+# the yanked zip dependency in calamine 0.27.0 is preventing us from publishing
+# to crates.io. qsv-calamine is a temporary crate that will be retired once a
+# new calamine release with the required zip dependency (4.x and up) is published.
+qsv-calamine = { version = "0.27", features = ["dates"] }
 censor = { version = "0.3", optional = true }
 chrono = { version = "0.4", default-features = false }
 chrono-tz = "0.10"
@@ -320,9 +323,6 @@ csv-index = { git = "https://github.com/dathere/rust-csv", branch = "qsv-optimiz
 # use our patched fork of cached; though our PR of hashbrown to 0.15 has been merged,
 # our redis PR is still pending
 cached = { git = "https://github.com/jqnatividad/cached", branch = "bump-redis-to-0.32-hashbrown-to-0.15" }
-
-# use fork fixing zip dependency until PR is merged
-calamine = { git = "https://github.com/prophittcorey/calamine", branch = "fix/zip-3.0" }
 
 # use our patched fork of csvs_convert to bump dependencies until our PR is merged
 csvs_convert = { git = "https://github.com/jqnatividad/csvs_convert", branch = "bump-rust_xlsxwriter-to-0.88" }

--- a/src/cmd/excel.rs
+++ b/src/cmd/excel.rs
@@ -166,6 +166,7 @@ use calamine::{
 use file_format::FileFormat;
 use indicatif::HumanCount;
 use log::info;
+use qsv_calamine as calamine;
 use rayon::prelude::{IndexedParallelIterator, ParallelIterator, ParallelSlice};
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
the yanked zip dependency in calamine 0.27.0 is preventing new releases of qsv from being published to crates.io