### PR TITLE
docs: fix inconsistent formatting in command help examples

### DIFF
--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -17,7 +17,7 @@ applied in order:
 
   trim => Trim the cell
   trim,upper => Trim the cell, then transform to uppercase
-  lower,simdln => Lowercase the cell, then compute the normalized 
+  lower,simdln => Lowercase the cell, then compute the normalized
       Damerau-Levenshtein similarity to --comparand
 
 Operations support multi-column transformations. Just make sure the
@@ -26,7 +26,7 @@ number of transformed columns with the --rename option is the same. e.g.:
 # trim and fold to uppercase the col1,col2 and col3 columns and rename them
 # to newcol1,newcol2 and newcol3
 
- $ qsv apply operations trim,upper col1,col2,col3 -r newcol1,newcol2,newcol3 file.csv
+  $ qsv apply operations trim,upper col1,col2,col3 -r newcol1,newcol2,newcol3 file.csv
 
 It has 40 supported operations:
 
@@ -69,7 +69,7 @@ It has 40 supported operations:
       indiancomma (place a comma every two digits, except the last three digits).
       The decimal separator can be specified with --replacement (default: '.')
   * currencytonum: Gets the numeric value of a currency. Supports currency symbols
-      (e.g. $,¥,£,€,֏,₱,₽,₪,₩,ƒ,฿,₫) and strings (e.g. USD, EUR, RMB, JPY, etc.). 
+      (e.g. $,¥,£,€,֏,₱,₽,₪,₩,ƒ,฿,₫) and strings (e.g. USD, EUR, RMB, JPY, etc.).
       Recognizes point, comma and space separators. Is "permissive" by default, meaning it
       will allow no or non-ISO currency symbols. To enforce strict parsing, which will require
       a valid ISO currency symbol, set the --formatstr to "strict".
@@ -153,24 +153,24 @@ Non-empty cells are not modified. See the `fill` command for more complex empty 
 Examples:
 Replace empty cells in file.csv Measurement column with 'None'.
 
-$ qsv apply emptyreplace Measurement --replacement None file.csv
+  $ qsv apply emptyreplace Measurement --replacement None file.csv
 
 Replace empty cells in file.csv Measurement column with 'Unknown Measurement'.
 
-$ qsv apply emptyreplace Measurement --replacement 'Unknown Measurement' file.csv
+  $ qsv apply emptyreplace Measurement --replacement 'Unknown Measurement' file.csv
 
 Replace empty cells in file.csv M1,M2 and M3 columns with 'None'.
 
-$ qsv apply emptyreplace M1,M2,M3 --replacement None file.csv
+  $ qsv apply emptyreplace M1,M2,M3 --replacement None file.csv
 
 Replace all empty cells in file.csv for columns that start with 'Measurement' with 'None'.
 
-$ qsv apply emptyreplace '/^Measurement/' --replacement None file.csv
+  $ qsv apply emptyreplace '/^Measurement/' --replacement None file.csv
 
 Replace all empty cells in file.csv for columns that start with 'observation'
 case insensitive with 'None'.
 
-$ qsv apply emptyreplace --replacement None '/(?i)^observation/' file.csv
+  $ qsv apply emptyreplace --replacement None '/(?i)^observation/' file.csv
 
 DYNFMT
 Dynamically constructs a new column from other columns using the <--formatstr> template.
@@ -199,32 +199,32 @@ For a complete list of supported units, constants, operators and functions, see 
 
 Examples:
 Do simple arithmetic:
-$ qsv apply calcconv --formatstr '{col1} + {col2} * {col3}' --new-column result file.csv
+  $ qsv apply calcconv --formatstr '{col1} + {col2} * {col3}' --new-column result file.csv
 
 With support for operators like % and ^:
-$ qsv apply calcconv --formatstr '{col1} % 3' --new-column remainder file.csv
+  $ qsv apply calcconv --formatstr '{col1} % 3' --new-column remainder file.csv
 
 Convert from one unit to another:
-$ qsv apply calcconv --formatstr '{col1}mb in gigabytes' -c gb file.csv
-$ qsv apply calcconv --formatstr '{col1} Fahrenheit in Celsius" -c metric_temperature file.csv
+  $ qsv apply calcconv --formatstr '{col1}mb in gigabytes' -c gb file.csv
+  $ qsv apply calcconv --formatstr '{col1} Fahrenheit in Celsius" -c metric_temperature file.csv
 
 Mix units and conversions are automatically done for you:
-$ qsv apply calcconv --formatstr '{col1}km + {col2}mi in meters' -c meters file.csv
+  $ qsv apply calcconv --formatstr '{col1}km + {col2}mi in meters' -c meters file.csv
 
 You can append the inferred unit at the end of the result by ending the expression with '<UNIT>':
-$ qsv apply calcconv --formatstr '({col1} + {col2})km to light years <UNIT>' -c light_years file.csv
+  $ qsv apply calcconv --formatstr '({col1} + {col2})km to light years <UNIT>' -c light_years file.csv
 
 You can even do complex temporal unit conversions:
-$ qsv apply calcconv --formatstr '{col1}m/s + {col2}mi/h in kilometers per h' -c kms_per_h file.csv
+  $ qsv apply calcconv --formatstr '{col1}m/s + {col2}mi/h in kilometers per h' -c kms_per_h file.csv
 
 Use math functions - see https://docs.rs/cpc/latest/cpc/enum.FunctionIdentifier.html for list of functions:
-$ qsv apply calcconv --formatstr 'round(sqrt{col1}^4)! liters' -c liters file.csv
+  $ qsv apply calcconv --formatstr 'round(sqrt{col1}^4)! liters' -c liters file.csv
 
 Use percentages:
-$ qsv apply calcconv --formatstr '10% of abs(sin(pi)) horsepower to watts' -c watts file.csv
+  $ qsv apply calcconv --formatstr '10% of abs(sin(pi)) horsepower to watts' -c watts file.csv
 
 And use very large numbers:
-$ qsv apply calcconv --formatstr '{col1} Billion Trillion * {col2} quadrillion vigintillion' -c num_atoms file.csv 
+  $ qsv apply calcconv --formatstr '{col1} Billion Trillion * {col2} quadrillion vigintillion' -c num_atoms file.csv
 
 For more extensive examples, see https://github.com/dathere/qsv/blob/master/tests/test_apply.rs.
 
@@ -257,7 +257,7 @@ apply arguments:
     CALCONV subcommand:
         --formatstr=<string>        The calculation/conversion expression to use.
         --new-column=<name>         Put the calculated/converted values in a new column.
-        
+
     <input>                     The input file to read from. If not specified, reads from stdin.
 
 apply options:
@@ -283,7 +283,7 @@ apply options:
 
                                   thousands
                                     The thousands separator policy to use. The available policies are:
-                                    comma, dot, space, underscore, hexfour (place a space every four 
+                                    comma, dot, space, underscore, hexfour (place a space every four
                                     hex digits) and indiancomma (place a comma every two digits,
                                     except the last three digits). (default: comma)
 

--- a/src/cmd/applydp.rs
+++ b/src/cmd/applydp.rs
@@ -20,7 +20,7 @@ applied in order:
 Operations support multi-column transformations. Just make sure the
 number of transformed columns with the --rename option is the same. e.g.:
 
-$ qsv applydp operations trim,upper col1,col2,col3 -r newcol1,newcol2,newcol3 file.csv
+  $ qsv applydp operations trim,upper col1,col2,col3 -r newcol1,newcol2,newcol3 file.csv
 
 It has 18 supported operations:
 
@@ -57,14 +57,14 @@ Trim, then transform to uppercase the surname field and rename the column upperc
 
   $ qsv applydp operations trim,upper surname -r uppercase_clean_surname file.csv
 
-Trim, then transform to uppercase the surname field and 
+Trim, then transform to uppercase the surname field and
 save it to a new column named uppercase_clean_surname.
 
   $ qsv applydp operations trim,upper surname -c uppercase_clean_surname file.csv
 
-Trim, squeeze, then transform to uppercase in place ALL fields that end with "_name" 
-  
-    $ qsv applydp operations trim,squeeze,upper \_name$\ file.csv
+Trim, squeeze, then transform to uppercase in place ALL fields that end with "_name"
+
+  $ qsv applydp operations trim,squeeze,upper \_name$\ file.csv
 
 Trim, then transform to uppercase the firstname and surname fields and
 rename the columns ufirstname and usurname.
@@ -90,24 +90,24 @@ Non-empty cells are not modified. See the `fill` command for more complex empty 
 Examples:
 Replace empty cells in file.csv Measurement column with 'None'.
 
-$ qsv applydp emptyreplace Measurement --replacement None file.csv
+  $ qsv applydp emptyreplace Measurement --replacement None file.csv
 
 Replace empty cells in file.csv Measurement column with 'Unknown Measurement'.
 
-$ qsv applydp emptyreplace Measurement --replacement 'Unknown Measurement' file.csv
+  $ qsv applydp emptyreplace Measurement --replacement 'Unknown Measurement' file.csv
 
 Replace empty cells in file.csv M1,M2 and M3 columns with 'None'.
 
-$ qsv applydp emptyreplace M1,M2,M3 --replacement None file.csv
+  $ qsv applydp emptyreplace M1,M2,M3 --replacement None file.csv
 
 Replace all empty cells in file.csv for columns that start with 'Measurement' with 'None'.
 
-$ qsv applydp emptyreplace '/^Measurement/' --replacement None file.csv
+  $ qsv applydp emptyreplace '/^Measurement/' --replacement None file.csv
 
 Replace all empty cells in file.csv for columns that start with 'observation'
 case insensitive with 'None'.
 
-$ qsv applydp emptyreplace --replacement None '/(?i)^observation/' file.csv
+  $ qsv applydp emptyreplace --replacement None '/(?i)^observation/' file.csv
 
 DYNFMT
 Dynamically constructs a new column from other columns using the <--formatstr> template.

--- a/src/cmd/clipboard.rs
+++ b/src/cmd/clipboard.rs
@@ -7,12 +7,12 @@ Meanwhile on Linux and macOS, they may be represented as \n (LF).
 Examples:
 Pipe into qsv stats using qsv clipboard and render it as a table:
 
-  qsv clipboard | qsv stats | qsv table
+  $ qsv clipboard | qsv stats | qsv table
 
 If you want to save the output of a command to the clipboard,
 pipe into qsv clipboard using the --save or -s flag:
 
-  qsv clipboard | qsv stats | qsv clipboard -s
+  $ qsv clipboard | qsv stats | qsv clipboard -s
 
 Usage:
     qsv clipboard [options]

--- a/src/cmd/describegpt.rs
+++ b/src/cmd/describegpt.rs
@@ -7,11 +7,12 @@ inaccurate information being produced. Verify output results before using them.
 Let's say you have Ollama installed (must be v0.2.0 or above) to use LLMs locally with qsv describegpt.
 To attempt generating a data dictionary of a spreadsheet file you may run (replace <> values):
 
-qsv describegpt <filepath> --base-url http://localhost:11434/v1 --api-key ollama --model <model> --max-tokens <number> --dictionary
+  $ qsv describegpt <filepath> --base-url http://localhost:11434/v1 --api-key ollama \
+      --model <model> --max-tokens <number> --dictionary
 
 For more examples, see https://github.com/dathere/qsv/blob/master/tests/test_describegpt.rs.
 
-For more detailed info on how describegpt works and how to prepare a prompt file, 
+For more detailed info on how describegpt works and how to prepare a prompt file,
 see https://github.com/dathere/qsv/blob/master/docs/Describegpt.md
 
 Usage:
@@ -21,12 +22,12 @@ Usage:
 describegpt options:
     -A, --all              Print all extended metadata options output.
     --description          Print a general description of the dataset.
-    --dictionary           For each field, prints an inferred type, a 
+    --dictionary           For each field, prints an inferred type, a
                            human-readable label, a description, and stats.
     --tags                 Prints tags that categorize the dataset. Useful
                            for grouping datasets and filtering.
     --api-key <key>        The API key to use. The default API key for Ollama is ollama.
-                           If the QSV_LLM_APIKEY envvar is set, it will be used instead.                           
+                           If the QSV_LLM_APIKEY envvar is set, it will be used instead.
     --max-tokens <value>   Limits the number of generated tokens in the output.
                            [default: 50]
     --json                 Return results in JSON format.

--- a/src/cmd/diff.rs
+++ b/src/cmd/diff.rs
@@ -11,48 +11,48 @@ NOTE: diff does not support stdin. A file path is required for both arguments.
       To check if a CSV has unique primary key values, use `qsv extdedup`
       with the same key columns using the `--select` option:
 
-         qsv extdedup --select keycol data.csv --no-output
+         $ qsv extdedup --select keycol data.csv --no-output
 
       The duplicate count will be printed to stderr.
 
 Examples:
 
 Find the difference between two CSVs:
-    qsv diff left.csv right.csv
+    $ qsv diff left.csv right.csv
 
 Find the difference between two CSVs. The right CSV has no headers:
-    qsv diff left.csv --no-headers-right right-noheaders.csv
+    $ qsv diff left.csv --no-headers-right right-noheaders.csv
 
 Find the difference between two CSVs. The left CSV uses a tab as the delimiter:
-    qsv diff --delimiter-left '\t' left.csv right-tab.tsv
+    $ qsv diff --delimiter-left '\t' left.csv right-tab.tsv
     # or ';' as the delimiter
-    qsv diff --delimiter-left ';' left.csv right-semicolon.csv
+    $ qsv diff --delimiter-left ';' left.csv right-semicolon.csv
 
 Find the difference between two CSVs. The output CSV uses a tab as the delimiter
 and is written to a file:
-    qsv diff -o diff-tab.tsv --delimiter-output '\t' left.csv right.csv
+    $ qsv diff -o diff-tab.tsv --delimiter-output '\t' left.csv right.csv
     # or ';' as the delimiter
-    qsv diff -o diff-semicolon.csv --delimiter-output ';' left.csv right.csv
+    $ qsv diff -o diff-semicolon.csv --delimiter-output ';' left.csv right.csv
 
 Find the difference between two CSVs, comparing records that have the same values
 in the first two columns:
-    qsv diff --key 0,1 left.csv right.csv
+    $ qsv diff --key 0,1 left.csv right.csv
 
 Find the difference between two CSVs, comparing records that have the same values
 in the first two columns and sort the result by the first two columns:
-    qsv diff -k 0,1 --sort-columns 0,1 left.csv right.csv
+    $ qsv diff -k 0,1 --sort-columns 0,1 left.csv right.csv
 
 Find the difference between two CSVs, but do not output equal field values
 in the result (equal field values are replaced with the empty string). Key
 field values _will_ appear in the output:
-    qsv diff --drop-equal-fields left.csv right.csv
+    $ qsv diff --drop-equal-fields left.csv right.csv
 
 Find the difference between two CSVs, but do not output headers in the result:
-    qsv diff --no-headers-output left.csv right.csv
+    $ qsv diff --no-headers-output left.csv right.csv
 
 Find the difference between two CSVs. Both CSVs have no headers, but the result should have
 headers, so generic headers will be used in the form of: _col_1, _col_2, etc.:
-    qsv diff --no-headers-left --no-headers-right left.csv right.csv
+    $ qsv diff --no-headers-left --no-headers-right left.csv right.csv
 
 For more examples, see https://github.com/dathere/qsv/blob/master/tests/test_diff.rs
 
@@ -81,7 +81,7 @@ diff options:
     -k, --key <arg...>          The column indices that uniquely identify a record
                                 as a comma separated list of 0-based indices, e.g. 0,1,2
                                 or column names, e.g. name,age.
-                                Note that when selecting columns by name, only the 
+                                Note that when selecting columns by name, only the
                                 left CSV's headers are used to match the column names
                                 and it is assumed that the right CSV has the same
                                 selected column names in the same order as the left CSV.
@@ -94,7 +94,7 @@ diff options:
                                 but have different content) will always be kept together
                                 in the sorted diff result and so won't be sorted
                                 independently from each other.
-                                Note that when selecting columns by name, only the 
+                                Note that when selecting columns by name, only the
                                 left CSV's headers are used to match the column names
                                 and it is assumed that the right CSV has the same
                                 selected column names in the same order as the left CSV.

--- a/src/cmd/edit.rs
+++ b/src/cmd/edit.rs
@@ -9,7 +9,7 @@ flashlight,gray
 
 To output the data with the color of the shoes as green instead of blue, run:
 
-qsv edit items.csv color 0 green
+$ qsv edit items.csv color 0 green
 
 The following is returned as output:
 

--- a/src/cmd/edit.rs
+++ b/src/cmd/edit.rs
@@ -9,7 +9,7 @@ flashlight,gray
 
 To output the data with the color of the shoes as green instead of blue, run:
 
-$ qsv edit items.csv color 0 green
+  $ qsv edit items.csv color 0 green
 
 The following is returned as output:
 

--- a/src/cmd/excel.rs
+++ b/src/cmd/excel.rs
@@ -5,71 +5,71 @@ The first non-empty row of a sheet is assumed to be the header row.
 Examples:
 
 Export the first sheet of an Excel file to a CSV file:
-    qsv excel input.xlsx > output.csv
-    qsv excel input.xlsx --output output.csv
+  $ qsv excel input.xlsx > output.csv
+  $ qsv excel input.xlsx --output output.csv
 
 Export the first sheet of an ODS file to a CSV file:
-    qsv excel input.ods > output.csv
-    qsv excel input.ods -o output.csv
+  $ qsv excel input.ods > output.csv
+  $ qsv excel input.ods -o output.csv
 
 Export the first sheet of an Excel file to a CSV file with different delimiters:
-    # semicolon
-    qsv excel input.xlsx -d ";" > output.csv
-    # tab
-    qsv excel input.xlsx -d "\t" > output.tsv
+  # semicolon
+  $ qsv excel input.xlsx -d ";" > output.csv
+  # tab
+  $ qsv excel input.xlsx -d "\t" > output.tsv
 
 Export a sheet by name (case-insensitive):
-    qsv excel --sheet "Sheet 3" input.xlsx
+  $ qsv excel --sheet "Sheet 3" input.xlsx
 
 Export a sheet by index:
-    # this exports the 3nd sheet (0-based index)
-    qsv excel -s 2 input.xlsx
+  # this exports the 3nd sheet (0-based index)
+  $ qsv excel -s 2 input.xlsx
 
 Export the last sheet (negative index)):
-    qsv excel -s -1 input.xlsx
+  $ qsv excel -s -1 input.xlsx
 
 Export the second to last sheet:
-    qsv excel -s -2 input.xls
+  $ qsv excel -s -2 input.xls
 
 Export a table named "Table1" in an XLSX file. Note that --sheet is not required
 as the table definition includes the sheet.
-    qsv excel --table "Table1" input.xlsx
+  $ qsv excel --table "Table1" input.xlsx
 
 Export a range of cells in the first sheet:
-    qsv excel --range C3:T25 input.xlsx
+  $ qsv excel --range C3:T25 input.xlsx
 
 Export a named range in the workbook. Note that --sheet is not required
 as named ranges include the sheet.
-    qsv excel --range MyRange input.xlsx
+  $ qsv excel --range MyRange input.xlsx
 
 Export a range of cells in the second sheet:
-    qsv excel --range C3:T25 -s 1 input.xlsx
+  $ qsv excel --range C3:T25 -s 1 input.xlsx
 
 Export a range of cells in a sheet by name.
 Note the range name must be enclosed in single quotes in certain shells
 as it may contain special characters like ! and $:
-    qsv excel --range 'Sheet2!C3:T25' input.xlsx
-    qsv excel --range 'Sheet2!$C$3:$T$25' input.xlsx
+  $ qsv excel --range 'Sheet2!C3:T25' input.xlsx
+  $ qsv excel --range 'Sheet2!$C$3:$T$25' input.xlsx
 
 Export metadata for all sheets in CSV format:
-    qsv excel --metadata csv input.xlsx
-    qsv excel --metadata c input.xlsx
-    # short CSV mode is much faster, but doesn't contain as much metadata
-    qsv excel --metadata short input.xlsx
-    qsv excel --metadata s input.xlsx
+  $ qsv excel --metadata csv input.xlsx
+  $ qsv excel --metadata c input.xlsx
+  # short CSV mode is much faster, but doesn't contain as much metadata
+  $ qsv excel --metadata short input.xlsx
+  $ qsv excel --metadata s input.xlsx
 
 Export metadata for all sheets in JSON format:
-    qsv excel --metadata json input.xlsx
-    qsv excel --metadata j input.xlsx
-    # pretty-printed JSON - first letter is capital J
-    qsv excel --metadata J input.xlsx
-    # short, minified JSON mode - first letter is capital S
-    qsv excel --metadata Short input.xlsx
-    qsv excel --metadata S input.xlsx
+  $ qsv excel --metadata json input.xlsx
+  $ qsv excel --metadata j input.xlsx
+  # pretty-printed JSON - first letter is capital J
+  $ qsv excel --metadata J input.xlsx
+  # short, minified JSON mode - first letter is capital S
+  $ qsv excel --metadata Short input.xlsx
+  $ qsv excel --metadata S input.xlsx
 
 Prompt for spreadsheets to export and then prompt where to save the CSV:
-    qsv prompt -d ~/Documents -m 'Select a spreadsheet to export to CSV' -F xlsx,xls,ods | \
-     qsv excel - | qsv prompt -m 'Save exported CSV to...' --fd-output
+  $ qsv prompt -d ~/Documents -m 'Select a spreadsheet to export to CSV' -F xlsx,xls,ods | \
+      qsv excel - | qsv prompt -m 'Save exported CSV to...' --fd-output
 
 For more examples, see https://github.com/dathere/qsv/blob/master/tests/test_excel.rs.
 
@@ -83,7 +83,7 @@ Excel argument:
 
 Excel options:
     -s, --sheet <name/index>   Name (case-insensitive) or zero-based index of sheet to export.
-                               Negative indices start from the end (-1 = last sheet). 
+                               Negative indices start from the end (-1 = last sheet).
                                If the sheet cannot be found, qsv will read the first sheet.
                                [default: 0]
     --header-row <row>         The header row. Set if other than the first non-empty row of the sheet.
@@ -100,14 +100,14 @@ Excel options:
                                duplicate_headers_count is a count of duplicate header names.
                                names is a list of defined names in the workbook, with the associated formula.
                                name_count is the number of defined names in the workbook.
-                               tables is a list of tables in the workbook, along with the sheet where 
+                               tables is a list of tables in the workbook, along with the sheet where
                                 the table is found, the columns and the column_count.  (XLSX only)
                                table_count is the number of tables in the workbook.  (XLSX only)
 
                                In CSV(c) mode, the output is in CSV format.
                                In short(s) CSV mode, the output is in CSV format with only the
                                 index, sheet_name, type and visible fields.
-                               
+
                                In JSON(j) mode, the output is minified JSON.
                                In Pretty JSON(J) mode, the output is pretty-printed JSON.
                                In Short(S) JSON mode, the output is minified JSON with only the
@@ -116,7 +116,7 @@ Excel options:
                                 and the number of sheets are also included.
                                If metadata retrieval performance is a concern, use the short modes
                                as they return instantaneously as they don't need to process the sheet data.
-                               
+
                                If this option is used, all other Excel options are ignored.
                                [default: none]
 

--- a/src/cmd/exclude.rs
+++ b/src/cmd/exclude.rs
@@ -15,17 +15,17 @@ columns1 and columns2 must specify exactly the same number of columns.
 
 Examples:
 
-    qsv exclude id records.csv id previously-processed.csv
-    qsv exclude col1,col2 records.csv col1,col2 previously-processed.csv
-    qsv exclude col1-col5 records.csv col1-col5 previously-processed.csv
-    qsv exclude id records.csv id previously-processed.csv > new-records.csv
-    qsv exclude id records.csv id previously-processed.csv --output new-records.csv
-    qsv exclude -v id records.csv id previously-processed.csv -o intersection.csv
-    qsv exclude --ignore-case id records.csv id previously-processed.csv
-    qsv exclude id records.csv id previously-processed.csv |
-       qsv sort > new-sorted-records.csv
-    qsv exclude id records.csv id previously-processed.csv | qsv sort |
-       qsv --sorted dedup > new-sorted-deduped-records.csv
+  $ qsv exclude id records.csv id previously-processed.csv
+  $ qsv exclude col1,col2 records.csv col1,col2 previously-processed.csv
+  $ qsv exclude col1-col5 records.csv col1-col5 previously-processed.csv
+  $ qsv exclude id records.csv id previously-processed.csv > new-records.csv
+  $ qsv exclude id records.csv id previously-processed.csv --output new-records.csv
+  $ qsv exclude -v id records.csv id previously-processed.csv -o intersection.csv
+  $ qsv exclude --ignore-case id records.csv id previously-processed.csv
+  $ qsv exclude id records.csv id previously-processed.csv |
+      qsv sort > new-sorted-records.csv
+  $ qsv exclude id records.csv id previously-processed.csv | qsv sort |
+      qsv --sorted dedup > new-sorted-deduped-records.csv
 
 For more examples, see https://github.com/dathere/qsv/blob/master/tests/test_exclude.rs.
 
@@ -35,7 +35,7 @@ Usage:
 
 input arguments:
     <input1> is the file from which data will be removed.
-    <input2> is the file containing the data to be removed from <input1> 
+    <input2> is the file containing the data to be removed from <input1>
      e.g. 'qsv exclude id records.csv id previously-processed.csv'
 
 exclude options:

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -30,12 +30,12 @@ Set the --disk-cache-dir option and the environment variables QSV_DISKCACHE_TTL_
 QSV_DISKCACHE_TTL_REFRESH to change default DiskCache settings.
 
 Redis Cache:
-Another persistent, inter-session cache option is a Redis cache enabled with the --redis flag. 
+Another persistent, inter-session cache option is a Redis cache enabled with the --redis flag.
 By default, it will connect to a local Redis instance at redis://127.0.0.1:6379/1,
 with a cache expiry Time-to-Live (TTL) of 2,419,200 seconds (28 days),
 and cache hits NOT refreshing the TTL of cached values.
 
-Set the environment variables QSV_REDIS_CONNSTR, QSV_REDIS_TTL_SECONDS and 
+Set the environment variables QSV_REDIS_CONNSTR, QSV_REDIS_TTL_SECONDS and
 QSV_REDIS_TTL_REFRESH to change default Redis settings.
 
 If you don't want responses to be cached at all, use the --no-cache flag.
@@ -71,15 +71,15 @@ data.csv
 
 Given the data.csv above, fetch the JSON response.
 
-  $ qsv fetch URL data.csv 
+  $ qsv fetch URL data.csv
 
 Note the output will be a JSONL file - with a minified JSON response per line, not a CSV file.
 
-Now, if we want to generate a CSV file with the parsed City and State, we use the 
+Now, if we want to generate a CSV file with the parsed City and State, we use the
 new-column and jaq options.
 
-$ qsv fetch URL --new-column CityState --jaq '[ ."places"[0]."place name",."places"[0]."state abbreviation" ]' 
-  data.csv > data_with_CityState.csv
+  $ qsv fetch URL --new-column CityState --jaq '[ ."places"[0]."place name",."places"[0]."state abbreviation" ]' \
+      data.csv > data_with_CityState.csv
 
 data_with_CityState.csv
   URL, CityState,
@@ -98,7 +98,7 @@ Instead of using hardcoded URLs, you can also dynamically construct the URL for 
 values in that row.
 
 Exanple 1:
-For example, we have a CSV with four columns and we want to geocode against the geocode.earth API that expects 
+For example, we have a CSV with four columns and we want to geocode against the geocode.earth API that expects
 latitude and longitude passed as URL parameters.
 
 addr_data.csv
@@ -112,17 +112,17 @@ addr_data.csv
 Geocode addresses in addr_data.csv, pass the latitude and longitude fields and store
 the response in a new column called response into enriched_addr_data.csv.
 
-$ qsv fetch --url-template "https://api.geocode.earth/v1/reverse?point.lat={latitude}&point.lon={longitude}" 
-  addr_data.csv -c response > enriched_addr_data.csv
+  $ qsv fetch --url-template "https://api.geocode.earth/v1/reverse?point.lat={latitude}&point.lon={longitude}" \
+      addr_data.csv -c response > enriched_addr_data.csv
 
 Example 2:
 Geocode addresses in addresses.csv, pass the "street address" and "zip-code" fields
 and use jaq to parse placename from the JSON response into a new column in addresses_with_placename.csv.
 Note how field name non-alphanumeric characters (space and hyphen) in the url-template were replaced with _.
 
-$ qsv fetch --jaq '."features"[0]."properties", ."name"' addresses.csv -c placename --url-template 
-  "https://api.geocode.earth/v1/search/structured?address={street_address}&postalcode={zip_code}"
-  > addresses_with_placename.csv
+  $ qsv fetch --jaq '."features"[0]."properties", ."name"' addresses.csv -c placename --url-template \
+      "https://api.geocode.earth/v1/search/structured?address={street_address}&postalcode={zip_code}" \
+      > addresses_with_placename.csv
 
 USING THE HTTP-HEADER OPTION:
 
@@ -130,7 +130,7 @@ The --http-header option allows you to append arbitrary key value pairs (a valid
 separated by a colon) to the HTTP header (to authenticate against an API, pass custom header fields, etc.).
 Note that you can pass as many key-value pairs by using --http-header option repeatedly. For example:
 
-$ qsv fetch URL data.csv --http-header "X-Api-Key:TEST_KEY" -H "X-Api-Secret:ABC123XYZ" -H "Accept-Language: fr-FR"
+  $ qsv fetch URL data.csv --http-header "X-Api-Key:TEST_KEY" -H "X-Api-Secret:ABC123XYZ" -H "Accept-Language: fr-FR"
 
 For more extensive examples, see https://github.com/dathere/qsv/blob/master/tests/test_fetch.rs.
 
@@ -165,7 +165,7 @@ Fetch options:
     --timeout <seconds>        Timeout for each URL request.
                                [default: 30 ]
     -H, --http-header <k:v>    Append custom header(s) to the HTTP header. Pass multiple key-value pairs
-                               by adding this option multiple times, once for each pair. The key and value 
+                               by adding this option multiple times, once for each pair. The key and value
                                should be separated by a colon.
     --max-retries <count>      Maximum number of retries per record before an error is raised.
                                [default: 5]
@@ -179,20 +179,20 @@ Fetch options:
                                Try to follow the syntax here -
                                https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent
     --report <d|s>             Creates a report of the fetch job. The report has the same name as the input file
-                               with the ".fetch-report" suffix. 
+                               with the ".fetch-report" suffix.
                                There are two kinds of report - d for "detailed" & s for "short". The detailed
-                               report has the same columns as the input CSV with six additional columns - 
-                               qsv_fetch_url, qsv_fetch_status, qsv_fetch_cache_hit, qsv_fetch_retries, 
+                               report has the same columns as the input CSV with six additional columns -
+                               qsv_fetch_url, qsv_fetch_status, qsv_fetch_cache_hit, qsv_fetch_retries,
                                qsv_fetch_elapsed_ms & qsv_fetch_response.
                                The short report only has the six columns without the "qsv_fetch_" prefix.
                                [default: none]
 
                                CACHING OPTIONS:
     --no-cache                 Do not cache responses.
-    
+
     --mem-cache-size <count>   Maximum number of entries in the in-memory LRU cache.
                                [default: 2000000]
-    
+
     --disk-cache               Use a persistent disk cache for responses. The cache is stored in the directory
                                specified by --disk-cache-dir. If the directory does not exist, it will be
                                created. If the directory exists, it will be used as is.
@@ -207,14 +207,14 @@ Fetch options:
                                [default: ~/.qsv/cache/fetch]
 
     --redis-cache              Use Redis to cache responses. It connects to "redis://127.0.0.1:6379/1"
-                               with a connection pool size of 20, with a TTL of 28 days, and a cache hit 
+                               with a connection pool size of 20, with a TTL of 28 days, and a cache hit
                                NOT renewing an entry's TTL.
-                               Adjust the QSV_REDIS_CONNSTR, QSV_REDIS_MAX_POOL_SIZE, QSV_REDIS_TTL_SECONDS & 
+                               Adjust the QSV_REDIS_CONNSTR, QSV_REDIS_MAX_POOL_SIZE, QSV_REDIS_TTL_SECONDS &
                                QSV_REDIS_TTL_REFRESH env vars respectively to change Redis settings.
                                This option is ignored if the --disk-cache option is enabled.
 
     --cache-error              Cache error responses even if a request fails. If an identical URL is requested,
-                               the cached error is returned. Otherwise, the fetch is attempted again 
+                               the cached error is returned. Otherwise, the fetch is attempted again
                                for --max-retries.
     --flush-cache              Flush all the keys in the current cache on startup. This only applies to
                                Disk and Redis caches.

--- a/src/cmd/fetchpost.rs
+++ b/src/cmd/fetchpost.rs
@@ -42,12 +42,12 @@ Set the --disk-cache-dir option and the environment variables QSV_DISKCACHE_TTL_
 QSV_DISKCACHE_TTL_REFRESH to change default DiskCache settings.
 
 Redis Cache:
-Another persistent, inter-session cache option is a Redis cache enabled with the --redis flag. 
+Another persistent, inter-session cache option is a Redis cache enabled with the --redis flag.
 By default, it will connect to a local Redis instance at redis://127.0.0.1:6379/2,
 with a cache expiry Time-to-Live (TTL) of 2,419,200 seconds (28 days),
 and cache hits NOT refreshing the TTL of cached values.
 
-Set the environment variables QSV_FP_REDIS_CONNSTR, QSV_REDIS_TTL_SECONDS and 
+Set the environment variables QSV_FP_REDIS_CONNSTR, QSV_REDIS_TTL_SECONDS and
 QSV_REDIS_TTL_REFRESH to change default Redis settings.
 
 Note that the default values are the same as the fetch command, except fetchpost creates the
@@ -91,14 +91,14 @@ data.csv
 
 Given the data.csv above, fetch the JSON response.
 
-  $ qsv fetchpost URL zipcode,country data.csv 
+  $ qsv fetchpost URL zipcode,country data.csv
 
 Note the output will be a JSONL file - with a minified JSON response per line, not a CSV file.
 
 Now, if we want to generate a CSV file with a parsed response - getting only the "form" property,
 we use the new-column and jaq options.
 
-$ qsv fetchpost URL zipcode,country --new-column form --jaq '."form"' data.csv > data_with_response.csv
+  $ qsv fetchpost URL zipcode,country --new-column form --jaq '."form"' data.csv > data_with_response.csv
 
 data_with_response.csv
   URL,zipcode,country,form
@@ -124,7 +124,7 @@ The --http-header option allows you to append arbitrary key value pairs (a valid
 separated by a colon) to the HTTP header (to authenticate against an API, pass custom header fields, etc.).
 Note that you can pass as many key-value pairs by using --http-header option repeatedly. For example:
 
-$ qsv fetchpost https://httpbin.org/post col1-col3 data.csv -H "X-Api-Key:TEST_KEY" -H "X-Api-Secret:ABC123XYZ"
+  $ qsv fetchpost https://httpbin.org/post col1-col3 data.csv -H "X-Api-Key:TEST_KEY" -H "X-Api-Secret:ABC123XYZ"
 
 For more extensive examples, see https://github.com/dathere/qsv/blob/master/tests/test_fetch.rs.
 
@@ -136,7 +136,7 @@ Fetchpost arguments:
     <url-column>               Name of the column with the URL.
                                Otherwise, if the argument starts with `http`, the URL to use.
     <column-list>              Comma-delimited list of columns to insert into the HTTP Post body.
-                               Uses `qsv select` syntax - i.e. Columns can be referenced by index or 
+                               Uses `qsv select` syntax - i.e. Columns can be referenced by index or
                                by name if there is a header row (duplicate column names can be disambiguated
                                with more indexing). Column ranges can also be specified. Finally, columns
                                can be selected using regular expressions.
@@ -147,7 +147,7 @@ Fetchpost options:
                                payload in the HTTP Post body. You can also use --payload-tpl to render
                                a non-JSON payload, but --content-type will have to be set manually.
                                If a rendered JSON is invalid, `fetchpost` will abort and return an error.
-    --content-type <arg>       Overrides automatic content types for `<column-list>` 
+    --content-type <arg>       Overrides automatic content types for `<column-list>`
                                (`application/x-www-form-urlencoded`) and `--payload-tpl` (`application/json`).
                                Typical alternative values are `multipart/form-data` and `text/plain`.
                                It is the responsibility of the user to format the payload accordingly
@@ -178,7 +178,7 @@ Fetchpost options:
     --timeout <seconds>        Timeout for each URL request.
                                [default: 30 ]
     -H, --http-header <k:v>    Append custom header(s) to the HTTP header. Pass multiple key-value pairs
-                               by adding this option multiple times, once for each pair. The key and value 
+                               by adding this option multiple times, once for each pair. The key and value
                                should be separated by a colon.
     --compress                 Compress the HTTP request body using gzip. Note that most servers do not support
                                compressed request bodies unless they are specifically configured to do so. This
@@ -197,9 +197,9 @@ Fetchpost options:
                                Try to follow the syntax here -
                                https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent
     --report <d|s>             Creates a report of the fetchpost job. The report has the same name as the
-                               input file with the ".fetchpost-report" suffix. 
+                               input file with the ".fetchpost-report" suffix.
                                There are two kinds of report - d for "detailed" & s for "short". The detailed
-                               report has the same columns as the input CSV with seven additional columns - 
+                               report has the same columns as the input CSV with seven additional columns -
                                qsv_fetchp_url, qsv_fetchp_form, qsv_fetchp_status, qsv_fetchp_cache_hit,
                                qsv_fetchp_retries, qsv_fetchp_elapsed_ms & qsv_fetchp_response.
                                The short report only has the seven columns without the "qsv_fetchp_" prefix.
@@ -225,9 +225,9 @@ Fetchpost options:
                                [default: ~/.qsv/cache/fetchpost]
 
     --redis-cache              Use Redis to cache responses. It connects to "redis://127.0.0.1:6379/2"
-                               with a connection pool size of 20, with a TTL of 28 days, and a cache hit 
+                               with a connection pool size of 20, with a TTL of 28 days, and a cache hit
                                NOT renewing an entry's TTL.
-                               Adjust the QSV_FP_REDIS_CONNSTR, QSV_REDIS_MAX_POOL_SIZE, QSV_REDIS_TTL_SECONDS & 
+                               Adjust the QSV_FP_REDIS_CONNSTR, QSV_REDIS_MAX_POOL_SIZE, QSV_REDIS_TTL_SECONDS &
                                QSV_REDIS_TTL_REFRESH respectively to change Redis settings.
 
     --cache-error              Cache error responses even if a request fails. If an identical URL is requested,

--- a/src/cmd/geoconvert.rs
+++ b/src/cmd/geoconvert.rs
@@ -3,19 +3,19 @@ Convert between various spatial formats and CSV/SVG including GeoJSON, SHP, and 
 
 For example to convert a GeoJSON file into CSV data:
 
-qsv geoconvert file.geojson geojson csv
+  $ qsv geoconvert file.geojson geojson csv
 
 To use stdin as input instead of a file path, use a dash "-":
 
-qsv prompt -m "Choose a GeoJSON file" -F geojson | qsv geoconvert - geojson csv
+  $ qsv prompt -m "Choose a GeoJSON file" -F geojson | qsv geoconvert - geojson csv
 
 To convert a CSV file into GeoJSON data, specify the WKT geometry column with the --geometry flag:
 
-qsv geoconvert file.csv csv geojson --geometry geometry
+  $ qsv geoconvert file.csv csv geojson --geometry geometry
 
 Alternatively specify the latitude and longitude columns with the --latitude and --longitude flags:
 
-qsv geoconvert file.csv csv geojson --latitude lat --longitude lon
+  $ qsv geoconvert file.csv csv geojson --latitude lat --longitude lon
 
 Usage:
     qsv geoconvert [options] (<input>) (<input-format>) (<output-format>)
@@ -39,7 +39,7 @@ geoconvert options:
 
     -l, --max-length <length>    The maximum column length when the output format is CSV.
                                  Oftentimes, the geometry column is too long to fit in a
-                                 CSV file, causing other tools like Python & PostgreSQL to fail. 
+                                 CSV file, causing other tools like Python & PostgreSQL to fail.
                                  If a column is too long, it will be truncated to the specified
                                  length and an ellipsis ("...") will be appended.
 

--- a/src/cmd/json.rs
+++ b/src/cmd/json.rs
@@ -31,7 +31,7 @@ As an example, say we have the following JSON data in a file fruits.json:
 
 To convert it to CSV format run:
 
-  qsv json fruits.json
+  $ qsv json fruits.json
 
 And the following is printed to the terminal:
 
@@ -39,7 +39,7 @@ fruit,price,calories
 apple,2.5,95
 banana,3.0,105
 
-IMPORTANT: 
+IMPORTANT:
   The order of the columns in the CSV file will be the same as the order of the keys in the first JSON object.
   The order of the rows in the CSV file will be the same as the order of the objects in the JSON array.
 
@@ -75,22 +75,22 @@ For example, say we have the following JSON data in a file fruits2.json:
 
 If we run the following command:
 
-  qsv json fruits2.json | qsv table
+  $ qsv json fruits2.json | qsv table
 
 The output CSV will have the following columns:
 
 fruit       cost  price  calories  rating
-apple       1.75  2.5    95        
-mangosteen        5.0    56        
+apple       1.75  2.5    95
+mangosteen        5.0    56
 starapple         4.5    95        9
-banana            3.0    105       
+banana            3.0    105
 
 Note that the "rating" column is added as an additional column in the output CSV,
 though it appears as the 2nd column in the third JSON object for "starapple".
 
 If you want to select/reorder/drop columns in the output CSV, use the --select option, for example:
 
-  qsv json fruits.json --select price,fruit
+  $ qsv json fruits.json --select price,fruit
 
 The following is printed to the terminal:
 
@@ -103,7 +103,7 @@ Note: Trailing zeroes in decimal numbers after the decimal are truncated (2.50 b
 If the JSON data was provided using stdin then either use - or do not provide a file path.
 For example you may copy the JSON data above to your clipboard then run:
 
-qsv clipboard | qsv json
+  $ qsv clipboard | qsv json
 
 Again, when JSON data is nested or complex, try using the --jaq option and provide a filter value.
 
@@ -115,7 +115,7 @@ For example we have a .json file with a "data" key and the value being the same 
 
 We may run the following to select the JSON file and convert the nested array to CSV:
 
-qsv prompt -F json | qsv json --jaq .data
+  $ qsv prompt -F json | qsv json --jaq .data
 
 For more examples, see https://github.com/dathere/qsv/blob/master/tests/test_json.rs.
 

--- a/src/cmd/luau.rs
+++ b/src/cmd/luau.rs
@@ -1,5 +1,5 @@
 static USAGE: &str = r#"
-Create multiple new computed columns, filter rows or compute aggregations by 
+Create multiple new computed columns, filter rows or compute aggregations by
 executing a Luau 0.682 script for every row (SEQUENTIAL MODE) or for
 specified rows (RANDOM ACCESS MODE) of a CSV file.
 
@@ -61,16 +61,16 @@ Some examples:
   $ qsv luau filter "tonumber(a) >= tonumber(b)"
 
   Typing long scripts on the command line gets tiresome rather quickly. Use the
-  "file:" prefix or the ".lua/.luau" file extension to read non-trivial scripts 
+  "file:" prefix or the ".lua/.luau" file extension to read non-trivial scripts
   from the filesystem.
 
   In the following example, both the BEGIN and END scripts have the lua/luau file
   extension so they are read from the filesystem.  With the debitcredit.script file,
   we use the "file:" prefix to read it from the filesystem.
 
-    $ qsv luau map Type -B init.lua file:debitcredit.script -E end.luau
+  $ qsv luau map Type -B init.lua file:debitcredit.script -E end.luau
 
-With "luau map", if the MAIN script is invalid for a row, "<ERROR>" followed by a 
+With "luau map", if the MAIN script is invalid for a row, "<ERROR>" followed by a
 detailed error message is returned for that row.
 With "luau filter", if the MAIN script is invalid for a row, that row is not filtered.
 
@@ -83,9 +83,9 @@ SPECIAL VARIABLES:
 
        It is primarily used in SEQUENTIAL MODE when the CSV has no index or you
        wish to process the CSV sequentially.
- 
+
   "_INDEX" - a READ/WRITE variable that enables RANDOM ACCESS MODE when used in
-       a script. Using "_INDEX" in a script switches qsv to RANDOM ACCESS MODE 
+       a script. Using "_INDEX" in a script switches qsv to RANDOM ACCESS MODE
        where setting it to a row number will change the current row to the
        specified row number. It will only work, however, if the CSV has an index.
 
@@ -95,8 +95,8 @@ SPECIAL VARIABLES:
 
        If the CSV has no index, qsv will abort with an error unless "qsv_autoindex()"
        is called in the BEGIN script to create an index.
-       
-  "_ROWCOUNT" - a READ-only variable which is zero during the BEGIN & MAIN scripts, 
+
+  "_ROWCOUNT" - a READ-only variable which is zero during the BEGIN & MAIN scripts,
        and set to the rowcount during the END script when the CSV has no index
        (SEQUENTIAL MODE).
 

--- a/src/cmd/partition.rs
+++ b/src/cmd/partition.rs
@@ -11,7 +11,7 @@ EXAMPLE:
 
 Partition nyc311.csv file into separate files based on the value of the
 "Borough" column in the current directory:
-    $ qsv partition Borough . --filename "nyc311-{}.csv" nyc311.csv
+  $ qsv partition Borough . --filename "nyc311-{}.csv" nyc311.csv
 
 will create the following files, each containing the data for each borough:
     nyc311-Bronx.csv

--- a/src/cmd/prompt.rs
+++ b/src/cmd/prompt.rs
@@ -5,17 +5,17 @@ Examples:
 Pick a single file as input to qsv stats using an INPUT file dialog,
 pipe into qsv stats using qsv prompt, and browse the stats using qsv lens:
 
-  qsv prompt | qsv stats | qsv lens
+  $ qsv prompt | qsv stats | qsv lens
 
 If you want to save the output of a command to a file using a save file OUTPUT dialog,
 pipe into qsv prompt using the --fd-output flag:
 
-  qsv prompt -m 'Pick a CSV file to summarize' | qsv stats -E | qsv prompt --fd-output
+  $ qsv prompt -m 'Pick a CSV file to summarize' | qsv stats -E | qsv prompt --fd-output
 
 Prompt for a spreadsheet, and export to CSV using a save file dialog:
 
-  qsv prompt -m 'Select a spreadsheet to export to CSV' -F xlsx,xls,ods | \
-    qsv excel - | qsv prompt -m 'Save exported CSV to...' --fd-output
+  $ qsv prompt -m 'Select a spreadsheet to export to CSV' -F xlsx,xls,ods | \
+      qsv excel - | qsv prompt -m 'Save exported CSV to...' --fd-output
 
 Usage:
     qsv prompt [options]

--- a/src/cmd/pseudo.rs
+++ b/src/cmd/pseudo.rs
@@ -14,7 +14,7 @@ EXAMPLE:
 Pseudonymise the value of the "Name" column by replacing it with an
 incremental identifier starting at 1000 and incrementing by 5:
 
-    $ qsv pseudo Name --start 1000 --increment 5 --fmtstr "ID-{}" data.csv
+  $ qsv pseudo Name --start 1000 --increment 5 --fmtstr "ID-{}" data.csv
 
 If run on the following CSV data:
 

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -9,19 +9,19 @@ Alternatively, you can specify pairs of old and new column names to rename
 only specific columns. The format is "old1,new1,old2,new2,...".
 
   Change the column names of a CSV with three columns:
-    $ qsv rename id,name,title
+  $ qsv rename id,name,title
 
   Rename only specific columns using pairs:
-    $ qsv rename oldname,newname,oldcol,newcol
+  $ qsv rename oldname,newname,oldcol,newcol
 
   Replace the column names with generic ones (_col_N):
-    $ qsv rename _all_generic
+  $ qsv rename _all_generic
 
   Add generic column names to a CSV with no headers:
-    $ qsv rename _all_generic --no-headers
+  $ qsv rename _all_generic --no-headers
 
   Use column names that contains commas and conflict with the separator:
-    $ qsv rename '"Date - Opening","Date - Actual Closing"'
+  $ qsv rename '"Date - Opening","Date - Actual Closing"'
 
 For more examples, see https://github.com/dathere/qsv/blob/master/tests/test_rename.rs.
 
@@ -41,7 +41,7 @@ rename arguments:
 Common options:
     -h, --help             Display this message
     -o, --output <file>    Write output to <file> instead of stdout.
-    -n, --no-headers       When set, the header will be inserted on top.    
+    -n, --no-headers       When set, the header will be inserted on top.
     -d, --delimiter <arg>  The field delimiter for reading CSV data.
                            Must be a single character. (default: ,)
 "#;

--- a/src/cmd/schema.rs
+++ b/src/cmd/schema.rs
@@ -3,11 +3,11 @@ Generate JSON Schema or Polars Schema (with the `--polars` option) from CSV data
 
 JSON Schema Validation:
 =======================
-This command derives a JSON Schema Validation (Draft 7) file from CSV data, 
+This command derives a JSON Schema Validation (Draft 7) file from CSV data,
 including validation rules based on data type and input data domain/range.
 https://json-schema.org/draft/2020-12/json-schema-validation.html
 
-Running `validate` command on original input CSV with generated schema 
+Running `validate` command on original input CSV with generated schema
 should not flag any invalid records.
 
 The intended workflow is to use the `schema` command to generate a JSON schema file
@@ -18,9 +18,9 @@ generated JSON schema.
 After manually fine-tuning the JSON schema file, note that you can also use the
 `validate` command to validate the JSON Schema file as well:
 
-  `qsv validate schema manually-tuned-jsonschema.json`
+  $ qsv validate schema manually-tuned-jsonschema.json
 
-The generated JSON schema file has `.schema.json` suffix appended. For example, 
+The generated JSON schema file has `.schema.json` suffix appended. For example,
 for input `mydata.csv`, the generated JSON schema is `mydata.csv.schema.json`.
 
 If piped from stdin, the schema file will be `stdin.csv.schema.json` and
@@ -43,7 +43,7 @@ instead of a JSON Schema. The generated Polars schema will be written to a file 
 The Polars schema is a JSON object that describes the schema of a CSV file. When present,
 the `sqlp`, `joinp`, and `pivotp` commands will use the Polars schema to read the CSV file
 instead of inferring the schema from the CSV data. Not only does this allow these commands to
-skip schema inferencing which may fail when the inferencing sample is too low, it also allows 
+skip schema inferencing which may fail when the inferencing sample is too low, it also allows
 Polars to optimize the query and gives the user the option to tailor the schema to their specific
 query needs (e.g. using a Decimal type instead of a Float type).
 
@@ -68,9 +68,9 @@ Schema options:
     --pattern-columns <args>   Select columns to derive regex pattern constraints.
                                That is, this will create a regular expression
                                that matches all values for each specified column.
-                               Columns are selected using `select` syntax 
+                               Columns are selected using `select` syntax
                                (see `qsv select --help` for details).
-    --dates-whitelist <list>   The case-insensitive patterns to look for when 
+    --dates-whitelist <list>   The case-insensitive patterns to look for when
                                shortlisting fields for date inference.
                                i.e. if the field's name has any of these patterns,
                                it is shortlisted for date inferencing.

--- a/src/cmd/slice.rs
+++ b/src/cmd/slice.rs
@@ -33,39 +33,39 @@ slice options:
     --invert               slice all records EXCEPT those in the specified range.
 
 Examples:
-    # Slice from the 3rd record to the end
-    qsv slice --start 2 data.csv
+  # Slice from the 3rd record to the end
+  $ qsv slice --start 2 data.csv
 
-    # Slice the first three records
-    qsv slice --start 0 --end 2 data.csv
-    qsv slice --len 3 data.csv
-    qsv slice -l 3 data.csv
+  # Slice the first three records
+  $ qsv slice --start 0 --end 2 data.csv
+  $ qsv slice --len 3 data.csv
+  $ qsv slice -l 3 data.csv
 
-    # Slice the last record
-    qsv slice -s -1 data.csv
+  # Slice the last record
+  $ qsv slice -s -1 data.csv
 
-    # Slice the last 10 records
-    qsv slice -s -10 data.csv
+  # Slice the last 10 records
+  $ qsv slice -s -10 data.csv
 
-    # Get everything except the last 10 records
-    qsv slice -s -10 --invert data.csv
+  # Get everything except the last 10 records
+  $ qsv slice -s -10 --invert data.csv
 
-    # Slice the first three records of the last 10 records
-    qsv slice -s -10 -l 3 data.csv
+  # Slice the first three records of the last 10 records
+  $ qsv slice -s -10 -l 3 data.csv
 
-    # Slice the second record
-    qsv slice --index 1 data.csv
-    qsv slice -i 1 data.csv
+  # Slice the second record
+  $ qsv slice --index 1 data.csv
+  $ qsv slice -i 1 data.csv
 
-    # Slice from the second record, two records
-    qsv slice -s 1 --len 2 data.csv
+  # Slice from the second record, two records
+  $ qsv slice -s 1 --len 2 data.csv
 
-    # Slice records 10 to 20 as JSON   
-    qsv slice -s 9 -e 19 --json data.csv
-    qsv slice -s 9 -l 10 --json data.csv
+  # Slice records 10 to 20 as JSON
+  $ qsv slice -s 9 -e 19 --json data.csv
+  $ qsv slice -s 9 -l 10 --json data.csv
 
-    # Slice records 1 to 9 and 21 to the end as JSON
-    qsv slice -s 9 -l 10 --invert --json data.csv
+  # Slice records 1 to 9 and 21 to the end as JSON
+  $ qsv slice -s 9 -l 10 --invert --json data.csv
 
 Common options:
     -h, --help             Display this message

--- a/src/cmd/split.rs
+++ b/src/cmd/split.rs
@@ -26,35 +26,35 @@ The files are written to the directory given with the name '{start}.csv',
 where {start} is the index of the first record of the chunk (starting at 0).
 
 Examples:
-    qsv split outdir --size 100 --filename chunk_{}.csv input.csv
-    # This will create files with names like chunk_0.csv, chunk_100.csv, etc.
-    # in the directory 'outdir', creating the directory if it does not exist.
+  $ qsv split outdir --size 100 --filename chunk_{}.csv input.csv
+  # This will create files with names like chunk_0.csv, chunk_100.csv, etc.
+  # in the directory 'outdir', creating the directory if it does not exist.
 
-    qsv split outdir/subdir -s 100 --filename chunk_{}.csv --pad 5 input.csv
-    # This will create files with names like chunk_00000.csv, chunk_00100.csv, etc.
-    # in the directory 'outdir/subdir', creating the directories if they do not exist.
+  $ qsv split outdir/subdir -s 100 --filename chunk_{}.csv --pad 5 input.csv
+  # This will create files with names like chunk_00000.csv, chunk_00100.csv, etc.
+  # in the directory 'outdir/subdir', creating the directories if they do not exist.
 
-    qsv split . -s 100 input.csv
-    # This will create files like 0.csv, 100.csv, etc. in the current directory.
+  $ qsv split . -s 100 input.csv
+  # This will create files like 0.csv, 100.csv, etc. in the current directory.
 
-    qsv split outdir --kb-size 1000 input.csv
-    # This will create files with names like 0.csv, 994.csv, etc. in the directory
-    # 'outdir', creating the directory if it does not exist. Each file will be close
-    # to 1000KB in size.
+  $ qsv split outdir --kb-size 1000 input.csv
+  # This will create files with names like 0.csv, 994.csv, etc. in the directory
+  # 'outdir', creating the directory if it does not exist. Each file will be close
+  # to 1000KB in size.
 
-    cat in.csv | qsv split mysplitoutput -s 1000
+  $ cat in.csv | qsv split mysplitoutput -s 1000
 
-    qsv split outdir --chunks 10 input.csv
+  $ qsv split outdir --chunks 10 input.csv
 
-    qsv split splitoutdir -c 10 -j 4 input.csv
+  $ qsv split splitoutdir -c 10 -j 4 input.csv
 
-    qsv split outdir -s 100 --filter "gzip $FILE" input.csv
-    # This will create files with names like 0.csv, 100.csv, etc. in the directory
-    # 'outdir', and then run the command "gzip" on each chunk.
+  $ qsv split outdir -s 100 --filter "gzip $FILE" input.csv
+  # This will create files with names like 0.csv, 100.csv, etc. in the directory
+  # 'outdir', and then run the command "gzip" on each chunk.
 
-    qsv split outdir --filter "powershell Compress-Archive -Path $FILE -Destination {}.zip" input.csv
-    # WINDOWS: This will create files with names like 0.zip, 100.zip, etc. in the directory
-    # 'outdir', and then run the command "Compress-Archive" on each chunk.
+  $ qsv split outdir --filter "powershell Compress-Archive -Path $FILE -Destination {}.zip" input.csv
+  # WINDOWS: This will create files with names like 0.zip, 100.zip, etc. in the directory
+  # 'outdir', and then run the command "Compress-Archive" on each chunk.
 
 For more examples, see https://github.com/dathere/qsv/blob/master/tests/test_split.rs.
 

--- a/src/cmd/sqlp.rs
+++ b/src/cmd/sqlp.rs
@@ -80,9 +80,9 @@ Example queries:
   $ qsv sqlp data.csv data2.csv "select data.c2 <=> data2.c2 from data join data2 on data.c1 = data2.c1"
 
   # support ^@ ("starts with"), and ~~ (like) ,~~* (ilike),!~~ (not like),!~~* (not ilike) operators
-  $  qsv sqlp data.csv "select * from data WHERE col1 ^@ 'foo'"
-  $  qsv sqlp data.csv "select c1 ^@ 'a' AS c1_starts_with_a from data"
-  $  qsv sqlp data.csv "select c1 ~~* '%B' AS c1_ends_with_b_caseinsensitive from data"
+  $ qsv sqlp data.csv "select * from data WHERE col1 ^@ 'foo'"
+  $ qsv sqlp data.csv "select c1 ^@ 'a' AS c1_starts_with_a from data"
+  $ qsv sqlp data.csv "select c1 ~~* '%B' AS c1_ends_with_b_caseinsensitive from data"
 
   # support SELECT * ILIKE wildcard syntax
   # select all columns from customers where the column contains 'a' followed by an 'e'

--- a/src/cmd/sqlp.rs
+++ b/src/cmd/sqlp.rs
@@ -3,7 +3,7 @@ Run blazing-fast Polars SQL queries against several CSVs - replete with joins, a
 grouping, table functions, sorting, and more - working on larger than memory CSV files directly,
 without having to load it first into a database.
 
-Polars SQL is a PostgreSQL dialect (https://docs.pola.rs/user-guide/sql/intro/), converting SQL 
+Polars SQL is a PostgreSQL dialect (https://docs.pola.rs/user-guide/sql/intro/), converting SQL
 queries to ultra-fast Polars LazyFrame expressions (https://docs.pola.rs/user-guide/lazy/).
 
 For a list of SQL functions and keywords supported by Polars SQL, see
@@ -14,44 +14,44 @@ Returns the shape of the query result (number of rows, number of columns) to std
 
 Example queries:
 
-   qsv sqlp data.csv 'select * from data where col1 > 10 order by all desc limit 20'
+  $ qsv sqlp data.csv 'select * from data where col1 > 10 order by all desc limit 20'
 
-   qsv sqlp data.csv 'select col1, col2 as friendlyname from data' --format parquet --output data.parquet
+  $ qsv sqlp data.csv 'select col1, col2 as friendlyname from data' --format parquet --output data.parquet
 
   # enclose column names with spaces in double quotes
-   qsv sqlp data.csv 'select "col 1", "col 2" from data'
+  $ qsv sqlp data.csv 'select "col 1", "col 2" from data'
 
-   qsv sqlp data.csv data2.csv 'select * from data join data2 on data.colname = data2.colname'
+  $ qsv sqlp data.csv data2.csv 'select * from data join data2 on data.colname = data2.colname'
 
-   qsv sqlp data.csv data2.csv 'SELECT col1 FROM data WHERE col1 IN (SELECT col2 FROM data2)'
+  $ qsv sqlp data.csv data2.csv 'SELECT col1 FROM data WHERE col1 IN (SELECT col2 FROM data2)'
 
   # Use dollar-quoting to avoid escaping reserved characters in literals.
-  https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-DOLLAR-QUOTING 
-   qsv sqlp data.csv "SELECT * FROM data WHERE col1 = $$O'Reilly$$"
-   qsv sqlp data.csv 'SELECT * FROM data WHERE col1 = $SomeTag$Diane's horse "Twinkle"$SomeTag$'
+  https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-DOLLAR-QUOTING
+  $ qsv sqlp data.csv "SELECT * FROM data WHERE col1 = $$O'Reilly$$"
+  $ qsv sqlp data.csv 'SELECT * FROM data WHERE col1 = $SomeTag$Diane's horse "Twinkle"$SomeTag$'
 
   # Unions and Joins are supported.
-   qsv sqlp data1.csv data2.csv 'SELECT * FROM data1 UNION ALL BY NAME SELECT * FROM data2'
+  $ qsv sqlp data1.csv data2.csv 'SELECT * FROM data1 UNION ALL BY NAME SELECT * FROM data2'
 
-   qsv sqlp tbl_a.csv tbl_b.csv tbl_c.csv "SELECT * FROM tbl_a \
+  $ qsv sqlp tbl_a.csv tbl_b.csv tbl_c.csv "SELECT * FROM tbl_a \
      RIGHT ANTI JOIN tbl_b USING (b) \
      LEFT SEMI JOIN tbl_c USING (c)"
 
   # use "_t_N" aliases to refer to input files, where N is the 1-based index
   # of the input file/s. For example, _t_1 refers to the first input file, _t_2
   # refers to the second input file, and so on.
-   qsv sqlp data.csv data2.csv 'select * from _t_1 join _t_2 on _t_1.colname = _t_2.colname'
+  $ qsv sqlp data.csv data2.csv 'select * from _t_1 join _t_2 on _t_1.colname = _t_2.colname'
 
-   qsv sqlp data.csv 'SELECT col1, count(*) AS cnt FROM data GROUP BY col1 ORDER BY cnt DESC, col1 ASC'
+  $ qsv sqlp data.csv 'SELECT col1, count(*) AS cnt FROM data GROUP BY col1 ORDER BY cnt DESC, col1 ASC'
 
-   qsv sqlp data.csv "select lower(col1), substr(col2, 2, 4) from data WHERE starts_with(col1, 'foo')"
+  $ qsv sqlp data.csv "select lower(col1), substr(col2, 2, 4) from data WHERE starts_with(col1, 'foo')"
 
-   qsv sqlp data.csv "select COALESCE(NULLIF(col2, ''), 'foo') from data"
+  $ qsv sqlp data.csv "select COALESCE(NULLIF(col2, ''), 'foo') from data"
 
-   qsv sqlp tbl1.csv "SELECT x FROM tbl1 WHERE x IN (SELECT y FROM tbl1)"
+  $ qsv sqlp tbl1.csv "SELECT x FROM tbl1 WHERE x IN (SELECT y FROM tbl1)"
 
   # Natural Joins are supported too! (https://www.w3resource.com/sql/joins/natural-join.php)
-   qsv sqlp data1.csv data2.csv data3.csv \
+  $ qsv sqlp data1.csv data2.csv data3.csv \
     "SELECT COLUMNS('^[^:]+$') FROM data1 NATURAL JOIN data2 NATURAL JOIN data3 ORDER BY COMPANY_ID",
 
   # Use a SQL script to run a long, complex SQL query or to run SEVERAL SQL queries.
@@ -64,85 +64,85 @@ Example queries:
   # `truncate table <table_name>;` to free up memory used by temporary tables. Otherwise,
   # the memory used by the temporary tables won't be freed until the script finishes.
   # See test_sqlp/sqlp_boston311_sql_script() for an example.
-   qsv sqlp data.csv data2.csv data3.csv data4.csv script.sql --format json --output data.json
+  $ qsv sqlp data.csv data2.csv data3.csv data4.csv script.sql --format json --output data.json
 
   # use Common Table Expressions (CTEs) using WITH to simplify complex queries
-   qsv sqlp people.csv "WITH millennials AS (SELECT * FROM people WHERE age >= 25 and age <= 40) \
+  $ qsv sqlp people.csv "WITH millennials AS (SELECT * FROM people WHERE age >= 25 and age <= 40) \
      SELECT * FROM millennials WHERE STARTS_WITH(name,'C')"
 
   # CASE statement
-   qsv sqlp data.csv "select CASE WHEN col1 > 10 THEN 'foo' WHEN col1 > 5 THEN 'bar' ELSE 'baz' END from data"
-   qsv sqlp data.csv "select CASE col*5 WHEN 10 THEN 'foo' WHEN 5 THEN 'bar' ELSE 'baz' END from _t_1"
+  $ qsv sqlp data.csv "select CASE WHEN col1 > 10 THEN 'foo' WHEN col1 > 5 THEN 'bar' ELSE 'baz' END from data"
+  $ qsv sqlp data.csv "select CASE col*5 WHEN 10 THEN 'foo' WHEN 5 THEN 'bar' ELSE 'baz' END from _t_1"
 
   # spaceship operator: "<=>" (three-way comparison operator)
   #  returns -1 if left < right, 0 if left == right, 1 if left > right
   # https://en.wikipedia.org/wiki/Three-way_comparison#Spaceship_operator
-   qsv sqlp data.csv data2.csv "select data.c2 <=> data2.c2 from data join data2 on data.c1 = data2.c1"
+  $ qsv sqlp data.csv data2.csv "select data.c2 <=> data2.c2 from data join data2 on data.c1 = data2.c1"
 
   # support ^@ ("starts with"), and ~~ (like) ,~~* (ilike),!~~ (not like),!~~* (not ilike) operators
-    qsv sqlp data.csv "select * from data WHERE col1 ^@ 'foo'"
-    qsv sqlp data.csv "select c1 ^@ 'a' AS c1_starts_with_a from data"
-    qsv sqlp data.csv "select c1 ~~* '%B' AS c1_ends_with_b_caseinsensitive from data"
+  $  qsv sqlp data.csv "select * from data WHERE col1 ^@ 'foo'"
+  $  qsv sqlp data.csv "select c1 ^@ 'a' AS c1_starts_with_a from data"
+  $  qsv sqlp data.csv "select c1 ~~* '%B' AS c1_ends_with_b_caseinsensitive from data"
 
   # support SELECT * ILIKE wildcard syntax
-    # select all columns from customers where the column contains 'a' followed by an 'e'
-    # with any characters (or no characters), in between, case-insensitive
-    # if customers.csv has columns LastName, FirstName, Address, City, State, Zip
-    # this query will return all columns for all rows except the columns that don't
-    # contain 'a' followed by an 'e' - i.e. except City and Zip
-    qsv sqlp customers.csv "SELECT * ILIKE '%a%e%' FROM customers ORDER BY LastName, FirstName"
+  # select all columns from customers where the column contains 'a' followed by an 'e'
+  # with any characters (or no characters), in between, case-insensitive
+  # if customers.csv has columns LastName, FirstName, Address, City, State, Zip
+  # this query will return all columns for all rows except the columns that don't
+  # contain 'a' followed by an 'e' - i.e. except City and Zip
+  $  qsv sqlp customers.csv "SELECT * ILIKE '%a%e%' FROM customers ORDER BY LastName, FirstName"
 
   # regex operators: "~" (contains pattern, case-sensitive); "~*" (contains pattern, case-insensitive)
   #   "!~" (does not contain pattern, case-sensitive); "!~*" (does not contain pattern, case-insensitive)
-   qsv sqlp data.csv "select * from data WHERE col1 ~ '^foo' AND col2 > 10"
-   qsv sqlp data.csv "select * from data WHERE col1 !~* 'bar$' AND col2 > 10"
+  $ qsv sqlp data.csv "select * from data WHERE col1 ~ '^foo' AND col2 > 10"
+  $ qsv sqlp data.csv "select * from data WHERE col1 !~* 'bar$' AND col2 > 10"
 
   # regexp_like function: regexp_like(<string>, <pattern>, <optional flags>)
   # returns true if <string> matches <pattern>, false otherwise
   #   <optional flags> can be one or more of the following:
   #   'c' (case-sensitive - default), 'i' (case-insensitive), 'm' (multiline)
-   qsv sqlp data.csv "select * from data WHERE regexp_like(col1, '^foo') AND col2 > 10"
+  $ qsv sqlp data.csv "select * from data WHERE regexp_like(col1, '^foo') AND col2 > 10"
   # case-insensitive regexp_like
-   qsv sqlp data.csv "select * from data WHERE regexp_like(col1, '^foo', 'i') AND col2 > 10"
+  $ qsv sqlp data.csv "select * from data WHERE regexp_like(col1, '^foo', 'i') AND col2 > 10"
 
   # regexp match using a literal pattern
-   qsv sqlp data.csv "select idx,val from data WHERE val regexp '^foo'"
+  $ qsv sqlp data.csv "select idx,val from data WHERE val regexp '^foo'"
 
   # regexp match using patterns from another column
-   qsv sqlp data.csv "select idx,val from data WHERE val regexp pattern_col"
+  $ qsv sqlp data.csv "select idx,val from data WHERE val regexp pattern_col"
 
   # use Parquet, JSONL and Arrow files in SQL queries
-   qsv sqlp data.csv "select * from data join read_parquet('data2.parquet') as t2 ON data.c1 = t2.c1"
-   qsv sqlp data.csv "select * from data join read_ndjson('data2.jsonl') as t2 on data.c1 = t2.c1"
-   qsv sqlp data.csv "select * from data join read_ipc('data2.arrow') as t2 ON data.c1 = t2.c1"
-   qsv sqlp SKIP_INPUT "select * from read_parquet('data.parquet') order by col1 desc limit 100"
-   qsv sqlp SKIP_INPUT "select * from read_ndjson('data.jsonl') as t1 join read_ipc('data.arrow') as t2 on t1.c1 = t2.c1" 
+  $ qsv sqlp data.csv "select * from data join read_parquet('data2.parquet') as t2 ON data.c1 = t2.c1"
+  $ qsv sqlp data.csv "select * from data join read_ndjson('data2.jsonl') as t2 on data.c1 = t2.c1"
+  $ qsv sqlp data.csv "select * from data join read_ipc('data2.arrow') as t2 ON data.c1 = t2.c1"
+  $ qsv sqlp SKIP_INPUT "select * from read_parquet('data.parquet') order by col1 desc limit 100"
+  $ qsv sqlp SKIP_INPUT "select * from read_ndjson('data.jsonl') as t1 join read_ipc('data.arrow') as t2 on t1.c1 = t2.c1"
 
   # you can also directly load CSVs using the Polars read_csv() SQL function. This is useful when
   # you want to bypass the regular CSV parser (with SKIP_INPUT) and use Polars' multithreaded,
   # mem-mapped CSV parser instead - making for dramatically faster queries at the cost of CSV parser
   # configurability (i.e. limited to comma delimiter, no CSV comments, etc.).
-   qsv sqlp SKIP_INPUT "select * from read_csv('data.csv') order by col1 desc limit 100"
+  $ qsv sqlp SKIP_INPUT "select * from read_csv('data.csv') order by col1 desc limit 100"
 
-   # note that you can also use read_csv() to read compressed files directly
-   # gzip, zstd and zlib automatic decompression are supported
-   qsv sqlp SKIP_INPUT "select * from read_csv('data.csv.gz')"
-   qsv sqlp SKIP_INPUT "select * from read_csv('data.csv.zst')"
-   qsv sqlp SKIP_INPUT "select * from read_csv('data.csv.zlib')"
+  # note that you can also use read_csv() to read compressed files directly
+  # gzip, zstd and zlib automatic decompression are supported
+  $ qsv sqlp SKIP_INPUT "select * from read_csv('data.csv.gz')"
+  $ qsv sqlp SKIP_INPUT "select * from read_csv('data.csv.zst')"
+  $ qsv sqlp SKIP_INPUT "select * from read_csv('data.csv.zlib')"
 
   # apart from using Polar's table functions, you can also use SKIP_INPUT when the SELECT
   # statement doesn't require an input file
-   qsv sqlp SKIP_INPUT "SELECT 1 AS one, '2' AS two, 3.0 AS three"
+  $ qsv sqlp SKIP_INPUT "SELECT 1 AS one, '2' AS two, 3.0 AS three"
 
   # use stdin as input
-   cat data.csv | qsv sqlp - 'select * from stdin'
-   cat data.csv | qsv sqlp - data2.csv 'select * from stdin join data2 on stdin.col1 = data2.col1'
+  $ cat data.csv | qsv sqlp - 'select * from stdin'
+  $ cat data.csv | qsv sqlp - data2.csv 'select * from stdin join data2 on stdin.col1 = data2.col1'
 
   # automatic snappy decompression/compression
-   qsv sqlp data.csv.sz 'select * from data where col1 > 10' --output result.csv.sz
+  $ qsv sqlp data.csv.sz 'select * from data where col1 > 10' --output result.csv.sz
 
   # explain query plan
-   qsv sqlp data.csv 'explain select * from data where col1 > 10 order by col2 desc limit 20'
+  $ qsv sqlp data.csv 'explain select * from data where col1 > 10 order by col2 desc limit 20'
 
 For more examples, see https://github.com/dathere/qsv/blob/master/tests/test_sqlp.rs.
 
@@ -198,8 +198,8 @@ sqlp options:
                               Polars "table" with the same file stem.
                               If specified and the schema file/s do not exist, it will check if a
                               stats cache is available. If so, it will use it to derive a Polars schema
-                              and save it. If there's no stats cache, it will infer the schema 
-                              using --infer-len and save the inferred schemas. 
+                              and save it. If there's no stats cache, it will infer the schema
+                              using --infer-len and save the inferred schemas.
                               Each schema file will have the same file stem as the corresponding
                               input file, with the extension ".pschema.json"
                               (data.csv's Polars schema file will be data.pschema.json)
@@ -212,7 +212,7 @@ sqlp options:
                               The valid types are: `Boolean`, `UInt8`, `UInt16`, `UInt32`, `UInt64`, `Int8`,
                               `Int16`, `Int32`, `Int64`, `Float32`, `Float64`, `String`, `Date`, `Datetime`,
                               `Duration`, `Time`, `Null`, `Categorical`, `Decimal` and `Enum`.
-                              
+
     --streaming               Use streaming mode when parsing CSVs. This will use less memory
                               but will be slower. Only use this when you get out of memory errors.
     --low-memory              Use low memory mode when parsing CSVs. This will use less memory
@@ -265,7 +265,7 @@ sqlp options:
                               Higher compression levels are slower.
                               The zstd default is 3, and the gzip default is 6.
     --statistics              Compute column statistics when writing parquet files.
-    
+
 Common options:
     -h, --help             Display this message
     -o, --output <file>    Write output to <file> instead of stdout.

--- a/src/cmd/sqlp.rs
+++ b/src/cmd/sqlp.rs
@@ -90,7 +90,7 @@ Example queries:
   # if customers.csv has columns LastName, FirstName, Address, City, State, Zip
   # this query will return all columns for all rows except the columns that don't
   # contain 'a' followed by an 'e' - i.e. except City and Zip
-  $  qsv sqlp customers.csv "SELECT * ILIKE '%a%e%' FROM customers ORDER BY LastName, FirstName"
+  $ qsv sqlp customers.csv "SELECT * ILIKE '%a%e%' FROM customers ORDER BY LastName, FirstName"
 
   # regex operators: "~" (contains pattern, case-sensitive); "~*" (contains pattern, case-insensitive)
   #   "!~" (does not contain pattern, case-sensitive); "!~*" (does not contain pattern, case-insensitive)

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -13,7 +13,7 @@ variation (CV), nullcount, max_precision, sparsity, Median Absolute Deviation (M
 interquartile range (IQR), lower/upper fences, skewness, median, cardinality/uniqueness ratio,
 mode/s & "antimode/s" & percentiles.
 
-Note that some stats require loading the entire file into memory, so they must be enabled explicitly. 
+Note that some stats require loading the entire file into memory, so they must be enabled explicitly.
 
 By default, the following "streaming" statistics are reported for *every* column:
   sum, min/max/range values, sort order/sortiness, min/max/sum/avg/stddev/variance/cv length, mean, sem,
@@ -48,11 +48,11 @@ For String data types, it also determines if the column is all ASCII characters.
 Unlike the sniff command, stats' data type inferences are GUARANTEED, as the entire file
 is scanned, and not just sampled.
 
-Note that the Date and DateTime data types are only inferred with the --infer-dates option 
+Note that the Date and DateTime data types are only inferred with the --infer-dates option
 as its an expensive operation to match a date candidate against 19 possible date formats,
 with each format, having several variants.
 
-The date formats recognized and its sub-variants along with examples can be found at 
+The date formats recognized and its sub-variants along with examples can be found at
 https://github.com/dathere/qsv-dateparser?tab=readme-ov-file#accepted-date-formats.
 
 Computing statistics on a large file can be made MUCH faster if you create an index for it
@@ -71,56 +71,56 @@ hasn't changed, the stats will be loaded from the cache instead of recomputing i
 These cached stats are also used by other qsv commands (currently `describegpt`, `frequency`,
 `joinp`, `pivotp`, `schema`, `sqlp` & `tojsonl`) to work smarter & faster.
 If the cached stats are not current (i.e., the input file is newer than the cached stats),
-the cached stats will be ignored and recomputed. For example, see the "boston311" test files in 
+the cached stats will be ignored and recomputed. For example, see the "boston311" test files in
 https://github.com/dathere/qsv/blob/4529d51273218347fef6aca15ac24e22b85b2ec4/tests/test_stats.rs#L608.
 
 Examples:
 
 Compute "streaming" statistics for the "nyc311.csv" file:
-   $ qsv stats nyc311.csv
+  $ qsv stats nyc311.csv
 
 Compute all statistics for the "nyc311.csv" file:
-    $ qsv stats --everything nyc311.csv
-    $ qsv stats -E nyc311.csv
+  $ qsv stats --everything nyc311.csv
+  $ qsv stats -E nyc311.csv
 
 Compute all statistics for "nyc311.csv", inferring dates using default date column name patterns:
-    $ qsv stats -E --infer-dates nyc311.csv
+  $ qsv stats -E --infer-dates nyc311.csv
 
 Compute all statistics for "nyc311.csv", inferring dates only for columns with "_date" & "_dte"
 in the column names:
-    $ qsv stats -E --infer-dates --dates-whitelist _date,_dte nyc311.csv
+  $ qsv stats -E --infer-dates --dates-whitelist _date,_dte nyc311.csv
 
 In addition, also infer boolean data types for "nyc311.csv" file:
-    $ qsv stats -E --infer-dates --dates-whitelist _date --infer-boolean nyc311.csv
+  $ qsv stats -E --infer-dates --dates-whitelist _date --infer-boolean nyc311.csv
 
 In addition to basic "streaming" stats, also compute cardinality for the "nyc311.csv" file:
-    $ qsv stats --cardinality nyc311.csv
+  $ qsv stats --cardinality nyc311.csv
 
 Prefer DMY format when inferring dates for the "nyc311.csv" file:
-    $ qsv stats -E --infer-dates --prefer-dmy nyc311.csv    
+  $ qsv stats -E --infer-dates --prefer-dmy nyc311.csv
 
 Infer data types only for the "nyc311.csv" file:
-    $ qsv stats --typesonly nyc311.csv
+  $ qsv stats --typesonly nyc311.csv
 
 Infer data types only, including boolean and date types for the "nyc311.csv" file:
-    $ qsv stats --typesonly --infer-boolean --infer-dates nyc311.csv
+  $ qsv stats --typesonly --infer-boolean --infer-dates nyc311.csv
 
 Automatically create an index for the "nyc311.csv" file to enable multithreading
 if it's larger than 5MB and there is no existing index file:
-    $ qsv stats -E --cache-threshold -5000000 nyc311.csv
+  $ qsv stats -E --cache-threshold -5000000 nyc311.csv
 
 Auto-create a TEMPORARY index for the "nyc311.csv" file to enable multithreading
 if it's larger than 5MB and delete the index and the stats cache file after the stats run:
-    $ qsv stats -E --cache-threshold -5000005 nyc311.csv
+  $ qsv stats -E --cache-threshold -5000005 nyc311.csv
 
 Prompt for CSV/TSV/TAB file to compute stats for:
-    $ qsv prompt -F tsv,csv,tab | qsv stats -E | qsv table
+  $ qsv prompt -F tsv,csv,tab | qsv stats -E | qsv table
 
 Prompt for a file to save the stats to in the ~/Documents directory:
-    $ qsv stats -E nyc311.csv | qsv prompt -d ~/Documents --fd-output
+  $ qsv stats -E nyc311.csv | qsv prompt -d ~/Documents --fd-output
 
 Prompt for both INPUT and OUTPUT files in the ~/Documents dir with custom prompts:
-    $ qsv prompt -m 'Select a CSV file to summarize' -d ~/Documents -F csv | \
+  $ qsv prompt -m 'Select a CSV file to summarize' -d ~/Documents -F csv | \
       qsv stats -E --infer-dates | \
       qsv prompt -m 'Save summary to...' -d ~/Documents --fd-output --save-fname summarystats.csv
 
@@ -204,7 +204,7 @@ stats options:
                               are date/datetime fields.
                               Also, if timezone is not specified in the data, it'll
                               be set to UTC.
-    --dates-whitelist <list>  The comma-separated, case-insensitive patterns to look for when 
+    --dates-whitelist <list>  The comma-separated, case-insensitive patterns to look for when
                               shortlisting fields for date inferencing.
                               i.e. if the field's name has any of these patterns,
                               it is shortlisted for date inferencing.
@@ -216,7 +216,7 @@ stats options:
                               Be sure to only use "all" if you know ALL the columns you're
                               inspecting are dates, boolean or string fields.
 
-                              To avoid false positives, preprocess the file first 
+                              To avoid false positives, preprocess the file first
                               with the `datefmt` command to convert unix epoch timestamp
                               columns to RFC3339 format.
                               [default: date,time,due,open,close,created]
@@ -230,7 +230,7 @@ stats options:
                               Note that a file handle is opened for each job.
                               When not set, the number of jobs is set to the
                               number of CPUs detected.
-    --stats-jsonl             Also write the stats in JSONL format. 
+    --stats-jsonl             Also write the stats in JSONL format.
                               If set, the stats will be written to <FILESTEM>.stats.csv.data.jsonl.
                               Note that this option used internally by other qsv "smart" commands (see
                               https://github.com/dathere/qsv/blob/master/docs/PERFORMANCE.md#stats-cache)
@@ -241,7 +241,7 @@ stats options:
                                 - when greater than 1, the threshold in milliseconds before caching
                                   stats results. If a stats run takes longer than this threshold,
                                   the stats results will be cached.
-                                - 0 to suppress caching. 
+                                - 0 to suppress caching.
                                 - 1 to force caching.
                                 - a negative number to automatically create an index when
                                   the input file size is greater than abs(arg) in bytes.

--- a/src/cmd/template.rs
+++ b/src/cmd/template.rs
@@ -6,14 +6,14 @@ This command processes each row of the CSV file, making the column values availa
 Each row is rendered using the template. Column headers become variable names, with non-alphanumeric
 characters converted to underscore (_).
 
-Templates use Jinja2 syntax (https://jinja.palletsprojects.com/en/stable/templates/) 
+Templates use Jinja2 syntax (https://jinja.palletsprojects.com/en/stable/templates/)
 and can access an extensive library of built-in filters/functions, with additional ones
 from minijinja_contrib https://docs.rs/minijinja-contrib/latest/minijinja_contrib/.
 Additional qsv custom filters are also documented at the end of this file.
 
 If the <outdir> argument is specified, it will create a file for each row in <outdir>, with
 the filename rendered using --outfilename option.
-Otherwise, ALL the rendered rows will be sent to STDOUT or the designated --output. 
+Otherwise, ALL the rendered rows will be sent to STDOUT or the designated --output.
 
 Example:
 data.csv:
@@ -49,7 +49,7 @@ template.tpl
     {% endif %}
     Status: {% if active|to_bool %}Active{% else %}Inactive{% endif %}
 
-qsv template --template-file template.tpl data.csv
+  $ qsv template --template-file template.tpl data.csv
 
 For more examples, see https://github.com/dathere/qsv/blob/master/tests/test_template.rs.
 For a relatively complex MiniJinja template, see https://github.com/dathere/qsv/blob/master/scripts/template.tpl
@@ -78,7 +78,7 @@ template options:
                                 The JSON properties can be accessed in templates using the "qsv_g"
                                 namespace (e.g. {{qsv_g.school_name}}, {{qsv_g.year}}).
                                 This allows sharing common values across all template renders.
-    --outfilename <str>         MiniJinja template string to use to create the filename of the output 
+    --outfilename <str>         MiniJinja template string to use to create the filename of the output
                                 files to write to <outdir>. If set to just QSV_ROWNO, the filestem
                                 is set to the current rowno of the record, padded with leading
                                 zeroes, with the ".txt" extension (e.g. 001.txt, 002.txt, etc.)

--- a/src/cmd/to.rs
+++ b/src/cmd/to.rs
@@ -69,7 +69,7 @@ Load all files in dir1 to sqlite database `test.db`
 
 Load files listed in the 'mydata.infile-list' to sqlite database `test.db`
 
-    $ qsv to sqlite test.db mydata.infile-list
+  $ qsv to sqlite test.db mydata.infile-list
 
 Drop tables if they exist before loading.
 
@@ -103,11 +103,11 @@ filename without the extension. Note the `output.xlsx` will be overwritten if it
 
 Load all files in dir1 into xlsx file.
 
-    $ qsv to xlsx output.xlsx dir1
+  $ qsv to xlsx output.xlsx dir1
 
 Load files listed in the 'ourdata.infile-list' into xlsx file.
 
-    $ qsv to xlsx output.xlsx ourdata.infile-list
+  $ qsv to xlsx output.xlsx ourdata.infile-list
 
 ODS
 ===
@@ -123,11 +123,11 @@ filename without the extension. Note the `output.ods` will be overwritten if it 
 
 Load all files in dir1 into ODS file.
 
-    $ qsv to ods output.ods dir1
+  $ qsv to ods output.ods dir1
 
 Load files listed in the 'ourdata.infile-list' into ODS file.
 
-    $ qsv to ods output.ods ourdata.infile-list
+  $ qsv to ods output.ods ourdata.infile-list
 
 PARQUET
 =======
@@ -142,20 +142,20 @@ Examples:
 
 Convert `file1.csv` and `file2.csv' into `mydir/file1.parquet` and `mydir/file2.parquet` files.
 
-    $ qsv to parquet mydir file1.csv file2.csv
+  $ qsv to parquet mydir file1.csv file2.csv
 
 Convert from stdin.
 
-    $ qsv to parquet --pipe mydir -
+  $ qsv to parquet --pipe mydir -
 
 Convert all files in dir1 into parquet files in myparquetdir.
 
-    $ qsv to parquet myparquetdir dir1
+  $ qsv to parquet myparquetdir dir1
 
 Convert files listed in the 'data.infile-list' into parquet files in myparquetdir.
-    
-        $ qsv to parquet myparquetdir data.infile-list
-        
+
+  $ qsv to parquet myparquetdir data.infile-list
+
 DATA PACKAGE
 ============
 Generate a datapackage, which contains stats and information about what is in the CSV files.
@@ -176,7 +176,7 @@ Generate a `datapackage.json` file from all the files in dir1
 
 Generate a `datapackage.json` file from all the files listed in the 'data.infile-list'
 
-    $ qsv to datapackage datapackage.json data.infile-list
+  $ qsv to datapackage datapackage.json data.infile-list
 
 For all other conversions you can output the datapackage created by specifying `--print-package`.
 
@@ -208,7 +208,7 @@ To options:
     -A --all-strings       Convert all fields to strings.
     -j, --jobs <arg>       The number of jobs to run in parallel.
                            When not set, the number of jobs is set to the number of CPUs detected.
-                           
+
 Common options:
     -h, --help             Display this message
     -d, --delimiter <arg>  The field delimiter for reading CSV data.

--- a/src/cmd/validate.rs
+++ b/src/cmd/validate.rs
@@ -22,13 +22,13 @@ It uses the JSON Schema Validation Specification (draft 2020-12) to validate the
 It validates the structure of the file, as well as the data types and domain/range of the fields.
 See https://json-schema.org/draft/2020-12/json-schema-validation.html
 
-qsv supports a custom format - `currency`. This format will only accept a valid currency, defined as: 
+qsv supports a custom format - `currency`. This format will only accept a valid currency, defined as:
 
  1. ISO Currency Symbol (optional): This is the ISO 4217 three-character code or currency symbol
     (e.g. USD, EUR, JPY, $, €, ¥, etc.)
  2. Amount: This is the numerical value of the currency. More than 2 decimal places are allowed.
  3. Formats: Valid currency formats include:
-      Standard: $1,000.00 or USD1000.00  
+      Standard: $1,000.00 or USD1000.00
       Negative amounts: ($100.00) or -$100.00
       Different styles: 1.000,00 (used in some countries for euros)
 
@@ -58,7 +58,7 @@ The "dynamicEnum" value has the form:
   // on other qsv binary variants, dynamicEnum has expanded caching functionality
   dynamicEnum = "[cache_name;cache_age]|URI|colname" where cache_name and cache_age are optional
 
-    // use data.csv from current working directory; cache it as data with a default 
+    // use data.csv from current working directory; cache it as data with a default
     // cache age of 3600 seconds i.e. the cached data.csv expires after 1 hour
     dynamicEnum = "data.csv"
 
@@ -105,7 +105,7 @@ which columns had duplicate combinations (named columns first, then indexed colu
 records will be written to the .invalid file, while valid records will be written to the .valid file.
 
 `uniqueCombinedWith` complements the standard `uniqueItems` keyword, which can only validate
-uniqueness across a single column. 
+uniqueness across a single column.
 
 -------------------------------------------------------
 
@@ -115,14 +115,14 @@ files that have the same structure.
 
 Be sure to select a "training" CSV file that is representative of the data you want to validate
 when creating a schema. The data types, domain/range and regular expressions inferred from the
-reference CSV file should be appropriate for the data you want to validate. 
+reference CSV file should be appropriate for the data you want to validate.
 
 Typically, after creating a schema, you should edit it to fine-tune each field's inferred
 validation rules.
 
 For example, if we created a JSON schema file called "reference.schema.json" using the `schema` command.
 And want to validate "mydata.csv" which we know has validation errors, the output files from running
-`qsv validate mydata.csv reference.schema.json` are: 
+`qsv validate mydata.csv reference.schema.json` are:
 
   * mydata.csv.valid
   * mydata.csv.invalid
@@ -212,7 +212,7 @@ Validate options:
     --dfa-size-limit <mb>      Set the approximate capacity, in megabytes, of the cache of transitions
                                used by the engine's lazy Discrete Finite Automata.
                                [default: 10]
-    
+
     --timeout <seconds>        Timeout for downloading json-schemas on URLs and for
                                'dynamicEnum' lookups on URLs. [default: 30]
     --cache-dir <dir>          The directory to use for caching downloaded dynamicEnum resources.


### PR DESCRIPTION
This PR standardizes the formatting of command examples in the CLI help documentation:

* Consistent `$` prefix: All command examples now start with `$` (common convention for terminal commands).
* Fixed indentation: Examples now use 2-space indentation uniformly.
* Removed trailing whitespace: Cleaned up invisible formatting noise in the help text.