### PR TITLE
deps: replace tabwriter with renamed fork qsv-tabwriter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5906,9 +5906,9 @@ dependencies = [
 
 [[package]]
 name = "qsv-sniffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f04a9bb42ded5cd64a95dfcd3299c5d1ad7f3124b997e19c1d51a302f3d4306"
+checksum = "42d52719863e23a4eeb2a1deeb277565096295f5138c239c065c28db33dbf97d"
 dependencies = [
  "bitflags 2.9.4",
  "bytecount",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5906,9 +5906,9 @@ dependencies = [
 
 [[package]]
 name = "qsv-sniffer"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d52719863e23a4eeb2a1deeb277565096295f5138c239c065c28db33dbf97d"
+checksum = "a78937b2f303e65f6729979c37b5b544086121fcf482468fd38ba11f617ed0bb"
 dependencies = [
  "bitflags 2.9.4",
  "bytecount",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3611,9 +3611,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.80"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852f13bec5eba4ba9afbeb93fd7c13fe56147f055939ae21c43a29a0ecb2702e"
+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -5846,6 +5846,7 @@ dependencies = [
  "qsv-dateparser",
  "qsv-sniffer",
  "qsv-stats",
+ "qsv-tabwriter",
  "qsv_currency",
  "qsv_docopt",
  "qsv_vader_sentiment_analysis",
@@ -5877,7 +5878,6 @@ dependencies = [
  "strum 0.27.2",
  "strum_macros 0.27.2",
  "sysinfo",
- "tabwriter",
  "tempfile",
  "thousands",
  "threadpool",
@@ -5906,9 +5906,9 @@ dependencies = [
 
 [[package]]
 name = "qsv-sniffer"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b25b79fc637d5ec0a9d72612207f48676b39c8b5c48ab32cfa0d47915fd664a"
+checksum = "9f04a9bb42ded5cd64a95dfcd3299c5d1ad7f3124b997e19c1d51a302f3d4306"
 dependencies = [
  "bitflags 2.9.4",
  "bytecount",
@@ -5917,9 +5917,9 @@ dependencies = [
  "hashbrown 0.15.5",
  "memchr",
  "qsv-dateparser",
+ "qsv-tabwriter",
  "regex",
  "simdutf8",
- "tabwriter",
 ]
 
 [[package]]
@@ -5932,6 +5932,15 @@ dependencies = [
  "num-traits",
  "rayon",
  "serde",
+]
+
+[[package]]
+name = "qsv-tabwriter"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54463b66af16cc13ab644a864ca4f6972e7d612317d64caf4a30867f12637e50"
+dependencies = [
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -7514,14 +7523,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tabwriter"
-version = "1.4.1"
-source = "git+https://github.com/jqnatividad/tabwriter?rev=139deee#139deeed1530855a4ad0702f553220984b2eee10"
-dependencies = [
- "unicode-width 0.2.0",
-]
-
-[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8363,9 +8364,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.103"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab10a69fbd0a177f5f649ad4d8d3305499c42bab9aef2f7ff592d0ec8f833819"
+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -8376,9 +8377,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.103"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb702423545a6007bbc368fde243ba47ca275e549c8a28617f56f6ba53b1d1c"
+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
 dependencies = [
  "bumpalo",
  "log",
@@ -8390,9 +8391,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.53"
+version = "0.4.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b221ff421256839509adbb55998214a70d829d3a28c69b4a6672e9d2a42f67"
+checksum = "7e038d41e478cc73bae0ff9b36c60cff1c98b8f38f8d7e8061e79ee63608ac5c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -8403,9 +8404,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.103"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc65f4f411d91494355917b605e1480033152658d71f722a90647f56a70c88a0"
+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8413,9 +8414,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.103"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc003a991398a8ee604a401e194b6b3a39677b3173d6e74495eb51b82e99a32"
+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8426,9 +8427,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.103"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "293c37f4efa430ca14db3721dfbe48d8c33308096bd44d80ebaa775ab71ba1cf"
+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
 dependencies = [
  "unicode-ident",
 ]
@@ -8521,9 +8522,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.80"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbe734895e869dc429d78c4b433f8d17d95f8d05317440b4fad5ab2d33e596dc"
+checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -216,9 +216,10 @@ qsv-dateparser = "0.13"
 qsv_docopt = "1.8"
 qsv-stats = "0.38"
 qsv_currency = "0.7"
-qsv-sniffer = { version = "0.11", default-features = false, features = [
+qsv-sniffer = { version = "0.12", default-features = false, features = [
     "runtime-dispatch-simd",
 ] }
+qsv-tabwriter = "2"
 qsv_vader_sentiment_analysis = { version = "0.2", optional = true }
 rand = "0.9"
 rand_hc = "0.4"
@@ -265,7 +266,6 @@ strsim = { version = "0.11", optional = true }
 strum = { version = "0.27", features = ["phf"] }
 strum_macros = "0.27"
 sysinfo = "0.37"
-tabwriter = "1.4"
 tempfile = "3.23"
 thousands = { version = "0.2", optional = true }
 tikv-jemallocator = { version = "0.6", optional = true }
@@ -336,9 +336,6 @@ self_update = { git = "https://github.com/jqnatividad/self_update", branch = "bu
 
 # use our patched fork of sled to get rid of unmaintained instant
 sled = { git = "https://github.com/dathere/sled", branch = "v0.34.7-bumped-parking_lot_to_0.12" }
-
-# use our patched fork of tabwriter with LeftEndTab and LeftFwf alignment support
-tabwriter = { git = "https://github.com/jqnatividad/tabwriter", rev = "139deee" }
 
 # use upstream of time crate with unreleased fix that reverts perf regression in 0.3.43 release
 # see https://github.com/time-rs/time/issues/750

--- a/src/cmd/flatten.rs
+++ b/src/cmd/flatten.rs
@@ -39,8 +39,8 @@ use std::{
     io::{self, BufWriter, Write},
 };
 
+use qsv_tabwriter::TabWriter;
 use serde::Deserialize;
-use tabwriter::TabWriter;
 
 use crate::{
     CliResult,

--- a/src/cmd/headers.rs
+++ b/src/cmd/headers.rs
@@ -39,8 +39,8 @@ Common options:
 
 use std::{io, path::PathBuf};
 
+use qsv_tabwriter::TabWriter;
 use serde::Deserialize;
-use tabwriter::TabWriter;
 
 use crate::{CliResult, config::Delimiter, util};
 

--- a/src/cmd/sniff.rs
+++ b/src/cmd/sniff.rs
@@ -116,9 +116,9 @@ use indicatif::HumanCount;
 #[cfg(any(feature = "feature_capable", feature = "lite"))]
 use indicatif::{HumanBytes, ProgressBar, ProgressDrawTarget, ProgressStyle};
 use qsv_sniffer::{DatePreference, SampleSize, Sniffer};
+use qsv_tabwriter::TabWriter;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use tabwriter::TabWriter;
 use tempfile::NamedTempFile;
 use url::Url;
 

--- a/src/cmd/table.rs
+++ b/src/cmd/table.rs
@@ -50,8 +50,8 @@ Common options:
 
 use std::borrow::Cow;
 
+use qsv_tabwriter::{Alignment, TabWriter};
 use serde::Deserialize;
-use tabwriter::{Alignment, TabWriter};
 
 use crate::{
     CliResult,

--- a/src/cmd/to.rs
+++ b/src/cmd/to.rs
@@ -395,7 +395,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
             writeln!(&mut stdout)?;
 
-            let mut tabwriter = tabwriter::TabWriter::new(stdout);
+            let mut tabwriter = qsv_tabwriter::TabWriter::new(stdout);
 
             if args.flag_pipe {
                 writeln!(


### PR DESCRIPTION
as we made changes that will not be merged into tabwriter, so we ended up creating a renamed fork.

Doing this instead of using patch section of Cargo.toml for easier maintenance