### PR TITLE
fix(stats): restore big-endian build by giving slot fallbacks an accessible `.0`

### DIFF
--- a/.github/workflows/rust-macos-polars.yml
+++ b/.github/workflows/rust-macos-polars.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Setup Rust-cache
       uses: Swatinem/rust-cache@v2
       with:
-        key: qsv-macospolarslatestcache
+        key: qsv-macospolarslatestcache-v2
     - name: Remove cargo config from GH runner image which has target-cpu=native set
       run: rm -f .cargo/config.toml
     - name: Run tests

--- a/.github/workflows/rust-macos.yml
+++ b/.github/workflows/rust-macos.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Setup Rust-cache
       uses: Swatinem/rust-cache@v2
       with:
-        key: qsv-macoslatestcache
+        key: qsv-macoslatestcache-v2
     - name: Remove cargo config from GH runner image which has target-cpu=native set
       run: rm -f .cargo/config.toml
     - name: Run tests

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -3069,10 +3069,12 @@ struct TDigestStub;
 impl TDigestStub {
     #[inline]
     fn update(&mut self, _value: f64) {}
+
     #[inline]
     fn quantile(&self, _rank: f64) -> Option<f64> {
         None
     }
+
     #[inline]
     fn is_empty(&self) -> bool {
         true
@@ -3168,6 +3170,7 @@ struct HllSketchStub;
 impl HllSketchStub {
     #[inline]
     fn update(&mut self, _sample: &[u8]) {}
+
     #[inline]
     fn estimate(&self) -> f64 {
         0.0

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -3052,9 +3052,49 @@ impl TDigestStub {
     }
 }
 
+/// Big-endian fallback for `TDigestSlot`. Apache DataSketches is unavailable on
+/// big-endian targets, so we substitute a tuple-struct wrapping `Option<TDigestStub>`
+/// — the unit-like `TDigestStub` exposes the same no-op method surface used by the
+/// little-endian call sites (`update`, `quantile`, `is_empty`). `Stats::tdigest` is
+/// always `Default` (i.e. `Some` is never written) on these targets — the
+/// `--quantile-method approx` codepath is rejected upstream by `run()` — so the
+/// stub methods are never reached at runtime; they exist only so the shared call
+/// sites in `update_modes`, `add_numeric_value`, `to_record`, etc. type-check
+/// unchanged.
 #[cfg(target_endian = "big")]
-#[derive(Default, Clone, PartialEq)]
+#[derive(Default, Clone)]
+struct TDigestStub;
+
+#[cfg(target_endian = "big")]
+impl TDigestStub {
+    #[inline]
+    fn update(&mut self, _value: f64) {}
+    #[inline]
+    fn quantile(&self, _rank: f64) -> Option<f64> {
+        None
+    }
+    #[inline]
+    fn is_empty(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(target_endian = "big")]
+#[derive(Default, Clone)]
 struct TDigestSlot(Option<TDigestStub>);
+
+// Mirror the little-endian `PartialEq` semantics: equality between two
+// t-digests isn't meaningful, so `eq` is a constant `true`. On big-endian
+// the inner Option is always `None` anyway, but the explicit impl keeps
+// the cross-target API symmetric (Stats's derived `PartialEq` is only used
+// in tests for non-quantile fields).
+#[cfg(target_endian = "big")]
+impl PartialEq for TDigestSlot {
+    #[inline]
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
 
 /// Wrapper around `datasketches::hll::HllSketch` so the `Stats` struct can keep its
 /// derived `Clone`, `PartialEq`, `Serialize`, `Deserialize` impls without forcing the
@@ -3112,9 +3152,44 @@ impl HllSketchStub {
     }
 }
 
+/// Big-endian fallback for `HllSlot`. Apache DataSketches is unavailable on
+/// big-endian targets, so we substitute a tuple-struct wrapping `Option<HllSketchStub>`
+/// — the unit-like `HllSketchStub` exposes the same no-op method surface used by the
+/// little-endian call sites (`update`, `estimate`). `Stats::hll` is always `Default`
+/// (i.e. `Some` is never written) on these targets — the `--cardinality-method approx`
+/// codepath is rejected upstream by `run()` — so the stub methods are never reached
+/// at runtime; they exist only so the shared call sites in `update_modes` and
+/// `to_record` type-check unchanged.
 #[cfg(target_endian = "big")]
-#[derive(Default, Clone, PartialEq)]
+#[derive(Default, Clone)]
+struct HllSketchStub;
+
+#[cfg(target_endian = "big")]
+impl HllSketchStub {
+    #[inline]
+    fn update(&mut self, _sample: &[u8]) {}
+    #[inline]
+    fn estimate(&self) -> f64 {
+        0.0
+    }
+}
+
+#[cfg(target_endian = "big")]
+#[derive(Default, Clone)]
 struct HllSlot(Option<HllSketchStub>);
+
+// Mirror the little-endian `PartialEq` semantics: equality between two
+// HLL sketches isn't meaningful, so `eq` is a constant `true`. On big-endian
+// the inner Option is always `None` anyway, but the explicit impl keeps
+// the cross-target API symmetric (Stats's derived `PartialEq` is only used
+// in tests for non-sketch fields).
+#[cfg(target_endian = "big")]
+impl PartialEq for HllSlot {
+    #[inline]
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
 
 #[allow(clippy::unsafe_derive_deserialize)]
 #[allow(clippy::struct_field_names)]
@@ -5040,8 +5115,9 @@ impl Commute for Stats {
         // reproducible. Determinism for --jobs >= 2 is intentionally not guaranteed; the
         // --quantile-method help text documents the caveat for users.
         //
-        // Skipped on big-endian targets: `TDigestSlot` is a unit-like ZST there (Apache
-        // DataSketches is unavailable), so there's no inner state to merge.
+        // Skipped on big-endian targets: `TDigestSlot` is always `Default` (the inner
+        // `Option<TDigestStub>` is always `None`) since Apache DataSketches is
+        // unavailable, so there's no inner state to merge.
         #[cfg(not(target_endian = "big"))]
         match (&mut self.tdigest.0, other.tdigest.0) {
             (Some(s), Some(o)) => s.merge(&o),
@@ -5055,8 +5131,9 @@ impl Commute for Stats {
         // here MUST match the HLL_LG_K used in `Stats::new`; reading from the same
         // constant prevents a silent precision downgrade if one site is bumped.
         //
-        // Skipped on big-endian targets: `HllSlot` is a unit-like ZST there (Apache
-        // DataSketches is unavailable), so there's no inner state to merge.
+        // Skipped on big-endian targets: `HllSlot` is always `Default` (the inner
+        // `Option<HllSketchStub>` is always `None`) since Apache DataSketches is
+        // unavailable, so there's no inner state to merge.
         #[cfg(not(target_endian = "big"))]
         match (&mut self.hll.0, other.hll.0) {
             (Some(s), Some(o)) => {

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -3024,12 +3024,35 @@ impl PartialEq for TDigestSlot {
 }
 
 /// Big-endian fallback for `TDigestSlot`. Apache DataSketches is unavailable on
-/// big-endian targets, so we substitute a zero-sized type. `Stats::tdigest` is
-/// still declared (and `#[serde(skip)]`) on those targets but is never read; the
-/// `--quantile-method approx` codepath is rejected upstream by `run()`.
+/// big-endian targets, so we substitute a tuple-struct wrapping `Option<TDigestStub>`
+/// — the unit-like `TDigestStub` exposes the same no-op method surface used by the
+/// little-endian call sites (`update`, `quantile`, `is_empty`). `Stats::tdigest` is
+/// always `Default` (i.e. `Some` is never written) on these targets — the
+/// `--quantile-method approx` codepath is rejected upstream by `run()` — so the
+/// stub methods are never reached at runtime; they exist only so the shared call
+/// sites in `update_modes`, `add_numeric_value`, `to_record`, etc. type-check
+/// unchanged.
 #[cfg(target_endian = "big")]
 #[derive(Default, Clone, PartialEq)]
-struct TDigestSlot;
+struct TDigestStub;
+
+#[cfg(target_endian = "big")]
+impl TDigestStub {
+    #[inline]
+    fn update(&mut self, _value: f64) {}
+    #[inline]
+    fn quantile(&self, _rank: f64) -> Option<f64> {
+        None
+    }
+    #[inline]
+    fn is_empty(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(target_endian = "big")]
+#[derive(Default, Clone, PartialEq)]
+struct TDigestSlot(Option<TDigestStub>);
 
 /// Wrapper around `datasketches::hll::HllSketch` so the `Stats` struct can keep its
 /// derived `Clone`, `PartialEq`, `Serialize`, `Deserialize` impls without forcing the
@@ -3065,12 +3088,30 @@ impl PartialEq for HllSlot {
 }
 
 /// Big-endian fallback for `HllSlot`. Apache DataSketches is unavailable on
-/// big-endian targets, so we substitute a zero-sized type. `Stats::hll` is
-/// still declared (and `#[serde(skip)]`) on those targets but is never read; the
-/// `--cardinality-method approx` codepath is rejected upstream by `run()`.
+/// big-endian targets, so we substitute a tuple-struct wrapping `Option<HllSketchStub>`
+/// — the unit-like `HllSketchStub` exposes the same no-op method surface used by the
+/// little-endian call sites (`update`, `estimate`). `Stats::hll` is always `Default`
+/// (i.e. `Some` is never written) on these targets — the `--cardinality-method approx`
+/// codepath is rejected upstream by `run()` — so the stub methods are never reached
+/// at runtime; they exist only so the shared call sites in `update_modes` and
+/// `to_record` type-check unchanged.
 #[cfg(target_endian = "big")]
 #[derive(Default, Clone, PartialEq)]
-struct HllSlot;
+struct HllSketchStub;
+
+#[cfg(target_endian = "big")]
+impl HllSketchStub {
+    #[inline]
+    fn update(&mut self, _sample: &[u8]) {}
+    #[inline]
+    fn estimate(&self) -> f64 {
+        0.0
+    }
+}
+
+#[cfg(target_endian = "big")]
+#[derive(Default, Clone, PartialEq)]
+struct HllSlot(Option<HllSketchStub>);
 
 #[allow(clippy::unsafe_derive_deserialize)]
 #[allow(clippy::struct_field_names)]

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -3040,10 +3040,12 @@ struct TDigestStub;
 impl TDigestStub {
     #[inline]
     fn update(&mut self, _value: f64) {}
+
     #[inline]
     fn quantile(&self, _rank: f64) -> Option<f64> {
         None
     }
+
     #[inline]
     fn is_empty(&self) -> bool {
         true
@@ -3103,6 +3105,7 @@ struct HllSketchStub;
 impl HllSketchStub {
     #[inline]
     fn update(&mut self, _sample: &[u8]) {}
+
     #[inline]
     fn estimate(&self) -> f64 {
         0.0


### PR DESCRIPTION
## Summary
- s390x CI (run [25775525839](https://github.com/dathere/qsv/actions/runs/25775525839/job/75707168747)) failed with six `E0609: no field 0 on type HllSlot/TDigestSlot` errors in `src/cmd/stats.rs`. Commit f27ded229 (DataSketches big-endian gating) made the big-endian fallbacks unit structs (`struct HllSlot;`) but six call sites in `update_modes`, `add_numeric_value`, and `to_record` still touch `self.hll.0` / `self.tdigest.0` — the merge sites at lines 5001/5016 were cfg-gated, but these six sit inside `else if let` chains that don't gate cleanly.
- Promote the big-endian `HllSlot`/`TDigestSlot` to tuple structs of `Option<…Stub>`. The `TDigestStub` and `HllSketchStub` expose the same no-op method surface the call sites use (`update`, `quantile`, `is_empty`, `estimate`), with signatures mirroring upstream `datasketches-0.2.0`.
- Stubs are dead at runtime: on big-endian `run()` rejects `--quantile-method approx` and `--cardinality-method approx` upstream, so the slots are always `None`. The stubs exist only so the shared call sites type-check unchanged.

## Test plan
- [x] Standalone `rustc` check of all six call shapes against the new stub layout passes.
- [x] `cargo build --locked --bin qsv -F all_features` clean on macOS arm64.
- [x] `cargo t stats -F all_features` — 744 passed, 0 failed.
- [ ] Re-run the `s390x` workflow once this lands to confirm the original CI failure is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)