### PR TITLE
fix(stats): remove duplicate big-endian `TDigestStub`/`HllSketchStub` defs

### DIFF
--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -3032,35 +3032,10 @@ impl PartialEq for TDigestSlot {
 /// stub methods are never reached at runtime; they exist only so the shared call
 /// sites in `update_modes`, `add_numeric_value`, `to_record`, etc. type-check
 /// unchanged.
-#[cfg(target_endian = "big")]
-#[derive(Default, Clone, PartialEq)]
-struct TDigestStub;
-
-#[cfg(target_endian = "big")]
-impl TDigestStub {
-    #[inline]
-    fn update(&mut self, _value: f64) {}
-
-    #[inline]
-    fn quantile(&self, _rank: f64) -> Option<f64> {
-        None
-    }
-
-    #[inline]
-    fn is_empty(&self) -> bool {
-        true
-    }
-}
-
-/// Big-endian fallback for `TDigestSlot`. Apache DataSketches is unavailable on
-/// big-endian targets, so we substitute a tuple-struct wrapping `Option<TDigestStub>`
-/// — the unit-like `TDigestStub` exposes the same no-op method surface used by the
-/// little-endian call sites (`update`, `quantile`, `is_empty`). `Stats::tdigest` is
-/// always `Default` (i.e. `Some` is never written) on these targets — the
-/// `--quantile-method approx` codepath is rejected upstream by `run()` — so the
-/// stub methods are never reached at runtime; they exist only so the shared call
-/// sites in `update_modes`, `add_numeric_value`, `to_record`, etc. type-check
-/// unchanged.
+///
+/// `PartialEq` is not needed on the stub itself: the wrapping `TDigestSlot`
+/// has an explicit `impl PartialEq` (constant `true`) that mirrors the
+/// little-endian semantics.
 #[cfg(target_endian = "big")]
 #[derive(Default, Clone)]
 struct TDigestStub;
@@ -3139,29 +3114,10 @@ impl PartialEq for HllSlot {
 /// codepath is rejected upstream by `run()` — so the stub methods are never reached
 /// at runtime; they exist only so the shared call sites in `update_modes` and
 /// `to_record` type-check unchanged.
-#[cfg(target_endian = "big")]
-#[derive(Default, Clone, PartialEq)]
-struct HllSketchStub;
-
-#[cfg(target_endian = "big")]
-impl HllSketchStub {
-    #[inline]
-    fn update(&mut self, _sample: &[u8]) {}
-
-    #[inline]
-    fn estimate(&self) -> f64 {
-        0.0
-    }
-}
-
-/// Big-endian fallback for `HllSlot`. Apache DataSketches is unavailable on
-/// big-endian targets, so we substitute a tuple-struct wrapping `Option<HllSketchStub>`
-/// — the unit-like `HllSketchStub` exposes the same no-op method surface used by the
-/// little-endian call sites (`update`, `estimate`). `Stats::hll` is always `Default`
-/// (i.e. `Some` is never written) on these targets — the `--cardinality-method approx`
-/// codepath is rejected upstream by `run()` — so the stub methods are never reached
-/// at runtime; they exist only so the shared call sites in `update_modes` and
-/// `to_record` type-check unchanged.
+///
+/// `PartialEq` is not needed on the stub itself: the wrapping `HllSlot` has
+/// an explicit `impl PartialEq` (constant `true`) that mirrors the
+/// little-endian semantics.
 #[cfg(target_endian = "big")]
 #[derive(Default, Clone)]
 struct HllSketchStub;


### PR DESCRIPTION
## Summary
- PR #3850's second commit (addressing roborev review 2085 by moving `PartialEq` from a derive to an explicit `impl` on `TDigestSlot`/`HllSlot`) accidentally left the *old* stub struct + impl block alongside the new one. On big-endian targets both `TDigestStub` and `HllSketchStub` ended up defined twice — once with `#[derive(Default, Clone, PartialEq)]` and once with `#[derive(Default, Clone)]` — producing E0428 (`name … is defined multiple times`), E0119 (`conflicting impls of Default/Clone`), E0592 (`duplicate definitions`), and E0034 (`multiple applicable items in scope` on `update`/`quantile`/`is_empty`/`estimate`) and breaking the s390x build.
- The s390x workflow is `workflow_dispatch`-triggered only, so the regression slipped past normal CI — see run [25929817626](https://github.com/dathere/qsv/actions/runs/25929817626/job/76220565127).
- Fix: delete the redundant `#[derive(Default, Clone, PartialEq)]` copies and keep the leaner `#[derive(Default, Clone)]` versions. This matches the post-refactor intent of #3850 — `PartialEq` lives on the wrapping `TDigestSlot`/`HllSlot` slot types (manual `impl PartialEq` returning a constant `true`), not on the inner stubs.

## Test plan
- [x] Standalone `rustc --target s390x-unknown-linux-gnu --emit metadata` round-trip of the cfg-gated block (same shape-only verification approach used in #3850's commit message). All four symbols — `TDigestStub`, `TDigestSlot`, `HllSketchStub`, `HllSlot` — appear exactly once in the resulting metadata.
- [x] `cargo test --test tests stats -F all_features` (little-endian) — 749 passed, 0 failed.
- [x] `cargo clippy -F all_features` — clean.
- [ ] Manual re-run of the `s390x` workflow on this branch to confirm the build now passes on the native big-endian runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)