### PR TITLE
Initial support for DDI-Codebook in profile command

### DIFF
--- a/src/cmd/profile.rs
+++ b/src/cmd/profile.rs
@@ -32,6 +32,11 @@ profile options:
     --resource-meta <json>    Same, for the resource dict.
     --no-dcat                 Skip the DCAT-US v3 projection block.
     --no-ckan                 Skip the CKAN-shape block.
+    --ddi-c <file>            Optional output path for DDI-Codebook XML.
+    --ddi-catgry-limit <arg>  DDI category limit policy. Accepts either:
+                              1) number (global default cap),
+                              2) JSON object string (per-variable caps), or
+                              3) path to a JSON file containing that object.
     --force                   Force recomputing cardinality and unique values
                               even if a stats cache file exists.
     -j, --jobs <arg>          The number of jobs to run in parallel for the
@@ -61,6 +66,7 @@ use crate::{CliError, CliResult, util};
 
 mod context;
 mod dcat;
+mod ddic;
 mod py_engine;
 mod spec;
 
@@ -72,6 +78,8 @@ struct Args {
     flag_resource_meta: Option<String>,
     flag_no_dcat:       bool,
     flag_no_ckan:       bool,
+    flag_ddi_c:         Option<String>,
+    flag_ddi_catgry_limit: Option<String>,
     flag_force:         bool,
     flag_jobs:          Option<usize>,
     flag_output:        Option<String>,
@@ -81,7 +89,26 @@ struct Args {
 }
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
-    let args: Args = util::get_args(USAGE, argv)?;
+    // Accept legacy single-dash long form requested by users.
+    let normalized_argv: Vec<String> = argv
+        .iter()
+        .map(|arg| {
+            if *arg == "-ddi-c" {
+                "--ddi-c".to_string()
+            } else {
+                (*arg).to_string()
+            }
+        })
+        .collect();
+    let normalized_argv_ref: Vec<&str> = normalized_argv.iter().map(String::as_str).collect();
+
+    let args: Args = util::get_args(USAGE, &normalized_argv_ref)?;
+
+    let ddic_policy = ddic::parse_limit_policy(args.flag_ddi_catgry_limit.as_deref())?;
+    let frequency_limit = std::cmp::max(
+        context::DEFAULT_PROFILE_FREQUENCY_LIMIT,
+        ddic_policy.max_requested_cap(),
+    );
 
     // For v1 we require a real input file path — running stats + frequency in
     // subprocess form against stdin would require materializing it to a
@@ -110,6 +137,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         jobs:          args.flag_jobs,
         force:         args.flag_force,
         memcheck:      args.flag_memcheck,
+        frequency_limit,
         package_meta:  args.flag_package_meta.as_deref(),
         resource_meta: args.flag_resource_meta.as_deref(),
     };
@@ -197,7 +225,22 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         out_map.insert("dcat".to_string(), dcat_block);
     }
 
-    let _ = analysis.headers;
+    if let Some(ddi_out_path) = args.flag_ddi_c.as_deref() {
+        let dpp = analysis.context.get("dpp").cloned().unwrap_or(json!({}));
+        let stats = analysis.context.get("dpps").cloned().unwrap_or(json!({}));
+        let frequency = analysis.context.get("dppf").cloned().unwrap_or(json!({}));
+        let ddic_xml = ddic::build(
+            &input_path,
+            &analysis.headers,
+            &dpp,
+            &stats,
+            &frequency,
+            &ddic_policy,
+        )?;
+        std::fs::write(ddi_out_path, ddic_xml)
+            .map_err(|e| CliError::Other(format!("could not write `{ddi_out_path}`: {e}")))?;
+        eprintln!("qsv profile: wrote `{ddi_out_path}`");
+    }
 
     // --- 5. write output --------------------------------------------------
     let out_path = args.flag_output.clone().unwrap_or_else(|| {

--- a/src/cmd/profile/context.rs
+++ b/src/cmd/profile/context.rs
@@ -28,6 +28,8 @@ use crate::{
     util::{self, SchemaArgs, StatsMode},
 };
 
+pub const DEFAULT_PROFILE_FREQUENCY_LIMIT: usize = 25;
+
 /// CLI-facing knobs that the context builder cares about. Kept narrow so we
 /// don't couple `context.rs` to the full top-level `Args` struct.
 pub struct ContextArgs<'a> {
@@ -37,6 +39,7 @@ pub struct ContextArgs<'a> {
     pub jobs:          Option<usize>,
     pub force:         bool,
     pub memcheck:      bool,
+    pub frequency_limit: usize,
     pub package_meta:  Option<&'a str>,
     pub resource_meta: Option<&'a str>,
 }
@@ -78,7 +81,7 @@ pub fn build(args: &ContextArgs, _spec: Option<&Spec>) -> CliResult<AnalysisCont
 
     // --- 2. frequency ------------------------------------------------------
     // Mirrors describegpt: shell out to `qsv frequency` and parse the CSV.
-    // Defaults: top 25 values per column, drop "Other" / NULL aggregate rows
+    // Defaults: top N values per column, drop "Other" / NULL aggregate rows
     // so the per-column lists stay tight for downstream consumers.
     //
     // Forwards every CSV-parsing / execution flag that profile took on its
@@ -88,7 +91,7 @@ pub fn build(args: &ContextArgs, _spec: Option<&Spec>) -> CliResult<AnalysisCont
     // stats and another way for frequency, producing inconsistent records.
     let mut freq_owned: Vec<String> = vec![
         "--limit".to_string(),
-        "25".to_string(),
+        args.frequency_limit.to_string(),
         "--no-other".to_string(),
         "--no-nulls".to_string(),
     ];

--- a/src/cmd/profile/ddic.rs
+++ b/src/cmd/profile/ddic.rs
@@ -101,7 +101,7 @@ pub fn build(
 	frequency: &Value,
 	policy: &CatgryLimitPolicy,
 ) -> CliResult<String> {
-	let codebook_id = Uuid::new_v4().to_string();
+	let codebook_id = format!("_{}", Uuid::new_v4());
 	let filename = Path::new(input_path)
 		.file_name()
 		.and_then(|s| s.to_str())
@@ -146,7 +146,7 @@ pub fn build(
 
 	write!(
 		out,
-		"  <fileDscr ID=\"F1\">\n    <fileTxt>\n      <fileName>{}</fileName>\n      <fileType>CSV</fileType>\n      <dimensns>\n        <caseCnt>{}</caseCnt>\n        <varCnt>{}</varCnt>\n      </dimensns>\n    </fileTxt>\n  </fileDscr>\n",
+		"  <fileDscr ID=\"F1\">\n    <fileTxt>\n      <fileName>{}</fileName>\n      <dimensns>\n        <caseQnty>{}</caseQnty>\n        <varQnty>{}</varQnty>\n      </dimensns>\n      <fileType>CSV</fileType>\n    </fileTxt>\n  </fileDscr>\n",
 		escape_xml_text(&filename),
 		row_count,
 		headers.len()
@@ -183,7 +183,7 @@ pub fn build(
 
 		write!(
 			out,
-			"      <varFormat type=\"{}\" schema=\"qsv\" formatname=\"{}\"/>\n",
+			"      <varFormat type=\"{}\" schema=\"other\" otherSchema=\"qsv\" formatname=\"{}\"/>\n",
 			escape_xml_attr(var_type),
 			escape_xml_attr(infer_source_type(stats_obj).unwrap_or("Unknown"))
 		)
@@ -358,7 +358,7 @@ fn emit_sumstats(
 		.unwrap_or(0);
 	write!(
 		out,
-		"      <sumStat type=\"invld\">{}</sumStat>\n      <sumStat type=\"vald\">{}</sumStat>\n",
+		"      <sumStat type=\"invd\">{}</sumStat>\n      <sumStat type=\"vald\">{}</sumStat>\n",
 		nullcount,
 		row_count.saturating_sub(nullcount)
 	)?;
@@ -445,7 +445,7 @@ fn emit_categories(
 		let percentage = c.get("percentage").and_then(Value::as_f64).unwrap_or(0.0);
 		write!(
 			out,
-			"      <catgry>\n        <catVal>{}</catVal>\n        <labl>{}</labl>\n        <catStat type=\"freq\">{}</catStat>\n        <catStat type=\"percent\">{}</catStat>\n      </catgry>\n",
+			"      <catgry>\n        <catValu>{}</catValu>\n        <labl>{}</labl>\n        <catStat type=\"freq\">{}</catStat>\n        <catStat type=\"percent\">{}</catStat>\n      </catgry>\n",
 			escape_xml_text(&value),
 			escape_xml_text(&value),
 			count,

--- a/src/cmd/profile/ddic.rs
+++ b/src/cmd/profile/ddic.rs
@@ -1,0 +1,478 @@
+use std::{collections::HashMap, fmt::Write, path::Path};
+
+use chrono::Utc;
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::{CliError, CliResult};
+
+const DDI_NS: &str = "http://www.icpsr.umich.edu/DDI";
+const DDI_SCHEMA_LOCATION: &str =
+	"http://www.icpsr.umich.edu/DDI http://www.icpsr.umich.edu/DDI/Version2-6/XMLSchema/codebook.xsd";
+// Keep this aligned with profile/context SchemaArgs::flag_enum_threshold.
+const PROFILE_SCHEMA_ENUM_THRESHOLD: u64 = 50;
+
+pub const DEFAULT_DDIC_CATGRY_LIMIT: usize = 25;
+
+#[derive(Debug, Clone)]
+pub struct CatgryLimitPolicy {
+	default_cap: usize,
+	overrides:   HashMap<String, usize>,
+}
+
+impl Default for CatgryLimitPolicy {
+	fn default() -> Self {
+		Self {
+			default_cap: DEFAULT_DDIC_CATGRY_LIMIT,
+			overrides:   HashMap::new(),
+		}
+	}
+}
+
+impl CatgryLimitPolicy {
+	pub fn max_requested_cap(&self) -> usize {
+		self.overrides
+			.values()
+			.copied()
+			.max()
+			.unwrap_or(self.default_cap)
+			.max(self.default_cap)
+	}
+
+	pub fn cap_for(&self, field: &str) -> usize {
+		self.overrides
+			.get(field)
+			.copied()
+			.unwrap_or(self.default_cap)
+	}
+}
+
+pub fn parse_limit_policy(raw: Option<&str>) -> CliResult<CatgryLimitPolicy> {
+	let Some(raw) = raw else {
+		return Ok(CatgryLimitPolicy::default());
+	};
+
+	let trimmed = raw.trim();
+	if trimmed.is_empty() {
+		return Err(CliError::Other(
+			"--ddi-catgry-limit cannot be empty".to_string(),
+		));
+	}
+
+	// parse order: numeric literal -> inline JSON object -> JSON file path
+	if let Ok(n) = trimmed.parse::<usize>() {
+		return Ok(CatgryLimitPolicy {
+			default_cap: n,
+			overrides:   HashMap::new(),
+		});
+	}
+
+	if let Ok(overrides) = parse_override_json_object(trimmed) {
+		return Ok(CatgryLimitPolicy {
+			default_cap: DEFAULT_DDIC_CATGRY_LIMIT,
+			overrides,
+		});
+	}
+
+	let raw_file = std::fs::read_to_string(trimmed).map_err(|e| {
+		CliError::Other(format!(
+			"--ddi-catgry-limit value is neither numeric nor a valid JSON object and `{trimmed}` \
+			 could not be read as a JSON file: {e}"
+		))
+	})?;
+	let overrides = parse_override_json_object(&raw_file).map_err(|e| {
+		CliError::Other(format!(
+			"--ddi-catgry-limit file `{trimmed}` does not contain a valid JSON override object: \
+			 {e}"
+		))
+	})?;
+
+	Ok(CatgryLimitPolicy {
+		default_cap: DEFAULT_DDIC_CATGRY_LIMIT,
+		overrides,
+	})
+}
+
+pub fn build(
+	input_path: &str,
+	headers: &[String],
+	dpp: &Value,
+	stats: &Value,
+	frequency: &Value,
+	policy: &CatgryLimitPolicy,
+) -> CliResult<String> {
+	let codebook_id = Uuid::new_v4().to_string();
+	let filename = Path::new(input_path)
+		.file_name()
+		.and_then(|s| s.to_str())
+		.unwrap_or(input_path)
+		.to_string();
+
+	let row_count = dpp
+		.pointer("/dataset_stats/row_count")
+		.and_then(Value::as_u64)
+		.unwrap_or(0);
+
+	let mut out = String::with_capacity(16_384);
+	write!(
+		out,
+		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<codeBook version=\"2.6\" xml:lang=\"en-US\" ID=\"{}\" xmlns=\"{}\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"{}\">\n",
+		escape_xml_attr(&codebook_id),
+		escape_xml_attr(DDI_NS),
+		escape_xml_attr(DDI_SCHEMA_LOCATION)
+	)
+	.map_err(|e| CliError::Other(format!("could not build DDI XML: {e}")))?;
+
+	let today = Utc::now().format("%Y-%m-%d").to_string();
+
+	write!(
+		out,
+		"  <docDscr>\n    <citation>\n      <titlStmt>\n        <titl>{}</titl>\n      </titlStmt>\n      <prodStmt>\n        <prodDate date=\"{}\">{}</prodDate>\n        <software version=\"{}\">qsv</software>\n      </prodStmt>\n    </citation>\n  </docDscr>\n",
+		escape_xml_text(&format!("qsv profile DDI-Codebook: {filename}")),
+		escape_xml_attr(&today),
+		escape_xml_text(&today),
+		escape_xml_attr(env!("CARGO_PKG_VERSION"))
+	)
+	.map_err(|e| CliError::Other(format!("could not build DDI XML: {e}")))?;
+
+	// Required study title, sourced from the input filename.
+	write!(
+		out,
+		"  <stdyDscr>\n    <citation>\n      <titlStmt>\n        <titl>{}</titl>\n      \
+		 </titlStmt>\n    </citation>\n  </stdyDscr>\n",
+		escape_xml_text(&filename)
+	)
+	.map_err(|e| CliError::Other(format!("could not build DDI XML: {e}")))?;
+
+	write!(
+		out,
+		"  <fileDscr ID=\"F1\">\n    <fileTxt>\n      <fileName>{}</fileName>\n      <fileType>CSV</fileType>\n      <dimensns>\n        <caseCnt>{}</caseCnt>\n        <varCnt>{}</varCnt>\n      </dimensns>\n    </fileTxt>\n  </fileDscr>\n",
+		escape_xml_text(&filename),
+		row_count,
+		headers.len()
+	)
+	.map_err(|e| CliError::Other(format!("could not build DDI XML: {e}")))?;
+
+	out.push_str("  <dataDscr>\n");
+	for (idx, field) in headers.iter().enumerate() {
+		let var_id = format!("V{}", idx + 1);
+		let stats_obj = stats_for_field(stats, field);
+		let var_type = infer_var_type(stats_obj);
+		let has_categories = has_eligible_categories(field, frequency, policy);
+		let is_categorical = infer_is_categorical(stats_obj, row_count, has_categories);
+		let intrvl = infer_intrvl(var_type, is_categorical);
+		let representation_type = infer_representation_type(var_type, is_categorical);
+		let dcml_attr = max_precision_attr(stats_obj);
+		write!(
+			out,
+			"    <var ID=\"{}\" name=\"{}\" files=\"F1\" intrvl=\"{}\" representationType=\"{}\"{}>\n      <labl>{}</labl>\n",
+			escape_xml_attr(&var_id),
+			escape_xml_attr(field),
+			escape_xml_attr(intrvl),
+			escape_xml_attr(representation_type),
+			dcml_attr,
+			escape_xml_text(field)
+		)
+		.map_err(|e| CliError::Other(format!("could not build DDI XML: {e}")))?;
+
+		emit_sumstats(&mut out, stats_obj, row_count)
+			.map_err(|e| CliError::Other(format!("could not build DDI XML: {e}")))?;
+
+		emit_categories(&mut out, field, frequency, policy, is_categorical)
+			.map_err(|e| CliError::Other(format!("could not build DDI XML: {e}")))?;
+
+		write!(
+			out,
+			"      <varFormat type=\"{}\" schema=\"qsv\" formatname=\"{}\"/>\n",
+			escape_xml_attr(var_type),
+			escape_xml_attr(infer_source_type(stats_obj).unwrap_or("Unknown"))
+		)
+		.map_err(|e| CliError::Other(format!("could not build DDI XML: {e}")))?;
+
+		out.push_str("    </var>\n");
+	}
+	out.push_str("  </dataDscr>\n</codeBook>\n");
+
+	Ok(out)
+}
+
+fn parse_override_json_object(raw: &str) -> Result<HashMap<String, usize>, String> {
+	let parsed: Value = serde_json::from_str(raw).map_err(|e| e.to_string())?;
+	let obj = parsed
+		.as_object()
+		.ok_or_else(|| "expected a JSON object".to_string())?;
+
+	let mut overrides = HashMap::with_capacity(obj.len());
+	for (k, v) in obj {
+		let Some(num) = v.as_u64() else {
+			return Err(format!("override value for `{k}` must be an unsigned integer"));
+		};
+		let cap = usize::try_from(num)
+			.map_err(|_| format!("override value for `{k}` is too large for this platform"))?;
+		overrides.insert(k.to_string(), cap);
+	}
+	Ok(overrides)
+}
+
+fn stats_for_field<'a>(stats: &'a Value, field: &str) -> Option<&'a Value> {
+	stats
+		.as_object()
+		.and_then(|m| m.get(field))
+		.and_then(|v| v.get("stats"))
+}
+
+fn infer_var_type(stats_obj: Option<&Value>) -> &'static str {
+	match infer_source_type(stats_obj) {
+		Some("Integer") | Some("Float") => "numeric",
+		Some("Date") => "date",
+		Some("DateTime") => "datetime",
+		_ => "character",
+	}
+}
+
+fn infer_source_type(stats_obj: Option<&Value>) -> Option<&str> {
+	stats_obj
+		.and_then(|v| v.get("type"))
+		.and_then(Value::as_str)
+}
+
+fn infer_intrvl(var_type: &str, is_categorical: bool) -> &'static str {
+	if is_categorical {
+		return "discrete";
+	}
+
+	match var_type {
+		"numeric" | "date" | "datetime" => "contin",
+		_ => "discrete",
+	}
+}
+
+fn infer_representation_type(var_type: &str, is_categorical: bool) -> &'static str {
+	if is_categorical {
+		"coded"
+	} else if var_type == "numeric" {
+		"numeric"
+	} else if var_type == "date" || var_type == "datetime" {
+		"datetime"
+	} else {
+		"text"
+	}
+}
+
+fn infer_is_categorical(stats_obj: Option<&Value>, row_count: u64, has_categories: bool) -> bool {
+	let Some(stats_obj) = stats_obj else {
+		return has_categories;
+	};
+
+	let source_type = infer_source_type(Some(stats_obj)).unwrap_or("Unknown");
+	if has_schema_enum_or_const(stats_obj, source_type) {
+		return true;
+	}
+
+	if source_type == "Date" || source_type == "DateTime" {
+		return false;
+	}
+
+	let cardinality = stats_obj
+		.get("cardinality")
+		.and_then(Value::as_u64)
+		.unwrap_or(0);
+	let uniqueness_ratio = stats_obj
+		.get("uniqueness_ratio")
+		.and_then(Value::as_f64)
+		.unwrap_or(1.0);
+	let nullcount = stats_obj
+		.get("nullcount")
+		.and_then(Value::as_u64)
+		.unwrap_or(0);
+	let non_null_count = row_count.saturating_sub(nullcount);
+
+	if non_null_count == 0 {
+		return false;
+	}
+
+	match source_type {
+		"String" | "Integer" => false,
+		"Float" => {
+			cardinality <= 12 && uniqueness_ratio <= 0.20
+		}
+		_ => has_categories && cardinality <= 30,
+	}
+}
+
+fn has_schema_enum_or_const(stats_obj: &Value, source_type: &str) -> bool {
+	if source_type != "String" && source_type != "Integer" {
+		return false;
+	}
+
+	let cardinality = stats_obj
+		.get("cardinality")
+		.and_then(Value::as_u64)
+		.unwrap_or(u64::MAX);
+
+	cardinality <= PROFILE_SCHEMA_ENUM_THRESHOLD
+}
+
+fn max_precision_attr(stats_obj: Option<&Value>) -> String {
+	let Some(dcml) = stats_obj
+		.and_then(|v| v.get("max_precision"))
+		.and_then(Value::as_u64)
+	else {
+		return String::new();
+	};
+
+	format!(" dcml=\"{}\"", dcml)
+}
+
+fn has_eligible_categories(field: &str, frequency: &Value, policy: &CatgryLimitPolicy) -> bool {
+	let cap = policy.cap_for(field);
+	if cap == 0 {
+		return false;
+	}
+
+	let Some(cats) = frequency.as_object().and_then(|m| m.get(field)).and_then(Value::as_array)
+	else {
+		return false;
+	};
+
+	!cats.is_empty() && cats.len() <= cap
+}
+
+fn emit_sumstats(
+	out: &mut String,
+	stats_obj: Option<&Value>,
+	row_count: u64,
+) -> Result<(), std::fmt::Error> {
+	let Some(stats_obj) = stats_obj else {
+		return Ok(());
+	};
+
+	emit_sumstat_f64(out, "mean", stats_obj.get("mean"));
+	emit_sumstat_f64(out, "stdev", stats_obj.get("stddev"));
+	emit_sumstat_text(out, "min", stats_obj.get("min"));
+	emit_sumstat_text(out, "max", stats_obj.get("max"));
+
+	let nullcount = stats_obj
+		.get("nullcount")
+		.and_then(Value::as_u64)
+		.unwrap_or(0);
+	write!(
+		out,
+		"      <sumStat type=\"invld\">{}</sumStat>\n      <sumStat type=\"vald\">{}</sumStat>\n",
+		nullcount,
+		row_count.saturating_sub(nullcount)
+	)?;
+
+	emit_other_sumstat_f64(out, "sum", stats_obj.get("sum"));
+	emit_other_sumstat_f64(out, "range", stats_obj.get("range"));
+	emit_other_sumstat_f64(out, "variance", stats_obj.get("variance"));
+	emit_other_sumstat_f64(out, "cv", stats_obj.get("cv"));
+	emit_other_sumstat_f64(out, "sparsity", stats_obj.get("sparsity"));
+
+	if let Some(cardinality) = stats_obj.get("cardinality").and_then(Value::as_u64) {
+		write!(
+			out,
+			"      <sumStat type=\"other\" otherType=\"cardinality\">{}</sumStat>\n",
+			cardinality
+		)?;
+	}
+
+	Ok(())
+}
+
+fn emit_sumstat_f64(out: &mut String, kind: &str, v: Option<&Value>) {
+	if let Some(n) = v.and_then(Value::as_f64) {
+		let _ = writeln!(
+			out,
+			"      <sumStat type=\"{}\">{}</sumStat>",
+			escape_xml_attr(kind),
+			n
+		);
+	}
+}
+
+fn emit_sumstat_text(out: &mut String, kind: &str, v: Option<&Value>) {
+	if let Some(s) = v.and_then(Value::as_str) {
+		let _ = writeln!(
+			out,
+			"      <sumStat type=\"{}\">{}</sumStat>",
+			escape_xml_attr(kind),
+			escape_xml_text(s)
+		);
+	}
+}
+
+fn emit_other_sumstat_f64(out: &mut String, other_type: &str, v: Option<&Value>) {
+	if let Some(n) = v.and_then(Value::as_f64) {
+		let _ = writeln!(
+			out,
+			"      <sumStat type=\"other\" otherType=\"{}\">{}</sumStat>",
+			escape_xml_attr(other_type),
+			n
+		);
+	}
+}
+
+fn emit_categories(
+	out: &mut String,
+	field: &str,
+	frequency: &Value,
+	policy: &CatgryLimitPolicy,
+	is_categorical: bool,
+) -> Result<(), std::fmt::Error> {
+	if !is_categorical {
+		return Ok(());
+	}
+
+	let cap = policy.cap_for(field);
+	if cap == 0 {
+		return Ok(());
+	}
+
+	let Some(cats) = frequency.as_object().and_then(|m| m.get(field)).and_then(Value::as_array)
+	else {
+		return Ok(());
+	};
+
+	// Conservative rule: if categories exceed cap, omit categories entirely.
+	if cats.len() > cap {
+		return Ok(());
+	}
+
+	for c in cats {
+		let value = c.get("value").map(json_value_to_string).unwrap_or_default();
+		let count = c.get("count").and_then(Value::as_u64).unwrap_or(0);
+		let percentage = c.get("percentage").and_then(Value::as_f64).unwrap_or(0.0);
+		write!(
+			out,
+			"      <catgry>\n        <catVal>{}</catVal>\n        <labl>{}</labl>\n        <catStat type=\"freq\">{}</catStat>\n        <catStat type=\"percent\">{}</catStat>\n      </catgry>\n",
+			escape_xml_text(&value),
+			escape_xml_text(&value),
+			count,
+			percentage
+		)?;
+	}
+	Ok(())
+}
+
+fn json_value_to_string(v: &Value) -> String {
+	match v {
+		Value::Null => String::new(),
+		Value::Bool(b) => b.to_string(),
+		Value::Number(n) => n.to_string(),
+		Value::String(s) => s.to_string(),
+		Value::Array(_) | Value::Object(_) => v.to_string(),
+	}
+}
+
+fn escape_xml_text(s: &str) -> String {
+	s.replace('&', "&amp;")
+		.replace('<', "&lt;")
+		.replace('>', "&gt;")
+}
+
+fn escape_xml_attr(s: &str) -> String {
+	escape_xml_text(s)
+		.replace('"', "&quot;")
+		.replace('\'', "&apos;")
+}

--- a/tests/test_profile_ddic.rs
+++ b/tests/test_profile_ddic.rs
@@ -38,8 +38,12 @@ fn profile_ddic_emits_required_identifiers_and_metadata() {
 
     let codebook_id = extract_attr(&xml, "codeBook", "ID").expect("codeBook/@ID missing");
     assert!(
-        Uuid::parse_str(&codebook_id).is_ok(),
-        "codeBook/@ID is not a UUID: {codebook_id}"
+        codebook_id.starts_with('_'),
+        "codeBook/@ID should start with an underscore: {codebook_id}"
+    );
+    assert!(
+        Uuid::parse_str(&codebook_id[1..]).is_ok(),
+        "codeBook/@ID suffix is not a UUID: {codebook_id}"
     );
 
     assert!(xml.contains("<fileDscr ID=\"F1\">"));
@@ -175,7 +179,7 @@ fn profile_ddic_emits_sumstats_var_attrs_and_varformat_after_categories() {
         "expected numeric mean sumStat"
     );
     assert!(
-        xml.contains("<sumStat type=\"invld\">0</sumStat>"),
+        xml.contains("<sumStat type=\"invd\">0</sumStat>"),
         "expected invalid count sumStat"
     );
     assert!(
@@ -189,6 +193,10 @@ fn profile_ddic_emits_sumstats_var_attrs_and_varformat_after_categories() {
     assert!(
         xml.contains("<catStat type=\"percent\">"),
         "expected category percent stat"
+    );
+    assert!(
+        xml.contains("<varFormat type=\"numeric\" schema=\"other\" otherSchema=\"qsv\" formatname=\"Float\"/>"),
+        "expected DDI-compliant varFormat schema attributes"
     );
 
     let kind_var_start = xml.find("<var ID=\"V2\"").expect("V2 var missing");

--- a/tests/test_profile_ddic.rs
+++ b/tests/test_profile_ddic.rs
@@ -1,0 +1,330 @@
+use uuid::Uuid;
+
+use crate::workdir::Workdir;
+
+fn extract_attr(xml: &str, tag: &str, attr: &str) -> Option<String> {
+    let tag_start = xml.find(&format!("<{tag}"))?;
+    let rel_tag_end = xml[tag_start..].find('>')?;
+    let tag_end = tag_start + rel_tag_end;
+    let tag_text = &xml[tag_start..=tag_end];
+    let needle = format!("{attr}=\"");
+    let attr_start = tag_text.find(&needle)? + needle.len();
+    let attr_end = tag_text[attr_start..].find('"')?;
+    Some(tag_text[attr_start..attr_start + attr_end].to_string())
+}
+
+fn seed_basic_csv(wrk: &Workdir) {
+    wrk.create(
+        "in.csv",
+        vec![
+            svec!["city", "kind"],
+            svec!["Boston", "store"],
+            svec!["Austin", "office"],
+            svec!["Seattle", "store"],
+        ],
+    );
+}
+
+#[test]
+fn profile_ddic_emits_required_identifiers_and_metadata() {
+    let wrk = Workdir::new("profile_ddic_ids");
+    seed_basic_csv(&wrk);
+
+    let mut cmd = wrk.command("profile");
+    cmd.args(["in.csv", "--ddi-c", "out.xml", "-o", "out.json"]);
+    wrk.assert_success(&mut cmd);
+
+    let xml = wrk.read_to_string("out.xml").expect("read ddic xml");
+
+    let codebook_id = extract_attr(&xml, "codeBook", "ID").expect("codeBook/@ID missing");
+    assert!(
+        Uuid::parse_str(&codebook_id).is_ok(),
+        "codeBook/@ID is not a UUID: {codebook_id}"
+    );
+
+    assert!(xml.contains("<fileDscr ID=\"F1\">"));
+    assert!(xml.contains("<var ID=\"V1\""));
+    assert!(xml.contains("<var ID=\"V2\""));
+
+    assert!(
+        xml.contains("<titl>in.csv</titl>"),
+        "expected stdyDscr title from input filename"
+    );
+
+    let expected_software = format!(
+        "<software version=\"{}\">qsv</software>",
+        env!("CARGO_PKG_VERSION")
+    );
+    assert!(xml.contains(&expected_software), "missing qsv software citation");
+}
+
+#[test]
+fn profile_ddic_zero_limit_emits_no_categories() {
+    let wrk = Workdir::new("profile_ddic_zero_limit");
+    seed_basic_csv(&wrk);
+
+    let mut cmd = wrk.command("profile");
+    cmd.args([
+        "in.csv",
+        "--ddi-c",
+        "out.xml",
+        "--ddi-catgry-limit",
+        "0",
+        "-o",
+        "out.json",
+    ]);
+    wrk.assert_success(&mut cmd);
+
+    let xml = wrk.read_to_string("out.xml").expect("read ddic xml");
+    assert!(
+        !xml.contains("<catgry>"),
+        "expected no categories when --ddi-catgry-limit is 0"
+    );
+}
+
+#[test]
+fn profile_ddic_json_override_skips_high_cardinality_variable() {
+    let wrk = Workdir::new("profile_ddic_json_override_skip");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec!["kind"],
+            svec!["store"],
+            svec!["store"],
+            svec!["office"],
+            svec!["warehouse"],
+        ],
+    );
+
+    let mut cmd = wrk.command("profile");
+    cmd.args([
+        "in.csv",
+        "--ddi-c",
+        "out.xml",
+        "--ddi-catgry-limit",
+        "{\"kind\":2}",
+        "-o",
+        "out.json",
+    ]);
+    wrk.assert_success(&mut cmd);
+
+    let xml = wrk.read_to_string("out.xml").expect("read ddic xml");
+    assert!(
+        !xml.contains("<catgry>"),
+        "expected high-cardinality variable categories to be omitted"
+    );
+}
+
+#[test]
+fn profile_ddic_json_file_override_is_supported() {
+    let wrk = Workdir::new("profile_ddic_json_file_override");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec!["kind"],
+            svec!["store"],
+            svec!["store"],
+            svec!["office"],
+            svec!["warehouse"],
+        ],
+    );
+    wrk.create_from_string("limits.json", "{\"kind\": 3}\n");
+
+    let mut cmd = wrk.command("profile");
+    cmd.args([
+        "in.csv",
+        "--ddi-c",
+        "out.xml",
+        "--ddi-catgry-limit",
+        "limits.json",
+        "-o",
+        "out.json",
+    ]);
+    wrk.assert_success(&mut cmd);
+
+    let xml = wrk.read_to_string("out.xml").expect("read ddic xml");
+    let catgry_count = xml.matches("<catgry>").count();
+    assert_eq!(catgry_count, 3, "expected all 3 categories to be emitted");
+}
+
+#[test]
+fn profile_ddic_emits_sumstats_var_attrs_and_varformat_after_categories() {
+    let wrk = Workdir::new("profile_ddic_sumstats_and_order");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec!["score", "kind"],
+            svec!["1.5", "store"],
+            svec!["2.5", "store"],
+            svec!["3.5", "office"],
+        ],
+    );
+
+    let mut cmd = wrk.command("profile");
+    cmd.args(["in.csv", "--ddi-c", "out.xml", "-o", "out.json"]);
+    wrk.assert_success(&mut cmd);
+
+    let xml = wrk.read_to_string("out.xml").expect("read ddic xml");
+
+    assert!(
+        xml.contains("xmlns=\"http://www.icpsr.umich.edu/DDI\""),
+        "expected DDI namespace on root"
+    );
+    assert!(
+        xml.contains("<sumStat type=\"mean\">2.5</sumStat>"),
+        "expected numeric mean sumStat"
+    );
+    assert!(
+        xml.contains("<sumStat type=\"invld\">0</sumStat>"),
+        "expected invalid count sumStat"
+    );
+    assert!(
+        xml.contains("<sumStat type=\"vald\">3</sumStat>"),
+        "expected valid count sumStat"
+    );
+    assert!(
+        xml.contains("<var ID=\"V1\" name=\"score\" files=\"F1\" intrvl=\"contin\" representationType=\"numeric\""),
+        "expected enriched var attributes for numeric column"
+    );
+    assert!(
+        xml.contains("<catStat type=\"percent\">"),
+        "expected category percent stat"
+    );
+
+    let kind_var_start = xml.find("<var ID=\"V2\"").expect("V2 var missing");
+    let kind_var_end = xml[kind_var_start..]
+        .find("</var>")
+        .map(|idx| kind_var_start + idx)
+        .expect("V2 var end missing");
+    let kind_var = &xml[kind_var_start..kind_var_end];
+    let catgry_pos = kind_var.find("<catgry>").expect("catgry missing in V2");
+    let varformat_pos = kind_var
+        .find("<varFormat")
+        .expect("varFormat missing in V2");
+    assert!(
+        varformat_pos > catgry_pos,
+        "expected varFormat to appear after catgry"
+    );
+}
+
+#[test]
+fn profile_ddic_keeps_categorical_classification_when_catgry_omitted_by_limit() {
+    let wrk = Workdir::new("profile_ddic_classify_categorical_without_catgry_output");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec!["kind"],
+            svec!["store"],
+            svec!["store"],
+            svec!["office"],
+            svec!["office"],
+        ],
+    );
+
+    let mut cmd = wrk.command("profile");
+    cmd.args([
+        "in.csv",
+        "--ddi-c",
+        "out.xml",
+        "--ddi-catgry-limit",
+        "1",
+        "-o",
+        "out.json",
+    ]);
+    wrk.assert_success(&mut cmd);
+
+    let xml = wrk.read_to_string("out.xml").expect("read ddic xml");
+    assert!(
+        !xml.contains("<catgry>"),
+        "expected categories to be omitted with low category limit"
+    );
+    assert!(
+        xml.contains("<var ID=\"V1\" name=\"kind\" files=\"F1\" intrvl=\"discrete\" representationType=\"coded\""),
+        "expected categorical variable to remain coded even when catgry output is omitted"
+    );
+}
+
+#[test]
+fn profile_ddic_classifies_high_cardinality_string_as_non_categorical() {
+    let wrk = Workdir::new("profile_ddic_classify_high_card_string_as_text");
+    let mut csv = String::from("id\n");
+    for i in 1..=51 {
+        csv.push_str(&format!("id_{i:03}\n"));
+    }
+    wrk.create_from_string("in.csv", &csv);
+
+    let mut cmd = wrk.command("profile");
+    cmd.args(["in.csv", "--ddi-c", "out.xml", "-o", "out.json"]);
+    wrk.assert_success(&mut cmd);
+
+    let xml = wrk.read_to_string("out.xml").expect("read ddic xml");
+    assert!(
+        xml.contains("<var ID=\"V1\" name=\"id\" files=\"F1\" intrvl=\"discrete\" representationType=\"text\""),
+        "expected high-cardinality string variable to be non-categorical text"
+    );
+}
+
+#[test]
+fn profile_ddic_uses_schema_enum_signal_for_integer_categorical_detection() {
+    let wrk = Workdir::new("profile_ddic_schema_enum_signal_integer");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec!["status_code"],
+            svec!["1"],
+            svec!["2"],
+            svec!["1"],
+            svec!["3"],
+            svec!["2"],
+        ],
+    );
+
+    let mut cmd = wrk.command("profile");
+    cmd.args([
+        "in.csv",
+        "--ddi-c",
+        "out.xml",
+        "--ddi-catgry-limit",
+        "1",
+        "-o",
+        "out.json",
+    ]);
+    wrk.assert_success(&mut cmd);
+
+    let xml = wrk.read_to_string("out.xml").expect("read ddic xml");
+    assert!(
+        xml.contains("<var ID=\"V1\" name=\"status_code\" files=\"F1\" intrvl=\"discrete\" representationType=\"coded\""),
+        "expected enum-like integer column to be classified as coded categorical"
+    );
+}
+
+#[test]
+fn profile_ddic_does_not_emit_categories_for_continuous_numeric_weights() {
+    let wrk = Workdir::new("profile_ddic_no_catgry_for_continuous_weights");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec!["hhweight"],
+            svec!["156.66755315036724"],
+            svec!["156.66755315036724"],
+            svec!["269.65684351914035"],
+            svec!["269.65684351914035"],
+            svec!["302.41537022900758"],
+            svec!["357.69991350549861"],
+        ],
+    );
+
+    let mut cmd = wrk.command("profile");
+    cmd.args(["in.csv", "--ddi-c", "out.xml", "-o", "out.json"]);
+    wrk.assert_success(&mut cmd);
+
+    let xml = wrk.read_to_string("out.xml").expect("read ddic xml");
+    assert!(
+        xml.contains("<var ID=\"V1\" name=\"hhweight\" files=\"F1\" intrvl=\"contin\" representationType=\"numeric\""),
+        "expected continuous numeric classification for hhweight"
+    );
+    assert!(
+        !xml.contains("<catgry>"),
+        "expected no categories for continuous non-categorical numeric weight"
+    );
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -111,6 +111,8 @@ mod test_pivotp;
 mod test_pragmastat;
 #[cfg(all(feature = "profile", feature = "feature_capable"))]
 mod test_profile;
+#[cfg(all(feature = "profile", feature = "feature_capable"))]
+mod test_profile_ddic;
 #[cfg(feature = "prompt")]
 mod test_prompt;
 mod test_pseudo;


### PR DESCRIPTION
Experimental integration of a [DDI-Codebook](https://ddialliance.org/ddi-codebook) serialization for the new `profile` command. This will likely need tweaking, but I do not want to delay in order to avoid falling out of sync with the ongoing work on `profile`.

DDI-C is the long-standing specification from the DDI Alliance, widely adopted by data stewards around the globe and by platforms such as Dataverse or Rich Data Services. It is a simple model (in a nutshell, a rich data dictionary), but nonetheless useful, and a good entry point into the DDI space. Being able to produce a DDI XML file from CSV in one step is significant.

Attached output example for this [Popstan Synthetic Household Survey 2023](https://nada-demo.ihsn.org/index.php/catalog/145) synthetic test dataset.

Note that a similar integration is being implemented in Data Artifex qsv-toolkit (a simple Python wrapper for QSV shell command). 

[WLD_2023_SYNTH-SVY-HLD-EN_v01_M.ddic-qsv.xml](https://github.com/user-attachments/files/28286546/WLD_2023_SYNTH-SVY-HLD-EN_v01_M.ddic-qsv.xml)

