### PR TITLE
feat(describegpt,synthesize): infer Content Type for temporal fields with LLM-hinted duration cap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2430,6 +2430,7 @@ dependencies = [
  "either",
  "rand 0.10.1",
  "random_color",
+ "time",
  "uuid",
 ]
 
@@ -6160,6 +6161,7 @@ dependencies = [
  "thousands",
  "threadpool",
  "tikv-jemallocator",
+ "time",
  "titlecase",
  "tokio",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,6 +128,7 @@ ext-sort = { version = "0.1", default-features = false }
 fake = { version = "5", features = [
     "derive",
     "chrono",
+    "time",
     "uuid",
     "random_color",
 ], optional = true }
@@ -293,6 +294,7 @@ textwrap = { version = "0.16", features = ["terminal_size"] }
 thousands = { version = "0.2", optional = true }
 threadpool = "1.8"
 tikv-jemallocator = { version = "0.6", optional = true }
+time = { version = "0.3", optional = true }
 titlecase = { version = "3", optional = true }
 tokio = { version = "1", features = ["parking_lot", "rt-multi-thread"] }
 unicode-width = { version = "0.2", optional = true }
@@ -443,7 +445,7 @@ polars = ["dep:polars", "bytemuck"]
 
 prompt = ["rfd"]
 python = ["pyo3"]
-synthesize = ["dep:fake"]
+synthesize = ["dep:fake", "dep:time"]
 to = ["csvs_convert"]
 lens = ["csvlens"]
 lite = []

--- a/resources/describegpt_defaults.toml
+++ b/resources/describegpt_defaults.toml
@@ -75,23 +75,26 @@ For each field, provide:
 - Description: a full description for this field (can be multiple sentences)
 {%- if infer_content_type %}
 - Content Type: classify the SEMANTIC CONTENT of this field by choosing exactly ONE token from the
-  fixed vocabulary below. Do NOT invent tokens and do NOT return free text. Base your choice on the
-  field name, the Label and Description you just produced for this field, the Summary Statistics
-  and the Frequency Distribution - the Label and Description capture your own semantic reading of
-  the field and must be consistent with the Content Type token you pick (e.g. a Label of "Email
-  Address" or a Description mentioning "email" should map to "email", not "free_text"). For plain
-  numeric, date, datetime or boolean fields with no specific semantic meaning, use "unknown" -
-  those are already covered by the deterministic Type column. Use "time" for fields that contain
-  only a time-of-day (e.g. "HH:MM:SS", "14:30") and "duration" for fields that contain
-  elapsed-time values (e.g. "PT5M30S", "00:05:30") - these are NOT covered by the deterministic
-  Type column. When you pick "duration", you MAY append a colon and a positive integer
-  upper bound in seconds to help synthesize produce realistic values - e.g. "duration:18000"
-  for race times (~5 hours), "duration:7200" for video lengths (~2 hours), "duration:300"
-  for HTTP request latencies (~5 minutes). Pick a cap that comfortably contains the values
-  you see in min/max and the Frequency Distribution; do NOT over-tighten. If you cannot
+  fixed vocabulary below. Do NOT invent tokens and do NOT return free text - with ONE explicit
+  exception documented below for "duration". Base your choice on the field name, the Label and
+  Description you just produced for this field, the Summary Statistics and the Frequency
+  Distribution - the Label and Description capture your own semantic reading of the field and
+  must be consistent with the Content Type token you pick (e.g. a Label of "Email Address" or a
+  Description mentioning "email" should map to "email", not "free_text"). For plain numeric,
+  date, datetime or boolean fields with no specific semantic meaning, use "unknown" - those are
+  already covered by the deterministic Type column. Use "time" for fields that contain only a
+  time-of-day (e.g. "HH:MM:SS", "14:30") and "duration" for fields that contain elapsed-time
+  values (e.g. "PT5M30S", "00:05:30") - these are NOT covered by the deterministic Type column.
+  ALLOWED EXTENSION (the only exception to "do not invent tokens"): the "duration" token
+  MAY optionally be suffixed with ":N" where N is a positive integer upper bound in
+  SECONDS, e.g. "duration:18000" for race times (~5 hours), "duration:7200" for video lengths
+  (~2 hours), "duration:300" for HTTP request latencies (~5 minutes). This suffix is part of
+  the allowed vocabulary, not a free-form invention. Pick a cap that comfortably contains the
+  values you see in min/max and the Frequency Distribution; do NOT over-tighten. If you cannot
   confidently pick a cap, just use bare "duration" (synthesize will default to a 24-hour
-  range). If no token fits, use "unknown".
-  Allowed Content Type tokens: {{ content_type_vocab }}
+  range). No other token accepts this suffix. If no token fits, use "unknown".
+  Allowed Content Type tokens: {{ content_type_vocab }} (plus the optional "duration:N" form
+  described above)
 {%- endif %}
 
 Return the results in JSON format where each field name is a key, and the value is an object with "label"{% if infer_content_type %},{% else %} and{% endif %} "description"{% if infer_content_type %} and "content_type"{% endif %} properties:

--- a/resources/describegpt_defaults.toml
+++ b/resources/describegpt_defaults.toml
@@ -76,9 +76,21 @@ For each field, provide:
 {%- if infer_content_type %}
 - Content Type: classify the SEMANTIC CONTENT of this field by choosing exactly ONE token from the
   fixed vocabulary below. Do NOT invent tokens and do NOT return free text. Base your choice on the
-  field name, Summary Statistics and Frequency Distribution. For plain numeric, date, datetime or
-  boolean fields with no specific semantic meaning, use "unknown" - those are already covered by the
-  deterministic Type column. If no token fits, use "unknown".
+  field name, the Label and Description you just produced for this field, the Summary Statistics
+  and the Frequency Distribution - the Label and Description capture your own semantic reading of
+  the field and must be consistent with the Content Type token you pick (e.g. a Label of "Email
+  Address" or a Description mentioning "email" should map to "email", not "free_text"). For plain
+  numeric, date, datetime or boolean fields with no specific semantic meaning, use "unknown" -
+  those are already covered by the deterministic Type column. Use "time" for fields that contain
+  only a time-of-day (e.g. "HH:MM:SS", "14:30") and "duration" for fields that contain
+  elapsed-time values (e.g. "PT5M30S", "00:05:30") - these are NOT covered by the deterministic
+  Type column. When you pick "duration", you MAY append a colon and a positive integer
+  upper bound in seconds to help synthesize produce realistic values - e.g. "duration:18000"
+  for race times (~5 hours), "duration:7200" for video lengths (~2 hours), "duration:300"
+  for HTTP request latencies (~5 minutes). Pick a cap that comfortably contains the values
+  you see in min/max and the Frequency Distribution; do NOT over-tighten. If you cannot
+  confidently pick a cap, just use bare "duration" (synthesize will default to a 24-hour
+  range). If no token fits, use "unknown".
   Allowed Content Type tokens: {{ content_type_vocab }}
 {%- endif %}
 

--- a/src/cmd/describegpt/dictionary.rs
+++ b/src/cmd/describegpt/dictionary.rs
@@ -17,7 +17,19 @@ use super::{CliError, CliResult, extract_json_from_output};
 /// Primitive types (`integer`, `decimal`, `boolean`, `date`, `datetime`) are
 /// deliberately excluded — they are redundant with the dictionary's deterministic
 /// `type` column. `synthesize` falls back to `type` + `min`/`max` for plain
-/// numeric/temporal fields whose `content_type` is `unknown`.
+/// numeric/date/datetime fields whose `content_type` is `unknown`.
+///
+/// `time` (time-of-day, e.g. `HH:MM:SS`) and `duration` (elapsed time) ARE
+/// included because qsv's stats reports them as `String`, so the deterministic
+/// `type` column doesn't cover them; without these tokens `synthesize` would
+/// fall through to lorem text for fields that are clearly temporal. They map
+/// to `fake::faker::time::en::Time` and `Duration` respectively.
+///
+/// `duration` accepts an optional `:N` suffix carrying an LLM-inferred
+/// upper bound in seconds (e.g. `"duration:3600"` for an hour cap). The
+/// suffix is normalized by `normalize_duration_token` and consumed by
+/// `synthesize::faker_map::parse_duration_cap`. Bare `"duration"` falls
+/// back to a 24-hour default at generation time.
 pub(crate) const CONTENT_TYPE_VOCAB: &[&str] = &[
     // person / identity
     "first_name",
@@ -56,8 +68,10 @@ pub(crate) const CONTENT_TYPE_VOCAB: &[&str] = &[
     "file_path",
     "mime_type",
     "color_hex",
-    // temporal
+    // temporal (time-of-day and durations; plain date/datetime fields stay
+    // "unknown" so synthesize's build_date() can use real min/max bounds)
     "time",
+    "duration",
     // generic / fallback
     "category",
     "lorem_word",
@@ -70,6 +84,31 @@ pub(crate) const CONTENT_TYPE_VOCAB: &[&str] = &[
 /// Render `CONTENT_TYPE_VOCAB` as a comma-separated string for prompt injection.
 pub(super) fn content_type_vocab_list() -> String {
     CONTENT_TYPE_VOCAB.join(", ")
+}
+
+/// Normalize the `duration` content type, optionally with an LLM-inferred
+/// per-field upper-bound suffix.
+///
+/// Accepts:
+///   * `"duration"` → returns `Some("duration")` (synthesize falls back to its default 24-hour cap)
+///   * `"duration:N"` where N is a positive integer → returns `Some("duration:N")` (whitespace
+///     around N is tolerated)
+///   * `"duration:<malformed>"` (non-numeric / zero) → returns `Some("duration")` so a bad suffix
+///     degrades gracefully to the unbounded form rather than dropping the classification entirely
+///
+/// Returns `None` for anything that isn't a duration token, so the caller can
+/// fall back to the regular `CONTENT_TYPE_VOCAB` membership check.
+///
+/// Caller is responsible for lowercasing / outer-trimming the input first.
+pub(super) fn normalize_duration_token(raw: &str) -> Option<String> {
+    if raw == "duration" {
+        return Some("duration".to_string());
+    }
+    let suffix = raw.strip_prefix("duration:")?;
+    match suffix.trim().parse::<u64>() {
+        Ok(n) if n > 0 => Some(format!("duration:{n}")),
+        _ => Some("duration".to_string()),
+    }
 }
 
 /// LLM-inferred fields for a single dictionary column, keyed by field name in the
@@ -503,13 +542,19 @@ pub(super) fn parse_llm_dictionary_response(
                     // "First_Name") even when given an explicit token list. A missing, empty, or
                     // out-of-vocabulary value is left empty here; `combine_dictionary_entries`
                     // coerces any still-empty content_type to "unknown" when the flag is set.
+                    //
+                    // `duration` is special: the LLM may append an upper-bound suffix (e.g.
+                    // "duration:3600") that isn't in `CONTENT_TYPE_VOCAB` literally, so route
+                    // it through `normalize_duration_token` first.
                     let raw = field_map
                         .get("content_type")
                         .and_then(|v| v.as_str())
                         .unwrap_or("")
                         .trim()
                         .to_ascii_lowercase();
-                    if CONTENT_TYPE_VOCAB.contains(&raw.as_str()) {
+                    if let Some(normalized) = normalize_duration_token(&raw) {
+                        normalized
+                    } else if CONTENT_TYPE_VOCAB.contains(&raw.as_str()) {
                         raw
                     } else {
                         String::new()
@@ -606,6 +651,78 @@ mod tests {
         let fields = vec!["mystery".to_string()];
         let parsed = parse_llm_dictionary_response(json, &fields, true).unwrap();
         assert!(parsed.get("mystery").unwrap().content_type.is_empty());
+    }
+
+    #[test]
+    fn normalize_duration_token_handles_all_forms() {
+        // Bare token is the trivial accept.
+        assert_eq!(
+            normalize_duration_token("duration").as_deref(),
+            Some("duration")
+        );
+        // Well-formed positive integer suffix: preserved verbatim.
+        assert_eq!(
+            normalize_duration_token("duration:3600").as_deref(),
+            Some("duration:3600")
+        );
+        // Whitespace around the number is tolerated.
+        assert_eq!(
+            normalize_duration_token("duration: 18000").as_deref(),
+            Some("duration:18000")
+        );
+        // Malformed suffixes degrade gracefully to bare "duration" rather
+        // than dropping the classification entirely — the LLM picked
+        // "duration" correctly, only the cap is bad.
+        assert_eq!(
+            normalize_duration_token("duration:0").as_deref(),
+            Some("duration")
+        );
+        assert_eq!(
+            normalize_duration_token("duration:-5").as_deref(),
+            Some("duration")
+        );
+        assert_eq!(
+            normalize_duration_token("duration:abc").as_deref(),
+            Some("duration")
+        );
+        assert_eq!(
+            normalize_duration_token("duration:").as_deref(),
+            Some("duration")
+        );
+        // Non-duration tokens return None so the caller falls through to
+        // the regular vocab check.
+        assert_eq!(normalize_duration_token("time"), None);
+        assert_eq!(normalize_duration_token("email"), None);
+        assert_eq!(normalize_duration_token(""), None);
+    }
+
+    #[test]
+    fn parse_llm_response_accepts_duration_suffix() {
+        let json = r#"{
+            "elapsed":    {"label": "E", "description": "d", "content_type": "duration:3600"},
+            "race_time":  {"label": "R", "description": "d", "content_type": "Duration: 18000"},
+            "bare":       {"label": "B", "description": "d", "content_type": "duration"},
+            "bad_cap":    {"label": "X", "description": "d", "content_type": "duration:0"},
+            "bad_suffix": {"label": "Y", "description": "d", "content_type": "duration:abc"}
+        }"#;
+        let fields = vec![
+            "elapsed".to_string(),
+            "race_time".to_string(),
+            "bare".to_string(),
+            "bad_cap".to_string(),
+            "bad_suffix".to_string(),
+        ];
+        let parsed = parse_llm_dictionary_response(json, &fields, true).unwrap();
+        assert_eq!(parsed.get("elapsed").unwrap().content_type, "duration:3600");
+        // Casing + inner whitespace normalized.
+        assert_eq!(
+            parsed.get("race_time").unwrap().content_type,
+            "duration:18000"
+        );
+        assert_eq!(parsed.get("bare").unwrap().content_type, "duration");
+        // Malformed suffix collapses to bare "duration" rather than empty.
+        assert_eq!(parsed.get("bad_cap").unwrap().content_type, "duration");
+        assert_eq!(parsed.get("bad_suffix").unwrap().content_type, "duration");
     }
 
     #[test]

--- a/src/cmd/synthesize/faker_map.rs
+++ b/src/cmd/synthesize/faker_map.rs
@@ -50,7 +50,15 @@ macro_rules! gen_faker_for_locale {
             // dispatch table simple. The cap is in seconds — bare "duration"
             // defaults to 86_400 (24 h); "duration:N" carries an LLM-inferred
             // upper bound. fake's Duration spans billions of seconds, so the
-            // `% cap` bound is what makes the HH:MM:SS output realistic.
+            // `% cap` bound is what makes the output realistic.
+            //
+            // Format is `H+:MM:SS` — minutes and seconds are always two
+            // digits, but the hours component is variable-width: for the
+            // 24-h default and typical LLM-picked caps (race times, session
+            // durations, etc.) it renders as 2 digits, but a cap above
+            // 99 h * 3600 s lets hours grow to 3+ digits. This is
+            // deliberate: clamping would silently distort the requested
+            // range; we keep the value faithful and accept the wider format.
             if let Some(cap) = parse_duration_cap(content_type) {
                 let d: ::time::Duration = ftime::Duration().fake_with_rng(rng);
                 let total = d.whole_seconds().unsigned_abs() % cap;
@@ -226,20 +234,29 @@ const NON_FAKER_TOKENS: &[&str] = &["category", "unknown"];
 ///
 /// Returns `Some(cap)` for:
 ///   * the bare `"duration"` token (defaults to 86_400 = 24 h)
-///   * `"duration:N"` where N is a positive integer (LLM-inferred upper bound)
+///   * `"duration:N"` where N is a positive integer (LLM-inferred upper bound; whitespace around N
+///     is tolerated)
+///   * `"duration:<malformed>"` (non-numeric / zero / negative / empty) — degrades to the 86_400
+///     default rather than `None`, so user-supplied dictionary JSON that bypasses
+///     `describegpt::normalize_duration_token` still gets duration generation instead of falling
+///     through to lorem fallback text
 ///
-/// Returns `None` for any other token so the caller can fall through to the
-/// regular `match` dispatch. Malformed suffixes (non-numeric, zero, negative)
-/// are NOT silently coerced — `parse_llm_dictionary_response` is responsible
-/// for rejecting bad suffixes upstream, so by the time a token reaches this
-/// helper it has already been validated.
+/// Returns `None` only when the token is not a duration token at all (no
+/// `"duration"` / `"duration:"` prefix), so the caller can fall through to
+/// the regular `match` dispatch.
 pub(crate) fn parse_duration_cap(content_type: &str) -> Option<u64> {
     if content_type == "duration" {
         return Some(86_400);
     }
     let suffix = content_type.strip_prefix("duration:")?;
-    let n: u64 = suffix.parse().ok()?;
-    (n > 0).then_some(n)
+    match suffix.trim().parse::<u64>() {
+        Ok(n) if n > 0 => Some(n),
+        // Malformed / zero / negative suffix → degrade to the default.
+        // describegpt's `normalize_duration_token` normalizes most of these
+        // before they hit the dictionary, but synthesize also accepts
+        // hand-crafted dictionary JSON, so we re-apply the contract here.
+        _ => Some(86_400),
+    }
 }
 
 /// Whether `content_type` maps to a faker (i.e. `content_type_to_value` would
@@ -247,8 +264,10 @@ pub(crate) fn parse_duration_cap(content_type: &str) -> Option<u64> {
 /// draw. Locale-agnostic: every faker token resolves under every locale
 /// (sparse locales fall back to EN data inside fake-rs).
 ///
-/// Also recognizes `duration:N` (positive-integer cap suffix); see
-/// `parse_duration_cap`.
+/// Also recognizes every form `parse_duration_cap` accepts — including
+/// malformed `duration:N` suffixes that degrade to the default cap — so the
+/// faker-vs-fallback decision stays consistent for hand-crafted dictionary
+/// JSON that bypasses `describegpt::normalize_duration_token`.
 pub(crate) fn is_faker_token(content_type: &str) -> bool {
     use crate::cmd::describegpt::dictionary::CONTENT_TYPE_VOCAB;
 
@@ -394,15 +413,19 @@ mod tests {
         assert_eq!(parse_duration_cap("duration:1"), Some(1));
         assert_eq!(parse_duration_cap("duration:3600"), Some(3_600));
         assert_eq!(parse_duration_cap("duration:31536000"), Some(31_536_000));
-        // Malformed suffix: parse_duration_cap rejects (returns None) — the
-        // normalize step upstream is what coerces these to bare "duration",
-        // so by the time parse_duration_cap sees the token it's already
-        // been normalized. Verifying None here documents that contract.
-        assert_eq!(parse_duration_cap("duration:0"), None);
-        assert_eq!(parse_duration_cap("duration:-5"), None);
-        assert_eq!(parse_duration_cap("duration:abc"), None);
-        assert_eq!(parse_duration_cap("duration:"), None);
-        // Non-duration tokens.
+        // Whitespace around the number is tolerated.
+        assert_eq!(parse_duration_cap("duration: 18000"), Some(18_000));
+        // Malformed / zero / negative / empty suffix degrades to the 86_400
+        // default — synthesize also accepts hand-crafted dictionary JSON
+        // that may not have been through normalize_duration_token, so this
+        // helper enforces the "degrade to bare duration" contract on its own.
+        assert_eq!(parse_duration_cap("duration:0"), Some(86_400));
+        assert_eq!(parse_duration_cap("duration:-5"), Some(86_400));
+        assert_eq!(parse_duration_cap("duration:abc"), Some(86_400));
+        assert_eq!(parse_duration_cap("duration:"), Some(86_400));
+        // Non-duration tokens: still None so the caller falls through to
+        // the regular faker-map dispatch.
+        assert_eq!(parse_duration_cap("durationfoo"), None);
         assert_eq!(parse_duration_cap("time"), None);
         assert_eq!(parse_duration_cap("email"), None);
         assert_eq!(parse_duration_cap(""), None);
@@ -437,17 +460,23 @@ mod tests {
         assert!(is_faker_token("duration"));
         assert!(is_faker_token("duration:1"));
         assert!(is_faker_token("duration:86400"));
-        // Malformed suffix is NOT a faker token here — upstream normalize
-        // would have stripped the suffix already, so this case shouldn't
-        // arise in practice; the check just documents the contract.
-        assert!(!is_faker_token("duration:0"));
-        assert!(!is_faker_token("duration:bogus"));
+        assert!(is_faker_token("duration: 18000"));
+        // Malformed suffixes ALSO count as faker tokens — they degrade
+        // to the default 86_400 cap inside parse_duration_cap so that
+        // hand-crafted dictionary JSON with a typo still produces fake
+        // durations instead of falling through to lorem text.
+        assert!(is_faker_token("duration:0"));
+        assert!(is_faker_token("duration:bogus"));
+        assert!(is_faker_token("duration:"));
         // Other vocab tokens still resolve correctly.
         assert!(is_faker_token("time"));
         assert!(is_faker_token("email"));
         assert!(!is_faker_token("category"));
         assert!(!is_faker_token("unknown"));
         assert!(!is_faker_token("not_a_token"));
+        // Non-duration tokens that just happen to start with "duration"
+        // (no colon, no exact match) are NOT faker tokens.
+        assert!(!is_faker_token("durationfoo"));
     }
 
     #[test]

--- a/src/cmd/synthesize/faker_map.rs
+++ b/src/cmd/synthesize/faker_map.rs
@@ -2,10 +2,14 @@
 //! produces a realistic fake value.
 //!
 //! The token vocabulary is `crate::cmd::describegpt::dictionary::CONTENT_TYPE_VOCAB`
-//! (the 40 tokens emitted by `describegpt --infer-content-type`). Every token
+//! (the 42 tokens emitted by `describegpt --infer-content-type`). Every token
 //! except `category` and `unknown` maps to a faker; those two (and any token not
 //! in the vocabulary) return `None` so the caller falls back to
 //! enumeration/frequency- or type-based generation.
+//!
+//! `duration` additionally accepts an LLM-inferred upper-bound suffix
+//! (`"duration:N"` where N is seconds); see `parse_duration_cap`. Both the
+//! bare and suffixed forms share one generation path.
 //!
 //! ## Multi-locale dispatch
 //!
@@ -28,17 +32,34 @@ macro_rules! gen_faker_for_locale {
         #[allow(clippy::too_many_lines)]
         fn $fn_name(content_type: &str, rng: &mut StdRng) -> Option<String> {
             use fake::faker::{
-                address::$loc as addr, barcode::$loc as barcode, chrono::$loc as fchrono,
-                color::$loc as fcolor, company::$loc as company, creditcard::$loc as creditcard,
+                address::$loc as addr, barcode::$loc as barcode, color::$loc as fcolor,
+                company::$loc as company, creditcard::$loc as creditcard,
                 currency::$loc as currency, filesystem::$loc as fs, internet::$loc as net,
                 job::$loc as job, lorem::$loc as lorem, name::$loc as name,
-                phone_number::$loc as phone,
+                phone_number::$loc as phone, time::$loc as ftime,
             };
 
             macro_rules! fake_str {
                 ($faker:expr) => {
                     Some(($faker).fake_with_rng::<String, _>(rng))
                 };
+            }
+
+            // `duration` (bare or "duration:N") shares one generation path with
+            // a parametric cap, so handle it before the literal match keeps the
+            // dispatch table simple. The cap is in seconds — bare "duration"
+            // defaults to 86_400 (24 h); "duration:N" carries an LLM-inferred
+            // upper bound. fake's Duration spans billions of seconds, so the
+            // `% cap` bound is what makes the HH:MM:SS output realistic.
+            if let Some(cap) = parse_duration_cap(content_type) {
+                let d: ::time::Duration = ftime::Duration().fake_with_rng(rng);
+                let total = d.whole_seconds().unsigned_abs() % cap;
+                return Some(format!(
+                    "{:02}:{:02}:{:02}",
+                    total / 3600,
+                    (total % 3600) / 60,
+                    total % 60
+                ));
             }
 
             match content_type {
@@ -95,8 +116,12 @@ macro_rules! gen_faker_for_locale {
                 "mime_type" => fake_str!(fs::MimeType()),
                 "color_hex" => fake_str!(fcolor::HexColor()),
 
-                // temporal
-                "time" => fake_str!(fchrono::Time()),
+                // temporal (time-of-day only; `duration` / `duration:N` is
+                // handled by the pre-match check above. Plain date/datetime
+                // are handled deterministically by the stats `type` column +
+                // min/max in generator::build_date(), so they don't appear
+                // here either.)
+                "time" => fake_str!(ftime::Time()),
 
                 // generic / fallback text
                 "lorem_word" => fake_str!(lorem::Word()),
@@ -197,13 +222,39 @@ define_locales! {
 /// enumeration/frequency- or type-based generation.
 const NON_FAKER_TOKENS: &[&str] = &["category", "unknown"];
 
+/// Parse the duration cap (in seconds) from a `content_type` token.
+///
+/// Returns `Some(cap)` for:
+///   * the bare `"duration"` token (defaults to 86_400 = 24 h)
+///   * `"duration:N"` where N is a positive integer (LLM-inferred upper bound)
+///
+/// Returns `None` for any other token so the caller can fall through to the
+/// regular `match` dispatch. Malformed suffixes (non-numeric, zero, negative)
+/// are NOT silently coerced — `parse_llm_dictionary_response` is responsible
+/// for rejecting bad suffixes upstream, so by the time a token reaches this
+/// helper it has already been validated.
+pub(crate) fn parse_duration_cap(content_type: &str) -> Option<u64> {
+    if content_type == "duration" {
+        return Some(86_400);
+    }
+    let suffix = content_type.strip_prefix("duration:")?;
+    let n: u64 = suffix.parse().ok()?;
+    (n > 0).then_some(n)
+}
+
 /// Whether `content_type` maps to a faker (i.e. `content_type_to_value` would
 /// return `Some`). Used at generator-construction time to avoid a wasted RNG
 /// draw. Locale-agnostic: every faker token resolves under every locale
 /// (sparse locales fall back to EN data inside fake-rs).
+///
+/// Also recognizes `duration:N` (positive-integer cap suffix); see
+/// `parse_duration_cap`.
 pub(crate) fn is_faker_token(content_type: &str) -> bool {
     use crate::cmd::describegpt::dictionary::CONTENT_TYPE_VOCAB;
 
+    if parse_duration_cap(content_type).is_some() {
+        return true;
+    }
     CONTENT_TYPE_VOCAB.contains(&content_type) && !NON_FAKER_TOKENS.contains(&content_type)
 }
 
@@ -292,6 +343,111 @@ mod tests {
             );
         }
         assert!(!is_faker_token("definitely_not_a_token"));
+    }
+
+    #[test]
+    fn temporal_fakers_emit_well_formed_strings() {
+        // `time` should produce a time-of-day (the time crate's Display gives
+        // "HH:MM:SS" or "HH:MM:SS.sssssssss"); `duration` is formatted
+        // explicitly as HH:MM:SS in the faker arm. Both must be non-empty
+        // and contain colon separators for every locale.
+        for locale in all_locales() {
+            let mut rng = StdRng::seed_from_u64(13); // DevSkim: ignore DS148264
+
+            let time = content_type_to_value("time", locale, &mut rng)
+                .unwrap_or_else(|| panic!("time/{locale:?} returned None"));
+            assert!(!time.is_empty(), "time/{locale:?} produced empty string");
+            assert!(
+                time.matches(':').count() >= 2,
+                "time/{locale:?} = {time:?} does not look like HH:MM:SS"
+            );
+
+            let duration = content_type_to_value("duration", locale, &mut rng)
+                .unwrap_or_else(|| panic!("duration/{locale:?} returned None"));
+            assert_eq!(
+                duration.matches(':').count(),
+                2,
+                "duration/{locale:?} = {duration:?} must be HH:MM:SS"
+            );
+            // Each segment must be a 2-digit integer.
+            let segments: Vec<&str> = duration.split(':').collect();
+            assert_eq!(segments.len(), 3, "duration/{locale:?} = {duration:?}");
+            for seg in &segments {
+                assert_eq!(
+                    seg.len(),
+                    2,
+                    "duration/{locale:?} segment {seg:?} not 2 digits in {duration:?}"
+                );
+                assert!(
+                    seg.chars().all(|c| c.is_ascii_digit()),
+                    "duration/{locale:?} segment {seg:?} not all digits in {duration:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn parse_duration_cap_handles_all_forms() {
+        // Bare token defaults to 24h.
+        assert_eq!(parse_duration_cap("duration"), Some(86_400));
+        // Well-formed suffix: any positive integer.
+        assert_eq!(parse_duration_cap("duration:1"), Some(1));
+        assert_eq!(parse_duration_cap("duration:3600"), Some(3_600));
+        assert_eq!(parse_duration_cap("duration:31536000"), Some(31_536_000));
+        // Malformed suffix: parse_duration_cap rejects (returns None) — the
+        // normalize step upstream is what coerces these to bare "duration",
+        // so by the time parse_duration_cap sees the token it's already
+        // been normalized. Verifying None here documents that contract.
+        assert_eq!(parse_duration_cap("duration:0"), None);
+        assert_eq!(parse_duration_cap("duration:-5"), None);
+        assert_eq!(parse_duration_cap("duration:abc"), None);
+        assert_eq!(parse_duration_cap("duration:"), None);
+        // Non-duration tokens.
+        assert_eq!(parse_duration_cap("time"), None);
+        assert_eq!(parse_duration_cap("email"), None);
+        assert_eq!(parse_duration_cap(""), None);
+    }
+
+    #[test]
+    fn duration_suffix_caps_generated_value() {
+        // With a tight cap, every generated value's whole-seconds total must
+        // fit inside [0, cap). Verify across many draws so the modulo bound
+        // is actually load-bearing.
+        let cap_seconds: u64 = 300; // 5 minutes
+        let mut rng = StdRng::seed_from_u64(99); // DevSkim: ignore DS148264
+        for _ in 0..200 {
+            let out = content_type_to_value("duration:300", Locale::EN, &mut rng)
+                .expect("duration:300 must produce a value");
+            // Format is HH:MM:SS; parse back to seconds.
+            let parts: Vec<u64> = out
+                .split(':')
+                .map(|s| s.parse::<u64>().expect("HH:MM:SS digits"))
+                .collect();
+            assert_eq!(parts.len(), 3, "{out:?} not HH:MM:SS");
+            let total = parts[0] * 3600 + parts[1] * 60 + parts[2];
+            assert!(
+                total < cap_seconds,
+                "duration:300 generated {out:?} ({total}s) outside [0,{cap_seconds})"
+            );
+        }
+    }
+
+    #[test]
+    fn is_faker_token_recognizes_duration_suffix() {
+        assert!(is_faker_token("duration"));
+        assert!(is_faker_token("duration:1"));
+        assert!(is_faker_token("duration:86400"));
+        // Malformed suffix is NOT a faker token here — upstream normalize
+        // would have stripped the suffix already, so this case shouldn't
+        // arise in practice; the check just documents the contract.
+        assert!(!is_faker_token("duration:0"));
+        assert!(!is_faker_token("duration:bogus"));
+        // Other vocab tokens still resolve correctly.
+        assert!(is_faker_token("time"));
+        assert!(is_faker_token("email"));
+        assert!(!is_faker_token("category"));
+        assert!(!is_faker_token("unknown"));
+        assert!(!is_faker_token("not_a_token"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds `time` and `duration` to `CONTENT_TYPE_VOCAB` so `describegpt --infer-content-type` can classify time-of-day and elapsed-time columns semantically. Previously these fell through to lorem text in `synthesize` because qsv stats reports them as `String`, so the deterministic Type column (which uses min/max + quartile bucketing for `Date`/`DateTime`) didn't apply.
- For `duration`, the LLM may append an upper-bound cap via a `duration:N` syntax (N = seconds) so `synthesize` generates realistic values instead of fake-rs's billion-second default range. The cap rides inside the existing `content_type` string — no dictionary schema or dispatch signature changes.
- Wires `fake::faker::time::en::Time` and `Duration` (via newly enabled `time` fake-rs feature) into the per-locale faker map for all 14 locales.

## Design notes

| Token | Generation path |
|------|-----------------|
| `time` | `fake::faker::time::en::Time` (per locale) — outputs `HH:MM:SS[.ffff]` |
| `duration` | `fake::faker::time::en::Duration` bounded to `% 86_400` seconds (24h default), formatted `HH:MM:SS` |
| `duration:N` | Same as above with `% N` (LLM-inferred cap in seconds) |

`date` and `datetime` deliberately stay OUT of the vocab — the existing `synthesize::generator::build_date()` path already uses the source column's real `min`/`max` + quartile bucketing, which is richer than what the LLM-hinted path can provide.

`normalize_duration_token` degrades malformed suffixes (`duration:0`, `duration:abc`, `duration:`) to bare `duration` rather than dropping the classification — the LLM picked `duration` correctly; only the cap is bad.

## Test plan

- [x] `cargo test --bin qsv -F all_features cmd::describegpt::` — 32 pass (30 existing + 2 new)
- [x] `cargo test --bin qsv -F all_features cmd::synthesize::` — 19 pass (16 existing + 3 new)
- [x] New tests:
  - `normalize_duration_token_handles_all_forms` (parser-side)
  - `parse_llm_response_accepts_duration_suffix` (end-to-end LLM JSON)
  - `parse_duration_cap_handles_all_forms` (dispatch-side)
  - `duration_suffix_caps_generated_value` (200-iter load-bearing modulo check across HH:MM:SS output)
  - `is_faker_token_recognizes_duration_suffix`
- [x] Existing cross-validation test `every_vocab_token_maps_or_is_known_non_faker_for_every_locale` continues to cover both new tokens across all 14 locales (any token without a faker arm or `NON_FAKER_TOKENS` entry fails it)
- [x] `cargo clippy --bin qsv -F all_features -- -D warnings` — clean
- [x] `cargo +nightly fmt` — applied (project-required nightly fmt config)
- [ ] Manual smoke test: `qsv describegpt sample.csv --dictionary --infer-content-type --json` on a CSV with a time-of-day column and a duration column; verify dictionary entries get the new tokens (and that an LLM picks a sensible `duration:N` cap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)