### PR TITLE
Revert "feat: `table` add `--in-place` option"

### DIFF
--- a/src/cmd/table.rs
+++ b/src/cmd/table.rs
@@ -23,8 +23,6 @@ table options:
                            specified. If the field is UTF-8 encoded, then
                            <arg> refers to the number of code points.
                            Otherwise, it refers to the number of bytes.
-    -i, --in-place         Overwrite the input file data with the output.
-                           The input file is renamed to a .bak file in the same directory.
 
 Common options:
     -h, --help             Display this message
@@ -56,7 +54,6 @@ struct Args {
     flag_align:     Align,
     flag_condense:  Option<usize>,
     flag_memcheck:  bool,
-    flag_in_place:  bool,
 }
 
 #[derive(Deserialize, Clone, Copy)]
@@ -88,67 +85,22 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         util::mem_file_check(&path, false, args.flag_memcheck)?;
     }
 
-    if args.flag_in_place {
-        // in-place is not valid with stdin
-        if rconfig.is_stdin() {
-            return fail_clierror!("--in-place is not valid with stdin.");
-        }
+    let wconfig = Config::new(args.flag_output.as_ref()).delimiter(Some(Delimiter(b'\t')));
 
-        let wconfig = Config::new(None).delimiter(Some(Delimiter(b'\t')));
-        let mut tempfile = tempfile::NamedTempFile::new()?;
-        let tw = TabWriter::new(Box::new(tempfile.as_file_mut()) as Box<dyn std::io::Write>)
-            .minwidth(args.flag_width)
-            .padding(args.flag_pad)
-            .alignment(args.flag_align.into());
-        let mut wtr = wconfig.from_writer(tw);
-        let mut rdr = rconfig.reader()?;
+    let tw = TabWriter::new(wconfig.io_writer()?)
+        .minwidth(args.flag_width)
+        .padding(args.flag_pad)
+        .alignment(args.flag_align.into());
+    let mut wtr = wconfig.from_writer(tw);
+    let mut rdr = rconfig.reader()?;
 
-        let mut record = csv::ByteRecord::new();
-        while rdr.read_byte_record(&mut record)? {
-            wtr.write_record(
-                record
-                    .iter()
-                    .map(|f| util::condense(Cow::Borrowed(f), args.flag_condense)),
-            )?;
-        }
-        wtr.flush()?;
-        drop(wtr);
-
-        if let Some(input_path_string) = args.arg_input {
-            let input_path = std::path::Path::new(&input_path_string);
-            let backup_path = if let Some(input_extension_osstr) = input_path.extension() {
-                // If the file has an extension, append ".bak" to the extension
-                let mut backup_extension = input_extension_osstr.to_string_lossy().to_string();
-                backup_extension.push_str(".bak");
-                input_path.with_extension(backup_extension)
-            } else {
-                // If the file has no extension, append ".bak" to the filename
-                // safety: we know the path has a filename
-                let mut backup_osstring = input_path.file_name().unwrap().to_os_string();
-                backup_osstring.push(".bak");
-                input_path.with_file_name(backup_osstring)
-            };
-            std::fs::rename(input_path, &backup_path)?;
-            std::fs::copy(tempfile.path(), input_path)?;
-        }
-    } else {
-        let wconfig = Config::new(args.flag_output.as_ref()).delimiter(Some(Delimiter(b'\t')));
-        let tw = TabWriter::new(wconfig.io_writer()?)
-            .minwidth(args.flag_width)
-            .padding(args.flag_pad)
-            .alignment(args.flag_align.into());
-        let mut wtr = wconfig.from_writer(tw);
-        let mut rdr = rconfig.reader()?;
-
-        let mut record = csv::ByteRecord::new();
-        while rdr.read_byte_record(&mut record)? {
-            wtr.write_record(
-                record
-                    .iter()
-                    .map(|f| util::condense(Cow::Borrowed(f), args.flag_condense)),
-            )?;
-        }
-        wtr.flush()?;
+    let mut record = csv::ByteRecord::new();
+    while rdr.read_byte_record(&mut record)? {
+        wtr.write_record(
+            record
+                .iter()
+                .map(|f| util::condense(Cow::Borrowed(f), args.flag_condense)),
+        )?;
     }
-    Ok(())
+    Ok(wtr.flush()?)
 }

--- a/tests/test_table.rs
+++ b/tests/test_table.rs
@@ -142,22 +142,3 @@ fn table_center_align() {
         concat!("  h1     h2   h3\n", "abcdefg   a   a\n", "   a     abc  z",)
     );
 }
-
-#[test]
-fn table_in_place_issue_2980() {
-    let wrk = Workdir::new("table_in_place");
-    wrk.create("in.csv", data());
-
-    let mut cmd = wrk.command("table");
-    cmd.arg("--in-place");
-    cmd.arg("in.csv");
-
-    wrk.assert_success(&mut cmd);
-
-    // Check that the original file was backed up
-    assert!(wrk.path("in.csv.bak").exists());
-
-    // Check that the formatted content was written to the original file
-    let got: String = std::fs::read_to_string(wrk.path("in.csv")).unwrap();
-    assert_eq!(&*got, format!("{}\n", EXPECTED_TABLE));
-}


### PR DESCRIPTION
Reverts dathere/qsv#2984

Mea culpa... `table` was never meant as a converter. It was primarily meant for display output.