### PR TITLE
feat: add CPU-accelerated, mem-mapped, chunked sha256 file checksum helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5783,7 +5783,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "serial_test",
- "sha256",
+ "sha2",
  "simd-json",
  "simdutf8",
  "sled",
@@ -6953,19 +6953,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
-]
-
-[[package]]
-name = "sha256"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f880fc8562bdeb709793f00eb42a2ad0e672c4f883bbe59122b926eca935c8f6"
-dependencies = [
- "async-trait",
- "bytes",
- "hex",
- "sha2",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -248,7 +248,7 @@ rfd = { version = "0.15", optional = true }
 rust_decimal = { version = "1.37", default-features = false }
 ryu = "1"
 sanitize-filename = { version = "0.6", optional = true }
-sha256 = "1.5"
+sha2 = "0.10"
 simd-json = "0.15"
 self_update = { version = "0.42", features = [
     "archive-zip",

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -306,6 +306,7 @@ use itertools::Itertools;
 use phf::phf_map;
 use qsv_dateparser::parse_with_preference;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use simd_json::{OwnedValue, prelude::ValueAsScalar};
 use smallvec::SmallVec;
 use stats::{Commute, MinMax, OnlineStats, Unsorted, merge_all};
@@ -1172,7 +1173,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                         format!("{record_count}\x1F{ds_column_count}\x1F{ds_filesize_bytes}\n")
                             .as_bytes(),
                     );
-                    sha256::digest(hash_input.as_slice())
+                    Sha256::digest(hash_input.as_slice())
                 };
 
                 dataset_stats_br.clear();
@@ -1182,7 +1183,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                     dataset_stats_br.push_field(b"");
                 }
                 // write qsv__value as last column
-                dataset_stats_br.push_field(stats_hash.as_bytes());
+                dataset_stats_br.push_field(format!("{stats_hash:x}").as_bytes());
                 wtr.write_byte_record(&dataset_stats_br)?;
             }
 


### PR DESCRIPTION
Should allow us to compute sha256 checksum required by both DCAT3 and Croissant very quickly (10 gb in ~3 seconds), even for larger than memory files.

For use by `describegpt` as well when analyzing datasets to ensure they've been unchanged and the cached metadata is still valid.

resolves #2828