### PR TITLE
`feat`: `schema` JSON schema description property set to cmdline used to generate the JSON schema

### DIFF
--- a/resources/test/adur-public-toilets.csv.schema-default.expected.json
+++ b/resources/test/adur-public-toilets.csv.schema-default.expected.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema",
   "title": "JSON Schema for adur-public-toilets.csv",
-  "description": "Inferred JSON Schema using `qsv schema` command",
+  "description": "Inferred JSON Schema with `qsv schema adur-public-toilets.csv`",
   "type": "object",
   "properties": {
     "ExtractDate": {

--- a/resources/test/adur-public-toilets.csv.schema-strict.expected.json
+++ b/resources/test/adur-public-toilets.csv.schema-strict.expected.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema",
   "title": "JSON Schema for adur-public-toilets.csv",
-  "description": "Inferred JSON Schema using `qsv schema` command",
+  "description": "Inferred JSON Schema with `qsv schema adur-public-toilets.csv --enum-threshold 13 --pattern-columns ReportEmail,OpeningHours --strict-dates`",
   "type": "object",
   "properties": {
     "ExtractDate": {

--- a/src/cmd/schema.rs
+++ b/src/cmd/schema.rs
@@ -221,7 +221,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let schema = json!({
         "$schema": "https://json-schema.org/draft-07/schema",
         "title": format!("JSON Schema for {input_filename}"),
-        "description": "Inferred JSON Schema using `qsv schema` command",
+        "description": format!("Inferred JSON Schema with `qsv {}`", argv[1..].join(" ")),
         "type": "object",
         "properties": Value::Object(properties_map),
         "required": Value::Array(required_fields)

--- a/tests/test_schema.rs
+++ b/tests/test_schema.rs
@@ -303,7 +303,7 @@ fn generate_schema_with_const_and_enum_constraints() {
     let expected_schema = r#"{
   "$schema": "https://json-schema.org/draft-07/schema",
   "title": "JSON Schema for enum_const_test.csv",
-  "description": "Inferred JSON Schema using `qsv schema` command",
+  "description": "Inferred JSON Schema with `qsv schema enum_const_test.csv --enum-threshold 5`",
   "type": "object",
   "properties": {
     "first": {


### PR DESCRIPTION
so users of the schema can easily regenerate the schema file if required.

This is especially helpful should the user want to revert back to the original generated schema after editing it.