### PR TITLE
feat: `stats` faster precision calculation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -442,6 +442,7 @@ nightly = [
     "rand/simd_support",
     "simd-json/hints",
 ]
+fast-precision = []
 
 [package.metadata.deb]
 maintainer           = "Konstantin Sivakov <konstantin@datHere.com>"

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -1618,7 +1618,7 @@ fn calculate_float_precision(f: f64) -> u16 {
         } else {
             53 - mantissa.leading_zeros() as u32
         };
-        (significant_digits - exponent as u32).max(0).min(15) as u16
+        significant_digits.saturating_sub(exponent as u32).max(0).min(15) as u16
     }
 }
 

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -1605,7 +1605,7 @@ fn timestamp_ms_to_rfc3339(timestamp: i64, typ: FieldType) -> String {
 fn calculate_float_precision(f: f64) -> u16 {
     // faster precision estimate calculation using bit manipulation
     let bits = f.to_bits();
-    let exponent = ((bits >> 52) & 0x7FF) as i32 - 1023;
+    let exponent = ((bits >> 52) & EXPONENT_MASK) as i32 - EXPONENT_BIAS;
     let mantissa = bits & MANTISSA_MASK;
 
     if exponent < 0 {

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -1613,7 +1613,11 @@ fn calculate_float_precision(f: f64) -> u16 {
         (-exponent).min(15) as u16
     } else {
         // For normal numbers, estimate precision based on mantissa
-        let significant_digits = 53 - mantissa.leading_zeros() as u32;
+        let significant_digits = if mantissa == 0 {
+            53 // Exact powers of 2 have full precision
+        } else {
+            53 - mantissa.leading_zeros() as u32
+        };
         (significant_digits - exponent as u32).max(0).min(15) as u16
     }
 }

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -1603,6 +1603,10 @@ fn timestamp_ms_to_rfc3339(timestamp: i64, typ: FieldType) -> String {
 #[allow(clippy::inline_always)]
 #[inline(always)]
 fn calculate_float_precision(f: f64) -> u16 {
+    const EXPONENT_MASK: u64 = 0x7FF;
+    const EXPONENT_BIAS: i32 = 1023;
+    const MANTISSA_MASK: u64 = 0xFFFFFFFFFFFFF;
+
     // faster precision estimate calculation using bit manipulation
     let bits = f.to_bits();
     let exponent = ((bits >> 52) & EXPONENT_MASK) as i32 - EXPONENT_BIAS;
@@ -1618,7 +1622,10 @@ fn calculate_float_precision(f: f64) -> u16 {
         } else {
             53 - mantissa.leading_zeros() as u32
         };
-        significant_digits.saturating_sub(exponent as u32).max(0).min(15) as u16
+        significant_digits
+            .saturating_sub(exponent as u32)
+            .max(0)
+            .min(15) as u16
     }
 }
 

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -1606,7 +1606,7 @@ fn calculate_float_precision(f: f64) -> u16 {
     // faster precision estimate calculation using bit manipulation
     let bits = f.to_bits();
     let exponent = ((bits >> 52) & 0x7FF) as i32 - 1023;
-    let mantissa = bits & 0xFFFFFFFFFFFFF;
+    let mantissa = bits & MANTISSA_MASK;
 
     if exponent < 0 {
         // For very small numbers, precision is approximately -exponent


### PR DESCRIPTION
The current precision calculation algorithm uses ryu to convert the float to a string, and then counting the len of the string after the decimal point.
This allocates a string for every calculation.

The new precision estimation algorithm uses bit manipulation without allocation, which should be faster.

However, they don't return the same results.

Leave it to the user to decide which precision calculation algorithm they prefer by gating the new bit manipulation algorithm behind the `fast-precision` feature.