### PR TITLE
feat(geocode): add cache-clear, cache-prune & cache-info subcommands

### DIFF
--- a/.claude/skills/qsv/qsv-geocode.json
+++ b/.claude/skills/qsv/qsv-geocode.json
@@ -1,7 +1,7 @@
 {
   "name": "qsv-geocode",
   "version": "20.1.0",
-  "description": "Geocodes a location against an updatable local copy of the Geonames cities & the Maxmind GeoLite2 databases. With caching and multi-threading, it geocodes up to 360,000 records/sec!",
+  "description": "Geocodes a location against an updatable local copy of the Geonames cities & the Maxmind GeoLite2 databases — with caching and multi-threading, this offline path geocodes up to 360,000 records/sec! Can also geocode online (forward & reverse) via the OpenCage API, which is sequential and rate-limited.",
   "category": "utility",
   "command": {
     "subcommand": "geocode",
@@ -10,8 +10,11 @@
         "name": "subcommand",
         "type": "string",
         "required": true,
-        "description": "Subcommand to execute. Valid values: countryinfo, countryinfonow, iplookup, iplookupnow, opencage, opencagenow, reverse, reversenow, suggest, suggestnow",
+        "description": "Subcommand to execute. Valid values: cache-clear, cache-info, cache-prune, countryinfo, countryinfonow, iplookup, iplookupnow, opencage, opencagenow, reverse, reversenow, suggest, suggestnow",
         "enum": [
+          "cache-clear",
+          "cache-info",
+          "cache-prune",
           "countryinfo",
           "countryinfonow",
           "iplookup",
@@ -142,6 +145,11 @@
         "flag": "--no-cache",
         "type": "flag",
         "description": "Disable the persistent on-disk OpenCage cache. Duplicate queries within a run are still de-duplicated."
+      },
+      {
+        "flag": "--older-than",
+        "type": "string",
+        "description": "Delete OpenCage cache entries older than this value. Accepts an absolute date/datetime (e.g. 2025-01-31) or a relative age with a unit suffix: s/m/h/d/w = seconds/minutes/hours/days/weeks (e.g. 30d, 2w, 48h). Required by the cache-prune subcommand."
       },
       {
         "flag": "--output",

--- a/.claude/skills/qsv/qsv-geocode.json
+++ b/.claude/skills/qsv/qsv-geocode.json
@@ -67,7 +67,7 @@
       {
         "flag": "--cache-dir",
         "type": "string",
-        "description": "The directory to use for caching the Geonames cities index. If the directory does not exist, qsv will attempt to create it. If the QSV_CACHE_DIR envvar is set, it will be used instead.",
+        "description": "The directory to use for caching the Geonames cities index and the persistent on-disk OpenCage result cache. If the directory does not exist, qsv will attempt to create it. If the QSV_CACHE_DIR envvar is set, it will be used instead.",
         "default": "~/.qsv-cache"
       },
       {

--- a/.claude/skills/qsv/qsv-geocode.json
+++ b/.claude/skills/qsv/qsv-geocode.json
@@ -149,7 +149,7 @@
       {
         "flag": "--older-than",
         "type": "string",
-        "description": "Delete OpenCage cache entries older than this value. Accepts an absolute date/datetime (e.g. 2025-01-31) or a relative age with a unit suffix: s/m/h/d/w = seconds/minutes/hours/days/weeks (e.g. 30d, 2w, 48h). Required by the cache-prune subcommand."
+        "description": "Delete OpenCage cache entries older than this value. Accepts an absolute date/datetime (e.g. 2025-01-31) or a relative age with a unit suffix (s/m/h/d/w = seconds, minutes, hours, days or weeks; e.g. 30d, 2w, 48h). Required by the cache-prune subcommand."
       },
       {
         "flag": "--output",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `sample`: `--varopt <col>` flag for variance-bounded weighted reservoir sampling (A-ExpJ keying, Efraimidis & Spirakis 2006). See Headline above.
 - `sample`: `--mergeable-reservoir` flag for a uniform reservoir sampler whose state is mergeable across runs (same distribution as the default RESERVOIR method). See Headline above.
 - `sample`: `--sketch-out <file>` / `--sketch-in <files>` for serializing and merging sampler state across runs. Sketches carry their source CSV header so merged output is schema-bearing.
+- `geocode`: new `cache-clear`, `cache-prune` & `cache-info` subcommands to manage the persistent on-disk OpenCage result cache. `cache-clear` wipes the cache, `cache-prune --older-than <val>` deletes entries older than an absolute date or a relative age (e.g. `30d`, `2w`), and `cache-info` reports the cache directory, entry count, on-disk size and oldest/newest entry timestamps.
 
 ## [20.1.0] - 2026-05-18 🤖 The "Synthetic Data" Release 🎲
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6153,6 +6153,7 @@ dependencies = [
  "regex",
  "reqwest 0.13.3",
  "rfd",
+ "rmp-serde",
  "rust_decimal",
  "sanitize-filename",
  "self_update",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -264,6 +264,7 @@ reqwest = { version = "0.13", features = [
     "zstd",
 ], default-features = false }
 rfd = { version = "0.17", optional = true }
+rmp-serde = { version = "1.3", optional = true }
 rust_decimal = { version = "1.42", default-features = false }
 sanitize-filename = { version = "0.6", optional = true }
 simd-json = "0.17"
@@ -437,6 +438,7 @@ geocode = [
     "geosuggest-utils",
     "geozero",
     "governor",
+    "rmp-serde",
     "sled",
 ]
 luau = ["mlua", "sanitize-filename"]

--- a/docs/help/geocode.md
+++ b/docs/help/geocode.md
@@ -543,7 +543,7 @@ qsv geocode --help
 
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Option&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Type | Description | Default |
 |--------|------|-------------|--------|
-| &nbsp;`‑‑older‑than`&nbsp; | string | Delete OpenCage cache entries older than this value. Accepts an absolute date/datetime (e.g. 2025-01-31) or a |  |
+| &nbsp;`‑‑older‑than`&nbsp; | string | Delete OpenCage cache entries older than this value. Accepts an absolute date/datetime (e.g. 2025-01-31) or a relative age with a unit suffix (s/m/h/d/w = seconds, minutes, hours, days or weeks; e.g. 30d, 2w, 48h). Required by the cache-prune subcommand. |  |
 
 <a name="index-update-only-options"></a>
 

--- a/docs/help/geocode.md
+++ b/docs/help/geocode.md
@@ -30,7 +30,7 @@ By default, the prebuilt index uses the Geonames Gazeteer cities15000.zip file u
 English names. It contains cities with populations > 15,000 (about ~26k cities).
 See <https://download.geonames.org/export/dump/> for more information.
 
-It has fourteen major subcommands:  
+It has twelve major subcommands:  
 * suggest        - given a partial City name, return the closest City's location metadata
 per the local Geonames cities index (Jaro-Winkler distance)
 * suggestnow     - same as suggest, but using a partial City name from the command line,
@@ -535,7 +535,7 @@ qsv geocode --help
 | &nbsp;`‑j,`<br>`‑‑jobs`&nbsp; | integer | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
 | &nbsp;`‑b,`<br>`‑‑batch`&nbsp; | integer | The number of rows per batch to load into memory, before running in parallel. Set to 0 to load all rows in one batch. | `50000` |
 | &nbsp;`‑‑timeout`&nbsp; | integer | Timeout for downloading Geonames cities index. | `120` |
-| &nbsp;`‑‑cache‑dir`&nbsp; | string | The directory to use for caching the Geonames cities index. If the directory does not exist, qsv will attempt to create it. If the QSV_CACHE_DIR envvar is set, it will be used instead. | `~/.qsv-cache` |
+| &nbsp;`‑‑cache‑dir`&nbsp; | string | The directory to use for caching the Geonames cities index and the persistent on-disk OpenCage result cache. If the directory does not exist, qsv will attempt to create it. If the QSV_CACHE_DIR envvar is set, it will be used instead. | `~/.qsv-cache` |
 
 <a name="cache-prune-only-option"></a>
 

--- a/docs/help/geocode.md
+++ b/docs/help/geocode.md
@@ -5,7 +5,7 @@
 **[Table of Contents](TableOfContents.md)** | **Source: [src/cmd/geocode.rs](https://github.com/dathere/qsv/blob/master/src/cmd/geocode.rs)** | [📇](TableOfContents.md#legend "uses an index when available.")[🧠](TableOfContents.md#legend "expensive operations are memoized with available inter-session Redis/Disk caching for fetch commands.")[🚀](TableOfContents.md#legend "multithreaded even without an index.")[🌐](TableOfContents.md#legend "has web-aware options.")[🔣](TableOfContents.md#legend "requires UTF-8 encoded input.")[👆](TableOfContents.md#legend "has powerful column selector support. See `select` for syntax.")[🌎](TableOfContents.md#legend "has geospatial capabilities.")
 
 <a name="nav"></a>
-[Description](#description) | [Examples](#examples) | [Usage](#usage) | [Arguments](#arguments) | [Geocode Options](#geocode-options) | [Suggest Only Options](#suggest-only-options) | [Reverse Only Option](#reverse-only-option) | [Opencage Only Options](#opencage-only-options) | [Dynamic Formatting Options](#dynamic-formatting-options) | [Index-Update Only Options](#index-update-only-options) | [Common Options](#common-options)
+[Description](#description) | [Examples](#examples) | [Usage](#usage) | [Arguments](#arguments) | [Geocode Options](#geocode-options) | [Suggest Only Options](#suggest-only-options) | [Reverse Only Option](#reverse-only-option) | [Opencage Only Options](#opencage-only-options) | [Dynamic Formatting Options](#dynamic-formatting-options) | [Cache-Prune Only Option](#cache-prune-only-option) | [Index-Update Only Options](#index-update-only-options) | [Common Options](#common-options)
 
 <a name="description"></a>
 
@@ -30,7 +30,7 @@ By default, the prebuilt index uses the Geonames Gazeteer cities15000.zip file u
 English names. It contains cities with populations > 15,000 (about ~26k cities).
 See <https://download.geonames.org/export/dump/> for more information.
 
-It has eleven major subcommands:  
+It has fourteen major subcommands:  
 * suggest        - given a partial City name, return the closest City's location metadata
 per the local Geonames cities index (Jaro-Winkler distance)
 * suggestnow     - same as suggest, but using a partial City name from the command line,
@@ -55,6 +55,8 @@ Forward-geocodes a free-form address, or reverse-geocodes a
 command line, instead of CSV data.
 * index-*        - operations to update the local Geonames cities index.
 (index-check, index-update, index-load & index-reset)
+* cache-*        - operations to manage the persistent on-disk OpenCage result cache.
+(cache-clear, cache-prune & cache-info)
 
 ### Suggest
 
@@ -378,6 +380,48 @@ $ qsv geocode index-load my_geonames_index.rkyv
 ```
 
 
+CACHE-<operation>
+Manage the persistent on-disk OpenCage result cache used by the opencage subcommands.
+This cache is separate from the Geonames cities index and is only populated by the
+opencage/opencagenow subcommands. It lives in {cache-dir}/geocode-opencage_v1.
+
+It has three operations:  
+* clear  - wipe the entire OpenCage disk cache, removing all cached results.
+* prune  - delete cache entries older than the --older-than value. The value is either
+an absolute date/datetime (e.g. 2025-01-31, "2025-01-31 12:00:00") or a
+relative age with a unit suffix - s(econds), m(inutes), h(ours), d(ays) or
+w(eeks). e.g. 30d, 2w, 48h, 90m, 3600s.
+* info   - report the cache directory, entry count, on-disk size and the oldest/newest
+cached entry timestamps. Emits a JSON summary to stdout.
+
+Wipe the entire OpenCage cache.
+
+```console
+$ qsv geocode cache-clear
+```
+
+
+Delete cached entries older than 30 days.
+
+```console
+$ qsv geocode cache-prune --older-than 30d
+```
+
+
+Delete cached entries created before a specific date.
+
+```console
+$ qsv geocode cache-prune --older-than 2025-01-01
+```
+
+
+Show cache statistics.
+
+```console
+$ qsv geocode cache-info
+```
+
+
 
 <a name="examples"></a>
 
@@ -423,6 +467,9 @@ qsv geocode index-load <index-file>
 qsv geocode index-check
 qsv geocode index-update [--languages=<lang>] [--cities-url=<url>] [--force] [--timeout=<seconds>]
 qsv geocode index-reset
+qsv geocode cache-clear [options]
+qsv geocode cache-prune --older-than=<val> [options]
+qsv geocode cache-info [options]
 qsv geocode --help
 ```
 
@@ -489,6 +536,14 @@ qsv geocode --help
 | &nbsp;`‑b,`<br>`‑‑batch`&nbsp; | integer | The number of rows per batch to load into memory, before running in parallel. Set to 0 to load all rows in one batch. | `50000` |
 | &nbsp;`‑‑timeout`&nbsp; | integer | Timeout for downloading Geonames cities index. | `120` |
 | &nbsp;`‑‑cache‑dir`&nbsp; | string | The directory to use for caching the Geonames cities index. If the directory does not exist, qsv will attempt to create it. If the QSV_CACHE_DIR envvar is set, it will be used instead. | `~/.qsv-cache` |
+
+<a name="cache-prune-only-option"></a>
+
+## Cache-Prune Only Option [↩](#nav)
+
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Option&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Type | Description | Default |
+|--------|------|-------------|--------|
+| &nbsp;`‑‑older‑than`&nbsp; | string | Delete OpenCage cache entries older than this value. Accepts an absolute date/datetime (e.g. 2025-01-31) or a |  |
 
 <a name="index-update-only-options"></a>
 

--- a/src/cmd/geocode.rs
+++ b/src/cmd/geocode.rs
@@ -18,7 +18,7 @@ By default, the prebuilt index uses the Geonames Gazeteer cities15000.zip file u
 English names. It contains cities with populations > 15,000 (about ~26k cities). 
 See https://download.geonames.org/export/dump/ for more information.
 
-It has fourteen major subcommands:
+It has twelve major subcommands:
  * suggest        - given a partial City name, return the closest City's location metadata
                     per the local Geonames cities index (Jaro-Winkler distance)
  * suggestnow     - same as suggest, but using a partial City name from the command line,
@@ -491,7 +491,8 @@ geocode options:
                                 [default: 50000]
     --timeout <seconds>         Timeout for downloading Geonames cities index.
                                 [default: 120]
-    --cache-dir <dir>           The directory to use for caching the Geonames cities index.
+    --cache-dir <dir>           The directory to use for caching the Geonames cities index
+                                and the persistent on-disk OpenCage result cache.
                                 If the directory does not exist, qsv will attempt to create it.
                                 If the QSV_CACHE_DIR envvar is set, it will be used instead.
                                 [default: ~/.qsv-cache]
@@ -1946,7 +1947,8 @@ fn run_cache_mgmt(args: &Args, mode: GeocodeSubCmd, cache_dir: &Path) -> CliResu
             cache
                 .remove_expired_entries()
                 .map_err(|e| CliError::Other(format!("Error pruning OpenCage cache: {e}")))?;
-            let _ = db.flush();
+            db.flush()
+                .map_err(|e| CliError::Other(format!("Error flushing OpenCage cache: {e}")))?;
             let after = db.len();
             let pruned = before.saturating_sub(after);
             winfo!(
@@ -1956,22 +1958,36 @@ fn run_cache_mgmt(args: &Args, mode: GeocodeSubCmd, cache_dir: &Path) -> CliResu
         },
         GeocodeSubCmd::CacheInfo => {
             let entry_count = db.len();
-            let size_on_disk = db.size_on_disk().unwrap_or(0);
+            // size_on_disk() can fail on I/O errors; degrade gracefully rather than
+            // reporting a misleading 0 bytes (None -> "unknown" / JSON null)
+            let size_on_disk: Option<u64> = db.size_on_disk().ok();
 
-            // oldest/newest created_at - degrade gracefully on a deserialize failure
+            // oldest/newest created_at - degrade gracefully on a deserialize failure;
+            // surface sled iteration errors via a warning so a partial scan is visible
             let mut oldest: Option<SystemTime> = None;
             let mut newest: Option<SystemTime> = None;
-            for (_key, value) in db.iter().flatten() {
+            for kv in db.iter() {
+                let (_key, value) = match kv {
+                    Ok(kv) => kv,
+                    Err(e) => {
+                        log::warn!("Error reading an OpenCage cache entry: {e}");
+                        continue;
+                    },
+                };
                 if let Ok(entry) = rmp_serde::from_slice::<OpencageCacheEntry>(&value) {
                     oldest = Some(oldest.map_or(entry.created_at, |o| o.min(entry.created_at)));
                     newest = Some(newest.map_or(entry.created_at, |n| n.max(entry.created_at)));
                 }
             }
             let fmt_ts = |t: Option<SystemTime>| t.map(|t| util::format_systemtime(t, "%+"));
+            let size_human = size_on_disk.map(|s| HumanBytes(s).to_string());
 
             winfo!("OpenCage cache directory: {}", cache_path.display());
             winfo!("Entries: {entry_count}");
-            winfo!("Size on disk: {}", HumanBytes(size_on_disk));
+            winfo!(
+                "Size on disk: {}",
+                size_human.clone().unwrap_or_else(|| "unknown".to_string())
+            );
             winfo!(
                 "Oldest entry: {}",
                 fmt_ts(oldest).unwrap_or_else(|| "n/a".to_string())
@@ -1988,7 +2004,7 @@ fn run_cache_mgmt(args: &Args, mode: GeocodeSubCmd, cache_dir: &Path) -> CliResu
                     "exists":       true,
                     "entry_count":  entry_count,
                     "size_on_disk": size_on_disk,
-                    "size_human":   HumanBytes(size_on_disk).to_string(),
+                    "size_human":   size_human,
                     "oldest_entry": fmt_ts(oldest),
                     "newest_entry": fmt_ts(newest),
                 })

--- a/src/cmd/geocode.rs
+++ b/src/cmd/geocode.rs
@@ -499,9 +499,9 @@ geocode options:
                                 CACHE-PRUNE only option:
     --older-than <val>          Delete OpenCage cache entries older than this value.
                                 Accepts an absolute date/datetime (e.g. 2025-01-31) or a
-                                relative age with a unit suffix:
-                                s/m/h/d/w = seconds/minutes/hours/days/weeks
-                                (e.g. 30d, 2w, 48h). Required by the cache-prune subcommand.
+                                relative age with a unit suffix (s/m/h/d/w = seconds,
+                                minutes, hours, days or weeks; e.g. 30d, 2w, 48h).
+                                Required by the cache-prune subcommand.
 
                                 INDEX-UPDATE only options:
     --languages <lang-list>     The comma-delimited, case-insensitive list of languages to use when building
@@ -1855,6 +1855,13 @@ fn parse_relative_age(input: &str) -> Option<Duration> {
 fn resolve_older_than(value: &str) -> CliResult<Duration> {
     if let Some(age) = parse_relative_age(value) {
         return Ok(age);
+    }
+    // a value with the shape of a relative age that didn't parse overflowed -
+    // report that explicitly instead of misleadingly falling through to date parsing
+    if RELATIVE_AGE_REGEX().is_match(value.trim()) {
+        return Err(CliError::IncorrectUsage(format!(
+            "Invalid --older-than value '{value}': the relative age is too large."
+        )));
     }
     // not a relative age - try parsing as an absolute date/datetime
     let cutoff = qsv_dateparser::parse(value).map_err(|e| {
@@ -3289,4 +3296,86 @@ fn add_fields(record: &mut csv::StringRecord, value: &str, count: u8) {
     (0..count).for_each(|_| {
         record.push_field(value);
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_relative_age_units() {
+        assert_eq!(parse_relative_age("30s"), Some(Duration::from_secs(30)));
+        assert_eq!(parse_relative_age("5m"), Some(Duration::from_secs(300)));
+        assert_eq!(parse_relative_age("2h"), Some(Duration::from_secs(7_200)));
+        assert_eq!(parse_relative_age("3d"), Some(Duration::from_secs(259_200)));
+        assert_eq!(parse_relative_age("1w"), Some(Duration::from_secs(604_800)));
+    }
+
+    #[test]
+    fn parse_relative_age_case_and_whitespace() {
+        // unit is case-insensitive and whitespace around/within is tolerated
+        assert_eq!(
+            parse_relative_age("30D"),
+            Some(Duration::from_secs(2_592_000))
+        );
+        assert_eq!(
+            parse_relative_age("  30 d  "),
+            Some(Duration::from_secs(2_592_000))
+        );
+    }
+
+    #[test]
+    fn parse_relative_age_non_matches() {
+        // not a relative-age form -> None (caller falls back to date parsing)
+        assert_eq!(parse_relative_age("2025-01-01"), None);
+        assert_eq!(parse_relative_age("garbage"), None);
+        assert_eq!(parse_relative_age("30"), None); // missing unit
+        assert_eq!(parse_relative_age("30y"), None); // unsupported unit
+    }
+
+    #[test]
+    fn parse_relative_age_overflow_is_none() {
+        // a relative-age form whose seconds overflow u64 -> None
+        assert_eq!(parse_relative_age("99999999999999999999999999w"), None);
+    }
+
+    #[test]
+    fn resolve_older_than_relative_age() {
+        assert_eq!(
+            resolve_older_than("30d").unwrap(),
+            Duration::from_secs(2_592_000)
+        );
+    }
+
+    #[test]
+    fn resolve_older_than_absolute_date() {
+        // a date safely in the past resolves to a large positive age
+        let age = resolve_older_than("2000-01-01").unwrap();
+        assert!(age.as_secs() > 600_000_000);
+    }
+
+    #[test]
+    fn resolve_older_than_future_date_rejected() {
+        let err = resolve_older_than("2099-01-01").unwrap_err();
+        assert!(matches!(&err, CliError::IncorrectUsage(m) if m.contains("in the future")));
+    }
+
+    #[test]
+    fn resolve_older_than_pre_epoch_rejected() {
+        let err = resolve_older_than("1850-01-01").unwrap_err();
+        assert!(matches!(&err, CliError::IncorrectUsage(m) if m.contains("Unix epoch")));
+    }
+
+    #[test]
+    fn resolve_older_than_overflow_rejected() {
+        // a relative-age form that overflows reports the overflow, not a date-parse error
+        let err = resolve_older_than("99999999999999999999999999w").unwrap_err();
+        assert!(matches!(&err, CliError::IncorrectUsage(m) if m.contains("too large")));
+    }
+
+    #[test]
+    fn resolve_older_than_garbage_rejected() {
+        let err = resolve_older_than("not-a-date").unwrap_err();
+        assert!(matches!(&err, CliError::IncorrectUsage(m) if m.contains("not a relative age")));
+    }
 }

--- a/src/cmd/geocode.rs
+++ b/src/cmd/geocode.rs
@@ -18,7 +18,7 @@ By default, the prebuilt index uses the Geonames Gazeteer cities15000.zip file u
 English names. It contains cities with populations > 15,000 (about ~26k cities). 
 See https://download.geonames.org/export/dump/ for more information.
 
-It has eleven major subcommands:
+It has fourteen major subcommands:
  * suggest        - given a partial City name, return the closest City's location metadata
                     per the local Geonames cities index (Jaro-Winkler distance)
  * suggestnow     - same as suggest, but using a partial City name from the command line,
@@ -43,7 +43,9 @@ It has eleven major subcommands:
                     command line, instead of CSV data.
  * index-*        - operations to update the local Geonames cities index.
                     (index-check, index-update, index-load & index-reset)
- 
+ * cache-*        - operations to manage the persistent on-disk OpenCage result cache.
+                    (cache-clear, cache-prune & cache-info)
+
 SUGGEST
 Suggest a Geonames city based on a partial city name. It returns the closest Geonames
 city record based on the Jaro-Winkler distance between the partial city name and the
@@ -233,6 +235,36 @@ Load an alternative Geonames cities index from a file, making it the default ind
 
   $ qsv geocode index-load my_geonames_index.rkyv
 
+CACHE-<operation>
+Manage the persistent on-disk OpenCage result cache used by the opencage subcommands.
+This cache is separate from the Geonames cities index and is only populated by the
+opencage/opencagenow subcommands. It lives in {cache-dir}/geocode-opencage_v1.
+
+It has three operations:
+ * clear  - wipe the entire OpenCage disk cache, removing all cached results.
+ * prune  - delete cache entries older than the --older-than value. The value is either
+            an absolute date/datetime (e.g. 2025-01-31, "2025-01-31 12:00:00") or a
+            relative age with a unit suffix - s(econds), m(inutes), h(ours), d(ays) or
+            w(eeks). e.g. 30d, 2w, 48h, 90m, 3600s.
+ * info   - report the cache directory, entry count, on-disk size and the oldest/newest
+            cached entry timestamps. Emits a JSON summary to stdout.
+
+Wipe the entire OpenCage cache.
+
+  $ qsv geocode cache-clear
+
+Delete cached entries older than 30 days.
+
+  $ qsv geocode cache-prune --older-than 30d
+
+Delete cached entries created before a specific date.
+
+  $ qsv geocode cache-prune --older-than 2025-01-01
+
+Show cache statistics.
+
+  $ qsv geocode cache-info
+
 Examples:
 
 # For US locations, you can retrieve the us_state_fips_code and us_county_fips_code fields of a US City
@@ -264,6 +296,9 @@ qsv geocode index-load <index-file>
 qsv geocode index-check
 qsv geocode index-update [--languages=<lang>] [--cities-url=<url>] [--force] [--timeout=<seconds>]
 qsv geocode index-reset
+qsv geocode cache-clear [options]
+qsv geocode cache-prune --older-than=<val> [options]
+qsv geocode cache-info [options]
 qsv geocode --help
 
 geocode arguments:
@@ -459,7 +494,14 @@ geocode options:
     --cache-dir <dir>           The directory to use for caching the Geonames cities index.
                                 If the directory does not exist, qsv will attempt to create it.
                                 If the QSV_CACHE_DIR envvar is set, it will be used instead.
-                                [default: ~/.qsv-cache]                                
+                                [default: ~/.qsv-cache]
+
+                                CACHE-PRUNE only option:
+    --older-than <val>          Delete OpenCage cache entries older than this value.
+                                Accepts an absolute date/datetime (e.g. 2025-01-31) or a
+                                relative age with a unit suffix:
+                                s/m/h/d/w = seconds/minutes/hours/days/weeks
+                                (e.g. 30d, 2w, 48h). Required by the cache-prune subcommand.
 
                                 INDEX-UPDATE only options:
     --languages <lang-list>     The comma-delimited, case-insensitive list of languages to use when building
@@ -498,6 +540,7 @@ use std::{
     net::{IpAddr, Ipv4Addr},
     num::NonZeroU32,
     path::{Path, PathBuf},
+    time::{Duration, SystemTime},
 };
 
 use cached::{DiskCache, IOCached, SizedCache, proc_macro::cached, stores::DiskCacheBuilder};
@@ -509,7 +552,7 @@ use geosuggest_core::{
 };
 use geosuggest_utils::{IndexUpdater, IndexUpdaterSettings, SourceItem};
 use governor::{DefaultDirectRateLimiter, Quota, RateLimiter};
-use indicatif::{ProgressBar, ProgressDrawTarget};
+use indicatif::{HumanBytes, ProgressBar, ProgressDrawTarget};
 use log::info;
 use phf::phf_map;
 use rayon::{
@@ -547,6 +590,10 @@ static FORMATSTR_REGEX: fn() -> &'static Regex = || regex_oncelock!(r"\{(?P<key>
 // {annotations.timezone.name}) used by the opencage subcommands' dynamic formatting
 static OPENCAGE_FORMATSTR_REGEX: fn() -> &'static Regex = || regex_oncelock!(r"\{([\w.-]+)\}");
 
+// matches a relative age for the cache-prune --older-than option, e.g. 30d, 2w,
+// 48h, 90m, 3600s (case-insensitive). Group 1 is the count, group 2 is the unit.
+static RELATIVE_AGE_REGEX: fn() -> &'static Regex = || regex_oncelock!(r"(?i)^(\d+)\s*([smhdw])$");
+
 #[derive(Deserialize)]
 struct Args {
     arg_column:          String,
@@ -565,6 +612,9 @@ struct Args {
     cmd_index_update:    bool,
     cmd_index_load:      bool,
     cmd_index_reset:     bool,
+    cmd_cache_clear:     bool,
+    cmd_cache_prune:     bool,
+    cmd_cache_info:      bool,
     arg_input:           Option<String>,
     arg_index_file:      Option<String>,
     flag_rename:         Option<String>,
@@ -592,6 +642,7 @@ struct Args {
     flag_no_annotations: bool,
     flag_cache_ttl:      u64,
     flag_no_cache:       bool,
+    flag_older_than:     Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -797,6 +848,9 @@ enum GeocodeSubCmd {
     IndexUpdate,
     IndexLoad,
     IndexReset,
+    CacheClear,
+    CachePrune,
+    CacheInfo,
 }
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
@@ -875,6 +929,19 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         );
     }
 
+    // --older-than is only valid with cache-prune. Validate it eagerly so a bad
+    // value errors regardless of whether an OpenCage cache exists yet.
+    if args.flag_older_than.is_some() && !args.cmd_cache_prune {
+        return fail_incorrectusage_clierror!(
+            "--older-than is only valid with the `cache-prune` subcommand."
+        );
+    }
+    if args.cmd_cache_prune
+        && let Some(older_than) = args.flag_older_than.as_deref()
+    {
+        resolve_older_than(older_than)?;
+    }
+
     // we need to use tokio runtime as geosuggest uses async
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(geocode_main(args))?;
@@ -927,6 +994,12 @@ async fn geocode_main(args: Args) -> CliResult<()> {
     } else if args.cmd_index_reset {
         index_cmd = true;
         GeocodeSubCmd::IndexReset
+    } else if args.cmd_cache_clear {
+        GeocodeSubCmd::CacheClear
+    } else if args.cmd_cache_prune {
+        GeocodeSubCmd::CachePrune
+    } else if args.cmd_cache_info {
+        GeocodeSubCmd::CacheInfo
     } else {
         // should not happen as docopt won't allow it
         unreachable!();
@@ -964,6 +1037,15 @@ async fn geocode_main(args: Args) -> CliResult<()> {
         GeocodeSubCmd::Opencage | GeocodeSubCmd::OpencageNow
     ) {
         return run_opencage(args, geocode_cmd, &geocode_cache_dir).await;
+    }
+
+    // cache-* subcommands manage the persistent on-disk OpenCage result cache.
+    // They do not use the Geonames index, so dispatch before any index handling.
+    if matches!(
+        geocode_cmd,
+        GeocodeSubCmd::CacheClear | GeocodeSubCmd::CachePrune | GeocodeSubCmd::CacheInfo
+    ) {
+        return run_cache_mgmt(&args, geocode_cmd, &geocode_cache_dir);
     }
 
     let geocode_index_filename = std::env::var("QSV_GEOCODE_INDEX_FILENAME")
@@ -1722,6 +1804,192 @@ async fn run_opencage(args: Args, mode: GeocodeSubCmd, cache_dir: &Path) -> CliR
         util::finish_progress(&progress);
     }
     Ok(wtr.flush()?)
+}
+
+// ─────────────────────── OpenCage disk-cache management ───────────────────────
+
+/// The cache name used for the persistent on-disk OpenCage result cache.
+/// `cached`'s `DiskCacheBuilder` stores the sled DB in `{cache_dir}/{name}_v{N}`,
+/// where N is the crate's `DISK_FILE_VERSION` (currently 1).
+const OPENCAGE_CACHE_NAME: &str = "geocode-opencage";
+
+/// The on-disk directory `cached` uses for the OpenCage cache. The `_v1` suffix
+/// tracks `cached`'s `DISK_FILE_VERSION`; update it if the `cached` crate bumps it.
+fn opencage_cache_path(cache_dir: &Path) -> PathBuf {
+    cache_dir.join(format!("{OPENCAGE_CACHE_NAME}_v1"))
+}
+
+/// Deserialize-only mirror of `cached` 0.59's private `CachedDiskValue<String>`.
+/// Entries are rmp_serde-encoded positionally as [value, created_at, version],
+/// so the field ORDER here must match exactly. Used to read entry timestamps for
+/// `cache-info`; if `cached` changes its encoding, deserialization simply fails
+/// and oldest/newest gracefully degrade to "n/a".
+#[derive(serde::Deserialize)]
+#[allow(dead_code)]
+struct OpencageCacheEntry {
+    value:      String,
+    created_at: SystemTime,
+    version:    u64,
+}
+
+/// Parse a relative age like "30d", "2w", "48h", "90m", "3600s" (case-insensitive,
+/// surrounding whitespace allowed) into a Duration. Returns None when the input is
+/// not a relative-age string, so the caller can fall back to absolute-date parsing.
+fn parse_relative_age(input: &str) -> Option<Duration> {
+    let caps = RELATIVE_AGE_REGEX().captures(input.trim())?;
+    let n: u64 = caps.get(1)?.as_str().parse().ok()?;
+    let secs = match caps.get(2)?.as_str().to_ascii_lowercase().as_str() {
+        "s" => n,
+        "m" => n.checked_mul(60)?,
+        "h" => n.checked_mul(3_600)?,
+        "d" => n.checked_mul(86_400)?,
+        "w" => n.checked_mul(604_800)?,
+        _ => return None,
+    };
+    Some(Duration::from_secs(secs))
+}
+
+/// Resolve a `--older-than` value into an age threshold (the lifespan handed to
+/// `DiskCacheBuilder::set_lifespan`). Accepts a relative age (30d, 2w, ...) or an
+/// absolute date/datetime parsed by `qsv_dateparser`. A future cutoff is rejected.
+fn resolve_older_than(value: &str) -> CliResult<Duration> {
+    if let Some(age) = parse_relative_age(value) {
+        return Ok(age);
+    }
+    // not a relative age - try parsing as an absolute date/datetime
+    let cutoff = qsv_dateparser::parse(value).map_err(|e| {
+        CliError::IncorrectUsage(format!(
+            "Invalid --older-than value '{value}': not a relative age (e.g. 30d, 2w) nor a \
+             parseable date - {e}"
+        ))
+    })?;
+    let cutoff_secs = u64::try_from(cutoff.timestamp()).map_err(|_| {
+        CliError::IncorrectUsage(format!(
+            "Invalid --older-than value '{value}': date is before the Unix epoch."
+        ))
+    })?;
+    let cutoff_systime = SystemTime::UNIX_EPOCH + Duration::from_secs(cutoff_secs);
+    SystemTime::now()
+        .duration_since(cutoff_systime)
+        .map_err(|_| {
+            CliError::IncorrectUsage(format!(
+                "Invalid --older-than value '{value}': the date is in the future."
+            ))
+        })
+}
+
+/// Run the `cache-clear` / `cache-prune` / `cache-info` subcommands, which manage
+/// the persistent on-disk OpenCage result cache. Synchronous - does not use the
+/// Geonames index nor make any network calls.
+fn run_cache_mgmt(args: &Args, mode: GeocodeSubCmd, cache_dir: &Path) -> CliResult<()> {
+    let cache_path = opencage_cache_path(cache_dir);
+
+    // graceful "no cache" path - do not create an empty sled DB as a side effect
+    if !cache_path.exists() {
+        winfo!(
+            "No OpenCage cache found at {}. Nothing to do.",
+            cache_path.display()
+        );
+        if mode == GeocodeSubCmd::CacheInfo {
+            println!(
+                "{}",
+                json!({
+                    "cache_dir":   cache_path.display().to_string(),
+                    "exists":      false,
+                    "entry_count": 0,
+                })
+            );
+        }
+        return Ok(());
+    }
+
+    // for cache-prune, the lifespan is the resolved age threshold;
+    // remove_expired_entries() deletes entries where (now - created_at) >= lifespan.
+    let lifespan = if mode == GeocodeSubCmd::CachePrune {
+        // run() guarantees --older-than is present & valid for cache-prune
+        resolve_older_than(args.flag_older_than.as_deref().unwrap_or_default())?
+    } else {
+        Duration::from_secs(0)
+    };
+
+    let mut builder = DiskCacheBuilder::new(OPENCAGE_CACHE_NAME)
+        .set_disk_directory(cache_dir)
+        .set_lifespan(lifespan)
+        .set_refresh(false);
+    if mode == GeocodeSubCmd::CachePrune {
+        // remove_expired_entries() only persists to disk when this is set
+        builder = builder.set_sync_to_disk_on_cache_change(true);
+    }
+    let cache: DiskCache<String, String> = builder
+        .build()
+        .map_err(|e| CliError::Other(format!("Error opening OpenCage disk cache: {e}")))?;
+    let db = cache.connection();
+
+    match mode {
+        GeocodeSubCmd::CacheClear => {
+            let count = db.len();
+            db.clear()
+                .map_err(|e| CliError::Other(format!("Error clearing OpenCage cache: {e}")))?;
+            db.flush()
+                .map_err(|e| CliError::Other(format!("Error flushing OpenCage cache: {e}")))?;
+            winfo!("Cleared the OpenCage cache - removed {count} entries.");
+        },
+        GeocodeSubCmd::CachePrune => {
+            let before = db.len();
+            cache
+                .remove_expired_entries()
+                .map_err(|e| CliError::Other(format!("Error pruning OpenCage cache: {e}")))?;
+            let _ = db.flush();
+            let after = db.len();
+            let pruned = before.saturating_sub(after);
+            winfo!(
+                "Pruned the OpenCage cache - removed {pruned} of {before} entries ({after} \
+                 remaining)."
+            );
+        },
+        GeocodeSubCmd::CacheInfo => {
+            let entry_count = db.len();
+            let size_on_disk = db.size_on_disk().unwrap_or(0);
+
+            // oldest/newest created_at - degrade gracefully on a deserialize failure
+            let mut oldest: Option<SystemTime> = None;
+            let mut newest: Option<SystemTime> = None;
+            for (_key, value) in db.iter().flatten() {
+                if let Ok(entry) = rmp_serde::from_slice::<OpencageCacheEntry>(&value) {
+                    oldest = Some(oldest.map_or(entry.created_at, |o| o.min(entry.created_at)));
+                    newest = Some(newest.map_or(entry.created_at, |n| n.max(entry.created_at)));
+                }
+            }
+            let fmt_ts = |t: Option<SystemTime>| t.map(|t| util::format_systemtime(t, "%+"));
+
+            winfo!("OpenCage cache directory: {}", cache_path.display());
+            winfo!("Entries: {entry_count}");
+            winfo!("Size on disk: {}", HumanBytes(size_on_disk));
+            winfo!(
+                "Oldest entry: {}",
+                fmt_ts(oldest).unwrap_or_else(|| "n/a".to_string())
+            );
+            winfo!(
+                "Newest entry: {}",
+                fmt_ts(newest).unwrap_or_else(|| "n/a".to_string())
+            );
+
+            println!(
+                "{}",
+                json!({
+                    "cache_dir":    cache_path.display().to_string(),
+                    "exists":       true,
+                    "entry_count":  entry_count,
+                    "size_on_disk": size_on_disk,
+                    "size_human":   HumanBytes(size_on_disk).to_string(),
+                    "oldest_entry": fmt_ts(oldest),
+                    "newest_entry": fmt_ts(newest),
+                })
+            );
+        },
+        _ => unreachable!("run_cache_mgmt called with a non-cache subcommand"),
+    }
+    Ok(())
 }
 
 /// Display instructions for rebuilding the Geonames index using the geosuggest crate directly

--- a/tests/test_geocode.rs
+++ b/tests/test_geocode.rs
@@ -2169,7 +2169,7 @@ fn geocode_cache_prune_missing_flag() {
 #[test]
 #[serial]
 fn geocode_cache_prune_bad_older_than() {
-    // an unparseable --older-than value -> clean error (validated in run(),
+    // an unparsable --older-than value -> clean error (validated in run(),
     // independent of whether a cache exists)
     let wrk = Workdir::new("geocode_cache_prune_bad_older_than");
     let mut cmd = wrk.command("geocode");

--- a/tests/test_geocode.rs
+++ b/tests/test_geocode.rs
@@ -2120,3 +2120,113 @@ fn geocode_opencagenow_dynfmt() {
     let got: String = wrk.stdout(&mut cmd);
     assert!(got.to_lowercase().contains("united states"));
 }
+
+// ---------------------------------------------------------------------------
+// cache-* subcommands manage the persistent on-disk OpenCage result cache.
+// The tests below isolate the cache via QSV_CACHE_DIR pointed at the Workdir,
+// so they never touch the real ~/.qsv-cache. The "no cache" tests run in CI;
+// the populated-cache round-trip is #[ignore]'d as it needs a live API key.
+// ---------------------------------------------------------------------------
+
+#[test]
+#[serial]
+fn geocode_cache_info_no_cache() {
+    // cache-info on a cache dir with no OpenCage cache -> graceful "no cache" report
+    let wrk = Workdir::new("geocode_cache_info_no_cache");
+    let mut cmd = wrk.command("geocode");
+    cmd.env("QSV_CACHE_DIR", wrk.path("").to_string_lossy().to_string());
+    cmd.arg("cache-info");
+
+    let output = wrk.output(&mut cmd);
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("No OpenCage cache found"));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("\"exists\":false"));
+}
+
+#[test]
+#[serial]
+fn geocode_cache_clear_no_cache() {
+    // cache-clear on an empty cache dir -> succeeds, nothing to do
+    let wrk = Workdir::new("geocode_cache_clear_no_cache");
+    let mut cmd = wrk.command("geocode");
+    cmd.env("QSV_CACHE_DIR", wrk.path("").to_string_lossy().to_string());
+    cmd.arg("cache-clear");
+    wrk.assert_success(&mut cmd);
+}
+
+#[test]
+#[serial]
+fn geocode_cache_prune_missing_flag() {
+    // cache-prune requires --older-than -> docopt usage error
+    let wrk = Workdir::new("geocode_cache_prune_missing_flag");
+    let mut cmd = wrk.command("geocode");
+    cmd.arg("cache-prune");
+    wrk.assert_err(&mut cmd);
+}
+
+#[test]
+#[serial]
+fn geocode_cache_prune_bad_older_than() {
+    // an unparseable --older-than value -> clean error (validated in run(),
+    // independent of whether a cache exists)
+    let wrk = Workdir::new("geocode_cache_prune_bad_older_than");
+    let mut cmd = wrk.command("geocode");
+    cmd.env("QSV_CACHE_DIR", wrk.path("").to_string_lossy().to_string());
+    cmd.arg("cache-prune").args(["--older-than", "not-a-date"]);
+
+    let output = wrk.output(&mut cmd);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Invalid --older-than"));
+}
+
+#[test]
+#[serial]
+fn geocode_cache_older_than_rejected_elsewhere() {
+    // --older-than is only valid with cache-prune -> rejected on cache-info
+    let wrk = Workdir::new("geocode_cache_older_than_rejected_elsewhere");
+    let mut cmd = wrk.command("geocode");
+    cmd.arg("cache-info").args(["--older-than", "30d"]);
+
+    let output = wrk.output(&mut cmd);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--older-than is only valid"));
+}
+
+#[test]
+#[serial]
+#[ignore = "requires an OpenCage API key (set QSV_OPENCAGE_API_KEY)"]
+fn geocode_cache_roundtrip() {
+    // populate the cache via opencagenow, inspect it, then clear it
+    let wrk = Workdir::new("geocode_cache_roundtrip");
+    let cache_dir = wrk.path("").to_string_lossy().to_string();
+
+    let mut populate = wrk.command("geocode");
+    populate
+        .env("QSV_CACHE_DIR", &cache_dir)
+        .arg("opencagenow")
+        .arg("Brooklyn, NY");
+    wrk.assert_success(&mut populate);
+
+    let mut info = wrk.command("geocode");
+    info.env("QSV_CACHE_DIR", &cache_dir).arg("cache-info");
+    let info_out = wrk.output(&mut info);
+    assert!(info_out.status.success());
+    let info_json = String::from_utf8_lossy(&info_out.stdout);
+    assert!(info_json.contains("\"exists\":true"));
+    assert!(!info_json.contains("\"entry_count\":0"));
+
+    let mut clear = wrk.command("geocode");
+    clear.env("QSV_CACHE_DIR", &cache_dir).arg("cache-clear");
+    wrk.assert_success(&mut clear);
+
+    let mut info2 = wrk.command("geocode");
+    info2.env("QSV_CACHE_DIR", &cache_dir).arg("cache-info");
+    let info2_out = wrk.output(&mut info2);
+    assert!(info2_out.status.success());
+    let info2_json = String::from_utf8_lossy(&info2_out.stdout);
+    assert!(info2_json.contains("\"entry_count\":0"));
+}


### PR DESCRIPTION
## Summary

The `geocode opencage`/`opencagenow` subcommands write geocoding results to a persistent on-disk cache (OpenCage's TOS permits caching). That cache previously had no user-facing management — only `--cache-ttl` / `--no-cache` at use time, with expired entries pruned implicitly on each `opencage` run. There was no way to inspect, wipe, or selectively prune it.

This adds three subcommands to manage the OpenCage disk cache directly:

- **`qsv geocode cache-clear`** — wipe the entire cache; reports entries removed
- **`qsv geocode cache-prune --older-than=<val>`** — delete entries older than an absolute date/datetime (e.g. `2025-01-01`, via `qsv-dateparser`) or a relative age (e.g. `30d`, `2w`, `48h`, `90m`, `3600s`)
- **`qsv geocode cache-info`** — report cache directory, entry count, on-disk size, and oldest/newest entry timestamps (human summary to stderr, JSON to stdout)

Scope is the OpenCage disk cache only (`{cache_dir}/geocode-opencage_v1`). The Geonames cities index already has `index-*`; the in-memory LRU cache is ephemeral.

## How it works

- `cache-prune` leverages `DiskCache::remove_expired_entries()` — the cache is built with `set_lifespan(age_threshold)`, so "older than 30d" is exactly a 30-day lifespan. Future cutoff dates are rejected.
- `cache-clear` goes through the sled API (`connection().clear()`) rather than coupling to the `cached` crate's internal `_v1` directory layout.
- `cache-info` reads per-entry `created_at` via a local deserialize-only mirror of `cached`'s private entry struct; if that encoding ever changes, oldest/newest degrade gracefully to `n/a` (dir/count/size still correct).
- All three short-circuit with "No OpenCage cache found" when no cache exists, avoiding creating an empty sled DB as a side effect.

## Changes

- `src/cmd/geocode.rs` — USAGE docs, `Args`/`GeocodeSubCmd`, dispatch, `run_cache_mgmt` + `resolve_older_than`/`parse_relative_age` helpers
- `Cargo.toml`/`Cargo.lock` — `rmp-serde` added as a `geocode`-feature-gated optional dep (already in the tree transitively via `cached`)
- `tests/test_geocode.rs` — 5 CI tests (no API key) + 1 `#[ignore]`'d populated-cache round-trip
- `CHANGELOG.md`, `docs/help/geocode.md`, `.claude/skills/qsv/qsv-geocode.json` — regenerated

## Testing

- `cargo build -F all_features` and `cargo clippy -F all_features` — clean
- `cargo test -F all_features test_geocode` — 40 passed, 25 ignored
- Manual smoke tests: no-cache reporting, future-date rejection, relative-age parsing, stray-`--older-than` rejection, and clear/prune/info on an existing sled DB all behave correctly
- `geocode_cache_roundtrip` is `#[ignore]`'d (needs `QSV_OPENCAGE_API_KEY`) and verifies the populated-cache paths end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)