### PR TITLE
chore: `python` replace deprecated `with_gil` with `attach`

### DIFF
--- a/src/cmd/python.rs
+++ b/src/cmd/python.rs
@@ -199,7 +199,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let debug_flag = log::log_enabled!(log::Level::Debug);
 
     if debug_flag {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let msg = format!("Detected Python={}", py.version());
             winfo!("{msg}");
         });
@@ -320,7 +320,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             break 'batch_loop;
         }
 
-        Python::with_gil(|py| -> PyResult<()> {
+        Python::attach(|py| -> PyResult<()> {
             let batch_ref = &mut batch;
             let helpers =
                 PyModule::from_code(py, &helpers_code, &helpers_filename, &helpers_module_name)?;

--- a/src/util.rs
+++ b/src/util.rs
@@ -472,7 +472,7 @@ pub fn version() -> String {
     #[cfg(all(feature = "python", not(feature = "lite")))]
     {
         enabled_features.push_str("python-");
-        pyo3::Python::with_gil(|py| {
+        pyo3::Python::attach(|py| {
             enabled_features.push_str(py.version());
             enabled_features.push(';');
         });


### PR DESCRIPTION
free-threading python v3.14 support, here we come!