### PR TITLE
feat: `validate` improved JSON Schema schema validation

### DIFF
--- a/src/cmd/validate.rs
+++ b/src/cmd/validate.rs
@@ -1046,15 +1046,18 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                         // Now, try_validate the JSON Schema
                         let validated = jsonschema::meta::try_validate(&schema_json);
                         match validated {
-                            Ok(_) => {
+                            Ok(Ok(_)) => {
                                 if !args.flag_quiet {
                                     winfo!("Valid JSON Schema.");
                                     return Ok(());
                                 }
                                 return Ok(());
                             },
-                            Err(e) => {
+                            Ok(Err(e)) => {
                                 return fail_clierror!("Invalid JSON Schema: {e}");
+                            },
+                            Err(e) => {
+                                return fail_clierror!("JSON Schema Reference Error: {e}");
                             },
                         }
                     } else {
@@ -1062,7 +1065,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                     }
                 },
                 Err(e) => {
-                    return fail_clierror!("Invalid JSON Schema: {e}");
+                    return fail_clierror!("JSON Schema Reference Error: {e}");
                 },
             }
         } else {

--- a/tests/test_validate.rs
+++ b/tests/test_validate.rs
@@ -1609,11 +1609,11 @@ fn validate_invalid_json_schema_file() {
     );
 
     // Run validate command
-    let mut cmd2 = wrk.command("validate");
-    cmd2.arg("schema").arg("schema2.json");
+    let mut cmd = wrk.command("validate");
+    cmd.arg("schema").arg("schema2.json");
 
-    wrk.assert_err(&mut cmd2);
+    wrk.assert_err(&mut cmd);
 
-    let got = wrk.output_stderr(&mut cmd2);
+    let got = wrk.output_stderr(&mut cmd);
     assert_eq!(got, "Invalid JSON Schema.\n");
 }

--- a/tests/test_validate.rs
+++ b/tests/test_validate.rs
@@ -1486,29 +1486,6 @@ fn validate_no_format_validation() {
 fn validate_json_schema_file() {
     let wrk = Workdir::new("validate_json_schema_file").flexible(true);
 
-    // Create test data with invalid format values
-    wrk.create(
-        "schema.json",
-        vec![
-            svec!["id", "name", "email", "website", "fee"],
-            svec![
-                "1",
-                "John Doe",
-                "john@example.com",
-                "https://example.com",
-                "$100.00"
-            ],
-            svec![
-                "2",
-                "Jane Smith",
-                "not-an-email",
-                "not-a-url",
-                "not-currency"
-            ],
-            svec!["3", "Bob Wilson", "bob.wilson", "ftp://invalid", "€ 50.00"],
-        ],
-    );
-
     // Create schema with format validation
     wrk.create_from_string(
         "schema.json",
@@ -1586,9 +1563,7 @@ fn validate_invalid_json_schema_file() {
     wrk.assert_err(&mut cmd);
 
     let got = wrk.output_stderr(&mut cmd);
-    assert!(got.contains(
-        "Invalid JSON Schema: Unknown specification: https://json-schema.org/draft/2020-25/schema"
-    ));
+    assert_eq!(got, "JSON Schema Reference Error: Unknown specification: https://json-schema.org/draft/2020-25/schema\n");
 
     // Create schema with format validation
     // This schema is invalid because of invalid types "stringy"

--- a/tests/test_validate.rs
+++ b/tests/test_validate.rs
@@ -1515,29 +1515,7 @@ fn validate_json_schema_file() {
 fn validate_invalid_json_schema_file() {
     let wrk = Workdir::new("validate_invalid_json_schema_file").flexible(true);
 
-    // Create test data with invalid format values
-    wrk.create(
-        "schema.json",
-        vec![
-            svec!["id", "name", "email", "website", "fee"],
-            svec![
-                "1",
-                "John Doe",
-                "john@example.com",
-                "https://example.com",
-                "$100.00"
-            ],
-            svec![
-                "2",
-                "Jane Smith",
-                "not-an-email",
-                "not-a-url",
-                "not-currency"
-            ],
-            svec!["3", "Bob Wilson", "bob.wilson", "ftp://invalid", "€ 50.00"],
-        ],
-    );
-
+    // Create schema with format validation
     // Create schema with format validation
     // This schema is invalid because it has a draft version that doesn't exist
     wrk.create_from_string(


### PR DESCRIPTION
we also now do a [`jsonschema::meta::try_validate()`](https://docs.rs/jsonschema/latest/jsonschema/meta/fn.try_validate.html) in addition to the [`jsonschema::meta::try_is_valid()`](https://docs.rs/jsonschema/latest/jsonschema/meta/fn.try_is_valid.html).