### PR TITLE
perf: `transpose` refactored for perf

### DIFF
--- a/src/cmd/transpose.rs
+++ b/src/cmd/transpose.rs
@@ -2,7 +2,8 @@ static USAGE: &str = r#"
 Transpose the rows/columns of CSV data.
 
 Note that by default this reads all of the CSV data into memory,
-unless --multipass is given.
+and will automatically go into multipass mode if the CSV is larger
+than memory.
 
 Usage:
     qsv transpose [options] [<input>]
@@ -26,17 +27,19 @@ Common options:
                            Ignored when --multipass option is enabled.
 "#;
 
-use std::str;
+use std::{fs::File, str};
 
 use csv::ByteRecord;
+use memmap2::MmapOptions;
 use serde::Deserialize;
 
 use crate::{
     CliResult,
-    config::{Config, Delimiter},
+    config::{Config, DEFAULT_RDR_BUFFER_CAPACITY, DEFAULT_WTR_BUFFER_CAPACITY, Delimiter},
     util,
 };
 
+#[allow(clippy::unsafe_derive_deserialize)]
 #[derive(Deserialize)]
 struct Args {
     arg_input:      Option<String>,
@@ -56,7 +59,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     };
 
     if args.flag_multipass && !input_is_stdin {
-        args.multipass_transpose()
+        args.multipass_transpose_streaming()
     } else {
         args.in_memory_transpose()
     }
@@ -66,7 +69,12 @@ impl Args {
     fn in_memory_transpose(&self) -> CliResult<()> {
         // we're loading the entire file into memory, we need to check avail mem
         if let Some(path) = self.rconfig().path {
-            util::mem_file_check(&path, false, self.flag_memcheck)?;
+            if let Err(e) = util::mem_file_check(&path, false, self.flag_memcheck) {
+                eprintln!(
+                    "File too large for in-memory transpose: {e}.\nDoing multipass transpose..."
+                );
+                return self.multipass_transpose_streaming();
+            }
         }
 
         let mut rdr = self.rconfig().reader()?;
@@ -74,9 +82,9 @@ impl Args {
         let nrows = rdr.byte_headers()?.len();
 
         let all = rdr.byte_records().collect::<Result<Vec<_>, _>>()?;
+        let mut record = ByteRecord::with_capacity(1024, nrows);
         for i in 0..nrows {
-            let mut record = ByteRecord::new();
-
+            record.clear();
             for row in &all {
                 record.push_field(&row[i]);
             }
@@ -85,29 +93,47 @@ impl Args {
         Ok(wtr.flush()?)
     }
 
-    fn multipass_transpose(&self) -> CliResult<()> {
+    fn multipass_transpose_streaming(&self) -> CliResult<()> {
         let mut wtr = self.wconfig().writer()?;
+
+        // Get the number of columns from the first row
         let nrows = self.rconfig().reader()?.byte_headers()?.len();
 
-        for i in 0..nrows {
-            let mut rdr = self.rconfig().reader()?;
+        // Memory map the file for efficient access
+        // safety: we know we have a file input at this stage
+        let file = File::open(self.arg_input.as_ref().unwrap())?;
+        let mmap = unsafe { MmapOptions::new().populate().map(&file)? };
 
-            let mut record = ByteRecord::new();
+        let mut record = ByteRecord::with_capacity(1024, nrows);
+
+        for i in 0..nrows {
+            record.clear();
+
+            // Create a reader from the memory-mapped data
+            // this is more efficient for large files as we reduce I/O
+            let mut rdr = self.rconfig().from_reader(&mmap[..]);
+
+            // Read all rows for this column
             for row in rdr.byte_records() {
-                record.push_field(&row?[i]);
+                let row = row?;
+                if i < row.len() {
+                    record.push_field(&row[i]);
+                }
             }
+
             wtr.write_byte_record(&record)?;
         }
         Ok(wtr.flush()?)
     }
 
     fn wconfig(&self) -> Config {
-        Config::new(self.flag_output.as_ref())
+        Config::new(self.flag_output.as_ref()).set_write_buffer(DEFAULT_WTR_BUFFER_CAPACITY * 20)
     }
 
     fn rconfig(&self) -> Config {
         Config::new(self.arg_input.as_ref())
             .delimiter(self.flag_delimiter)
             .no_headers(true)
+            .set_read_buffer(DEFAULT_RDR_BUFFER_CAPACITY * 20)
     }
 }

--- a/src/cmd/transpose.rs
+++ b/src/cmd/transpose.rs
@@ -94,15 +94,14 @@ impl Args {
     }
 
     fn multipass_transpose_streaming(&self) -> CliResult<()> {
-        let mut wtr = self.wconfig().writer()?;
-
         // Get the number of columns from the first row
         let nrows = self.rconfig().reader()?.byte_headers()?.len();
 
         // Memory map the file for efficient access
-        // safety: we know we have a file input at this stage
         let file = File::open(self.arg_input.as_ref().unwrap())?;
+        // safety: we know we have a file input at this stage
         let mmap = unsafe { MmapOptions::new().populate().map(&file)? };
+        let mut wtr = self.wconfig().writer()?;
 
         let mut record = ByteRecord::with_capacity(1024, nrows);
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,7 +28,7 @@ pub const DEFAULT_WTR_BUFFER_CAPACITY: usize = 512 * (1 << 10);
 const DEFAULT_SNIFFER_SAMPLE: usize = 100;
 
 // file size at which we warn user that a large file has not been indexed
-const NO_INDEX_WARNING_FILESIZE: u64 = 100_000_000; // 100MB
+const NO_INDEX_WARNING_FILESIZE: u64 = 100 * (1 << 20); // 100MB
 
 // so we don't have to keep checking if the index has been created
 static AUTO_INDEXED: AtomicBool = AtomicBool::new(false);
@@ -393,16 +393,19 @@ impl Config {
         self
     }
 
-    // comment read_buffer() and write_buffer() out for now, as they're not used
-    // pub const fn read_buffer(mut self, buffer: u32) -> Config {
-    //     self.read_buffer = buffer;
-    //     self
-    // }
+    pub fn set_read_buffer(mut self, buffer: usize) -> Config {
+        self.read_buffer = buffer
+            .try_into()
+            .unwrap_or(DEFAULT_RDR_BUFFER_CAPACITY as u32);
+        self
+    }
 
-    // pub const fn write_buffer(mut self, buffer: u32) -> Config {
-    //     self.write_buffer = buffer;
-    //     self
-    // }
+    pub fn set_write_buffer(mut self, buffer: usize) -> Config {
+        self.write_buffer = buffer
+            .try_into()
+            .unwrap_or(DEFAULT_WTR_BUFFER_CAPACITY as u32);
+        self
+    }
 
     #[allow(clippy::missing_const_for_fn)]
     pub fn select(mut self, sel_cols: SelectColumns) -> Config {


### PR DESCRIPTION
- increase default buffer size 10x as this is I/O bound
- use memmapped back file when doing multipass transpose
- automatic fallback to multipass mode when CSV doesn't fit in memory