### PR TITLE
refactor: adopt Rust 1.95 cfg_select! macro at platform-conditional sites

### DIFF
--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -1157,11 +1157,12 @@ fn apply_operations(
                     //safety: we set THOUSANDS_POLICY in validate_operations()
                     let mut temp_string = num.separate_by_policy(*THOUSANDS_POLICY.get().unwrap());
 
-                    // if there is a decimal separator (i.e. a non-zero fractional part), use
-                    // the requested decimal separator in --replacement. Compare against != 0.0
-                    // because f64::fract() preserves sign: (-1.5).fract() == -0.5, so a
-                    // `> 0.0` check would skip negative fractional numbers and leave their
-                    // decimal point as `.` regardless of --replacement.
+                    // If the number has no fractional part, use the formatted string as-is.
+                    // Otherwise, swap in the requested decimal separator from --replacement.
+                    // We compare against == 0.0 (rather than > 0.0 in the else branch) because
+                    // f64::fract() preserves sign: (-1.5).fract() == -0.5, so a `> 0.0` test
+                    // would skip negative fractional numbers and leave their decimal point as
+                    // `.` regardless of --replacement.
                     if num.fract() == 0.0 {
                         *cell = temp_string;
                     } else {

--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -1162,7 +1162,9 @@ fn apply_operations(
                     // because f64::fract() preserves sign: (-1.5).fract() == -0.5, so a
                     // `> 0.0` check would skip negative fractional numbers and leave their
                     // decimal point as `.` regardless of --replacement.
-                    if num.fract() != 0.0 {
+                    if num.fract() == 0.0 {
+                        *cell = temp_string;
+                    } else {
                         // if replacement is empty, use the default decimal separator (.)
                         *cell = if replacement.is_empty() {
                             temp_string
@@ -1176,8 +1178,6 @@ fn apply_operations(
                                 None => temp_string,
                             }
                         };
-                    } else {
-                        *cell = temp_string;
                     }
                 }
             },

--- a/src/cmd/foreach.rs
+++ b/src/cmd/foreach.rs
@@ -248,13 +248,11 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         };
 
         let prog_bytes = strip_outer_quotes(prog_match.as_bytes());
-        #[cfg(target_family = "unix")]
-        let prog = OsStr::from_bytes(prog_bytes);
-        #[cfg(target_family = "windows")]
-        let prog = match simdutf8::basic::from_utf8(prog_bytes) {
-            Ok(s) => OsString::from(s),
-            Err(_) => {
-                return fail_clierror!("foreach: program path contains invalid UTF-8");
+        let prog = cfg_select! {
+            target_family = "unix" => OsStr::from_bytes(prog_bytes),
+            target_family = "windows" => match simdutf8::basic::from_utf8(prog_bytes) {
+                Ok(s) => OsString::from(s),
+                Err(_) => return fail_clierror!("foreach: program path contains invalid UTF-8"),
             },
         };
 
@@ -267,10 +265,10 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             .collect();
 
         if is_dry_run {
-            #[cfg(target_family = "unix")]
-            let prog_str = simdutf8::basic::from_utf8(prog.as_bytes()).unwrap_or_default();
-            #[cfg(target_family = "windows")]
-            let prog_str = simdutf8::basic::from_utf8(prog.as_encoded_bytes()).unwrap_or_default();
+            let prog_str = cfg_select! {
+                target_family = "unix" => simdutf8::basic::from_utf8(prog.as_bytes()).unwrap_or_default(),
+                target_family = "windows" => simdutf8::basic::from_utf8(prog.as_encoded_bytes()).unwrap_or_default(),
+            };
             let cmd_args_string = cmd_args.join(" ");
             dry_run_file.write_all(format!("{prog_str} {cmd_args_string}\n").as_bytes())?;
             continue;

--- a/src/cmd/pragmastat.rs
+++ b/src/cmd/pragmastat.rs
@@ -718,10 +718,10 @@ fn columns_from_cache(args: &Args, headers: &csv::ByteRecord) -> Option<Vec<(usi
         #[cfg_attr(target_endian = "big", allow(unused_mut))]
         let mut s_slice = curr_line.as_bytes().to_vec();
 
-        #[cfg(target_endian = "big")]
-        let parse_result = serde_json::from_slice::<CacheRecord>(&s_slice);
-        #[cfg(target_endian = "little")]
-        let parse_result = simd_json::from_slice::<CacheRecord>(&mut s_slice);
+        let parse_result = cfg_select! {
+            target_endian = "little" => simd_json::from_slice::<CacheRecord>(&mut s_slice),
+            _ => serde_json::from_slice::<CacheRecord>(&s_slice),
+        };
 
         let Ok(record) = parse_result else {
             return None;

--- a/src/cmd/prompt.rs
+++ b/src/cmd/prompt.rs
@@ -198,18 +198,16 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             .flag_msg
             .unwrap_or_else(|| DEFAULT_OUTPUT_TITLE.to_owned());
 
-        #[cfg(not(target_os = "macos"))]
-        let fd = FileDialog::new()
-            .set_directory(args.flag_workdir)
-            .set_title(title)
-            .set_file_name(args.flag_save_fname);
-
-        #[cfg(target_os = "macos")]
-        let fd = FileDialog::new()
-            .set_directory(args.flag_workdir)
-            .set_title(title)
-            .set_file_name(args.flag_save_fname)
-            .set_can_create_directories(true);
+        let fd = {
+            let base = FileDialog::new()
+                .set_directory(args.flag_workdir)
+                .set_title(title)
+                .set_file_name(args.flag_save_fname);
+            cfg_select! {
+                target_os = "macos" => base.set_can_create_directories(true),
+                _ => base,
+            }
+        };
 
         // no delay here, we want the save dialog to appear immediately
         // the delay is only for input dialogs, so they pop over in reverse order

--- a/src/cmd/schema.rs
+++ b/src/cmd/schema.rs
@@ -251,13 +251,10 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     });
 
     // Use platform-appropriate JSON serialization
-    #[cfg(target_endian = "big")]
-    let schema_pretty = match serde_json::to_string_pretty(&schema) {
-        Ok(s) => s,
-        Err(e) => return fail_clierror!("Cannot prettify schema json: {e}"),
-    };
-    #[cfg(target_endian = "little")]
-    let schema_pretty = match simd_json::to_string_pretty(&schema) {
+    let schema_pretty = match cfg_select! {
+        target_endian = "little" => simd_json::to_string_pretty(&schema),
+        _ => serde_json::to_string_pretty(&schema),
+    } {
         Ok(s) => s,
         Err(e) => return fail_clierror!("Cannot prettify schema json: {e}"),
     };

--- a/src/cmd/scoresql.rs
+++ b/src/cmd/scoresql.rs
@@ -1182,10 +1182,10 @@ fn get_duckdb_path() -> CliResult<String> {
     } else {
         // Env var not set — try to find "duckdb" in PATH using a cross-platform approach.
         // On Unix we use "which", on Windows we use "where".
-        #[cfg(not(target_os = "windows"))]
-        let which_cmd = "which";
-        #[cfg(target_os = "windows")]
-        let which_cmd = "where";
+        let which_cmd = cfg_select! {
+            target_os = "windows" => "where",
+            _ => "which",
+        };
 
         if let Some(resolved) = Command::new(which_cmd)
             .arg("duckdb")

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -1748,10 +1748,10 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         // save the stats args to "stdin.stats.csv.json"
         stats_pathbuf.set_extension("csv.json");
         // Use platform-appropriate JSON serialization
-        #[cfg(target_endian = "big")]
-        let json_string = serde_json::to_string_pretty(&current_stats_args)?;
-        #[cfg(target_endian = "little")]
-        let json_string = simd_json::to_string_pretty(&current_stats_args)?;
+        let json_string = cfg_select! {
+            target_endian = "little" => simd_json::to_string_pretty(&current_stats_args)?,
+            _ => serde_json::to_string_pretty(&current_stats_args)?,
+        };
         std::fs::write(stats_pathbuf, json_string)?;
     } else if let Some(path) = rconfig.path {
         // if we read from a file, copy the temp stats file to "<FILESTEM>.stats.csv" or
@@ -1816,10 +1816,10 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                 .unwrap()
                 .to_string();
             // Use platform-appropriate JSON serialization
-            #[cfg(target_endian = "big")]
-            let json_string = serde_json::to_string_pretty(&current_stats_args)?;
-            #[cfg(target_endian = "little")]
-            let json_string = simd_json::to_string_pretty(&current_stats_args)?;
+            let json_string = cfg_select! {
+                target_endian = "little" => simd_json::to_string_pretty(&current_stats_args)?,
+                _ => serde_json::to_string_pretty(&current_stats_args)?,
+            };
             std::fs::write(stats_pathbuf.clone(), json_string)?;
 
             // save the stats data to "<FILESTEM>.stats.csv.data.jsonl"
@@ -2849,16 +2849,15 @@ fn resolve_sniff_whitelist(input_path: &std::path::Path) -> CliResult<String> {
     }
 
     // Parse JSON output (platform-specific)
-    #[cfg(target_endian = "little")]
-    let sniff_result: SniffResult = {
-        let mut json_bytes = output.stdout;
-        simd_json::from_slice(&mut json_bytes)
-            .map_err(|e| CliError::Other(format!("Failed to parse sniff JSON: {e}")))?
+    // simd_json mutates its input buffer; serde_json doesn't care.
+    #[cfg_attr(target_endian = "big", allow(unused_mut))]
+    let mut json_bytes = output.stdout;
+    let sniff_result: SniffResult = cfg_select! {
+        target_endian = "little" => simd_json::from_slice(&mut json_bytes)
+            .map_err(|e| CliError::Other(format!("Failed to parse sniff JSON: {e}")))?,
+        _ => serde_json::from_slice(&json_bytes)
+            .map_err(|e| CliError::Other(format!("Failed to parse sniff JSON: {e}")))?,
     };
-
-    #[cfg(target_endian = "big")]
-    let sniff_result: SniffResult = serde_json::from_slice(&output.stdout)
-        .map_err(|e| CliError::Other(format!("Failed to parse sniff JSON: {e}")))?;
 
     // Extract column names where type is Date or DateTime
     let date_columns: Vec<&str> = sniff_result

--- a/src/cmd/tojsonl.rs
+++ b/src/cmd/tojsonl.rs
@@ -128,10 +128,10 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     // as the polars-powered count_rows is failing CI tests on Windows
     // I suspect there is an optimization in Polars that is causing this
     // CI test flakiness
-    #[cfg(windows)]
-    let record_count = util::count_rows_regular(&conf)?;
-    #[cfg(not(windows))]
-    let record_count = util::count_rows(&conf)?;
+    let record_count = cfg_select! {
+        windows => util::count_rows_regular(&conf)?,
+        _ => util::count_rows(&conf)?,
+    };
 
     // we're calling the schema command to infer data types and enums
     let schema_args = util::SchemaArgs {

--- a/src/cmd/validate.rs
+++ b/src/cmd/validate.rs
@@ -1282,12 +1282,12 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             match load_json(&json_schema_path.to_string_lossy()) {
             Ok(s) => {
                 // parse JSON string - use platform-appropriate JSON deserialization
-                #[cfg(target_endian = "big")]
-                let json_result = serde_json::from_str::<Value>(&s);
+                // simd_json mutates its input buffer; serde_json reads from the str directly.
                 #[cfg(target_endian = "little")]
-                let json_result = {
-                    let mut s_slice = s.as_bytes().to_vec();
-                    simd_json::serde::from_slice::<Value>(&mut s_slice)
+                let mut s_slice = s.as_bytes().to_vec();
+                let json_result = cfg_select! {
+                    target_endian = "little" => simd_json::serde::from_slice::<Value>(&mut s_slice),
+                    _ => serde_json::from_str::<Value>(&s),
                 };
 
                 match json_result {

--- a/src/util.rs
+++ b/src/util.rs
@@ -160,16 +160,15 @@ const WHITESPACE_MARKERS: &[(char, &str)] = &[
     ('\u{200B}', "《zwsp》"),  // zero width space
 ];
 
-#[cfg(unix)]
 pub fn reset_sigpipe() {
-    unsafe {
-        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+    cfg_select! {
+        unix => {
+            unsafe {
+                libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+            }
+        }
+        _ => {}
     }
-}
-
-#[cfg(not(unix))]
-pub fn reset_sigpipe() {
-    // no-op
 }
 
 pub fn current_exe() -> CliResult<PathBuf> {
@@ -996,17 +995,16 @@ pub fn mem_file_check(
 
     // Platform-specific adjustment factors for conservative mode
     // These account for OS-specific memory management capabilities
-    #[cfg(target_os = "macos")]
-    let platform_factor = 1.3; // macOS has aggressive memory compression & dynamic swap                                                                                                    
-
-    #[cfg(target_os = "linux")]
-    let platform_factor = 1.15; // Linux page cache is reclaimable, but be conservative                                                                                                     
-
-    #[cfg(target_os = "windows")]
-    let platform_factor = 1.0; // Windows memory reporting is already conservative                                                                                                          
-
-    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-    let platform_factor = 1.0; // Other platforms: no adjustment   
+    let platform_factor = cfg_select! {
+        // macOS has aggressive memory compression & dynamic swap
+        target_os = "macos" => 1.3,
+        // Linux page cache is reclaimable, but be conservative
+        target_os = "linux" => 1.15,
+        // Windows memory reporting is already conservative
+        target_os = "windows" => 1.0,
+        // Other platforms: no adjustment
+        _ => 1.0,
+    };
 
     // Calculate maximum available memory based on mode
     #[allow(clippy::cast_precision_loss)]
@@ -2862,10 +2860,10 @@ pub fn get_stats_records(
             s_slice = curr_line.as_bytes().to_vec();
 
             // Parse regular stats record
-            #[cfg(target_endian = "big")]
-            let parse_result = serde_json::from_slice::<StatsData>(&s_slice);
-            #[cfg(target_endian = "little")]
-            let parse_result = simd_json::from_slice::<StatsData>(&mut s_slice);
+            let parse_result = cfg_select! {
+                target_endian = "little" => simd_json::from_slice::<StatsData>(&mut s_slice),
+                _ => serde_json::from_slice::<StatsData>(&s_slice),
+            };
 
             if let Ok(stats) = parse_result {
                 csv_stats.push(stats);
@@ -3023,23 +3021,13 @@ pub fn get_stats_records(
                     "qsv stats exited with code: {code}"
                 )));
             }
-            #[cfg(target_family = "unix")]
-            {
-                if let Some(signal) = status.signal() {
-                    return Err(CliError::Other(format!(
-                        "qsv stats terminated with signal: {signal}"
-                    )));
-                }
-                return Err(CliError::Other(
-                    "qsv stats terminated by unknown cause".to_string(),
-                ));
-            }
-            #[cfg(not(target_family = "unix"))]
-            {
-                return Err(CliError::Other(
-                    "qsv stats terminated by unknown cause".to_string(),
-                ));
-            }
+            return Err(CliError::Other(cfg_select! {
+                target_family = "unix" => match status.signal() {
+                    Some(signal) => format!("qsv stats terminated with signal: {signal}"),
+                    None => "qsv stats terminated by unknown cause".to_string(),
+                },
+                _ => "qsv stats terminated by unknown cause".to_string(),
+            }));
         }
 
         // create a stats data jsonl from the output of the stats command
@@ -3062,10 +3050,10 @@ pub fn get_stats_records(
             s_slice = curr_line.as_bytes().to_vec();
 
             // Parse regular stats record
-            #[cfg(target_endian = "big")]
-            let parse_result = serde_json::from_slice::<StatsData>(&s_slice);
-            #[cfg(target_endian = "little")]
-            let parse_result = simd_json::from_slice::<StatsData>(&mut s_slice);
+            let parse_result = cfg_select! {
+                target_endian = "little" => simd_json::from_slice::<StatsData>(&mut s_slice),
+                _ => serde_json::from_slice::<StatsData>(&s_slice),
+            };
 
             match parse_result {
                 Ok(stats) => csv_stats.push(stats),
@@ -3183,14 +3171,10 @@ pub fn csv_to_jsonl(
         }
 
         // Use platform-appropriate JSON serialization
-        #[cfg(target_endian = "big")]
-        {
-            json_line = serde_json::to_string(&json_object)?;
-        }
-        #[cfg(target_endian = "little")]
-        {
-            json_line = simd_json::to_string(&json_object)?;
-        }
+        json_line = cfg_select! {
+            target_endian = "little" => simd_json::to_string(&json_object)?,
+            _ => serde_json::to_string(&json_object)?,
+        };
         writeln!(writer, "{json_line}")?;
     }
 
@@ -3749,24 +3733,25 @@ pub fn hash_blake3_file(path: &Path) -> CliResult<String> {
     Ok(hasher.finalize().to_hex().to_string())
 }
 
-#[cfg(unix)]
 pub fn is_executable(path: &str) -> std::io::Result<bool> {
-    use std::{fs, os::unix::fs::PermissionsExt};
+    cfg_select! {
+        unix => {
+            use std::{fs, os::unix::fs::PermissionsExt};
 
-    let metadata = fs::metadata(path)?;
-    Ok(metadata.permissions().mode() & 0o111 != 0)
-}
-
-#[cfg(windows)]
-pub fn is_executable(path: &str) -> std::io::Result<bool> {
-    use std::path::Path;
-    let p = Path::new(path);
-    Ok(p.extension().and_then(|e| e.to_str()).is_some_and(|ext| {
-        matches!(
-            ext.to_ascii_lowercase().as_str(),
-            "exe" | "bat" | "cmd" | "com"
-        )
-    }))
+            let metadata = fs::metadata(path)?;
+            Ok(metadata.permissions().mode() & 0o111 != 0)
+        }
+        windows => {
+            use std::path::Path;
+            let p = Path::new(path);
+            Ok(p.extension().and_then(|e| e.to_str()).is_some_and(|ext| {
+                matches!(
+                    ext.to_ascii_lowercase().as_str(),
+                    "exe" | "bat" | "cmd" | "com"
+                )
+            }))
+        }
+    }
 }
 
 /// Print a status message with elapsed time if not in quiet mode


### PR DESCRIPTION
## Summary

- Convert 15 platform-conditional sites across 9 files from paired `#[cfg(...)]` attributes (or duplicated function defs) to std's new `cfg_select!` macro stabilized in Rust 1.95 (current MSRV).
- Notable wins: `reset_sigpipe` and `is_executable` collapse from 2 fn defs to 1; the `platform_factor` 4-arm `target_os` ladder becomes a single expression; the 9 `target_endian` simd_json/serde_json pairs lose their `#[cfg]` scaffolding.
- Net **−23 lines** (109 insertions, 132 deletions).

### Sites converted

**`src/util.rs`**
- `reset_sigpipe` — merged unix / not(unix) defs
- `is_executable` — merged unix / windows defs
- `platform_factor` — 4-arm `target_os` match
- 3 `target_endian` simd_json/serde_json sites
- Signal-status error block — refactored duplicated `return Err` into single `cfg_select!` over the message

**`src/cmd/`**
- `stats.rs` — 3 `target_endian` sites (incl. `sniff_result` with `let` pulled outside)
- `schema.rs`, `pragmastat.rs`, `validate.rs` — 1 `target_endian` site each
- `foreach.rs` — 2 unix/windows `let` bindings
- `tojsonl.rs` — `count_rows_regular` vs `count_rows`
- `scoresql.rs` — `which` vs `where`
- `prompt.rs` — macOS-only `set_can_create_directories`

### One site intentionally kept on `#[cfg]`

`stats.rs:1398` (`mut stat_args` for stats-args cache deserialization). The little-endian arm consumes the `String` into a `Vec<u8>` while the big-endian arm borrows it. `cfg_select!`'s expression-form arms must be single expressions, so squeezing this through required restructuring ownership without a clear win.

### Notes on `cfg_select!`

In expression position, brace-block arms must contain a single expression — multi-statement `{ let x = ...; expr }` blocks trigger "trailing semicolon in macro" errors. Workaround for `sniff_result` (stats.rs) and `validate.rs`: pull the `let mut` outside `cfg_select!` (using `#[cfg_attr(target_endian = "big", allow(unused_mut))]` to suppress the cross-arch warning). Item-position usage works fine with multi-statement blocks (e.g., `is_executable`).

## Test plan

- [x] `cargo build --locked --bin qsv -F all_features` — clean
- [x] `cargo build --bin qsvlite -F lite` — clean (only pre-existing `describegpt.rs` warning)
- [x] `cargo build --bin qsvmcp -F qsvmcp` — clean
- [x] `cargo clippy --bin qsv -F all_features` — clean
- [x] `cargo test --test tests stats_cache -F all_features` — 23 passed
- [x] `cargo test --test tests test_validate -F all_features` — 62 passed
- [x] `cargo test --test tests test_schema -F all_features` — 12 passed
- [x] `cargo test --test tests test_tojsonl -F all_features` — 25 passed
- [x] `cargo test --test tests test_foreach -F all_features` — 18 passed
- [x] `cargo test --test tests test_pragmastat -F all_features` — 47 passed
- [ ] CI confirms big-endian arms still compile (s390x / mips builds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)