### PR TITLE
feat(profile): YAML projection follow-ups — CI gate, per-dist merge, catalog inheritance

### DIFF
--- a/resources/profiles/README.md
+++ b/resources/profiles/README.md
@@ -48,3 +48,37 @@ Every entry under `dataset.fields[]`, `distribution.fields[]`, and
 | `emit_when` | Optional guard template; field skipped when this renders falsy/empty. |
 | `default` | Literal fallback when the main template renders empty (suppresses the warning). |
 | `for_each_column` | Croissant-style expansion: emit one entry per stats column. |
+
+## Discovery merge
+
+When the caller provides publisher-side DCAT (via `--initial-context` or
+auto-discovered from CKAN), `discovery_merge` controls how that metadata
+folds into the qsv-inferred projection.
+
+| Key | Meaning |
+|---|---|
+| `enabled` | Master switch. `false` skips merging entirely. |
+| `never_overwrite` | Top-level keys protected from any overlay (typical: `@context`, `@type`, `dcat:distribution`). |
+| `default_strategy` | `fill-if-absent` (default — inferred wins on conflict), `overlay-array` (append publisher elements to inferred arrays), or `never`. |
+| `distribution_merge` | Optional per-element merge for the distribution array. See below. |
+
+### Per-distribution merging
+
+By default the `dcat:distribution` array is `never_overwrite`'d — qsv's
+inferred distributions are canonical for the local data. Setting
+`distribution_merge.enabled: true` bypasses that protection for the
+array key and walks each publisher Distribution, matching it to an
+inferred one by `identity_keys` (first non-empty match wins). Matched
+fields flow into the inferred record via `field_strategy`.
+
+| Key | Meaning |
+|---|---|
+| `enabled` | Master switch for per-element merging. `false` (default) preserves the legacy "publisher distributions dropped" behavior. |
+| `array_key` | The top-level key holding the distribution array. Default `dcat:distribution`. |
+| `identity_keys` | Ordered list of fields used to match a publisher Distribution against an inferred one. Empty list disables matching. |
+| `field_strategy` | How to merge fields within a matched pair: `fill-if-absent` (default) / `overlay-array` / `never`. |
+| `append_unmatched` | When `true`, publisher distributions that match no inferred entry are appended. Default `false` (silently dropped). |
+
+DCAT-US v3 and DCAT-AP v3 enable this with `dcat:downloadURL` →
+`dcat:accessURL` → `@id` as the identity-key priority. Croissant
+disables `discovery_merge` entirely.

--- a/resources/profiles/README.md
+++ b/resources/profiles/README.md
@@ -49,6 +49,37 @@ Every entry under `dataset.fields[]`, `distribution.fields[]`, and
 | `default` | Literal fallback when the main template renders empty (suppresses the warning). |
 | `for_each_column` | Croissant-style expansion: emit one entry per stats column. |
 
+## Catalog envelope
+
+When `--catalog` is set, the Dataset block is wrapped inside the
+profile's `catalog:` block. Two paths are available for surfacing
+Dataset values on the outer Catalog envelope:
+
+* **`inherit_from_dataset: [key, key, ...]`** — verbatim copy. Each
+  listed Dataset key is copied (same name, same value) onto the
+  Catalog. Cheapest path; suitable when you just want to expose
+  `dct:publisher` or similar at the catalog level.
+* **`catalog.fields[]`** — template-driven. Each entry is a regular
+  `FieldDecl` (same directives as dataset/distribution fields), but
+  its template gets access to an extra `inner` binding holding the
+  rendered Dataset block. Use this for rename, conditional copy, or
+  value transformation:
+
+```yaml
+catalog:
+  inherit_from_dataset: ["dct:publisher"]   # verbatim
+  fields:
+    - path: "dcat:contactPoint"
+      template: '{{ inner["dcat:contactPoint"] | tojson }}'
+      emit_when: '{{ inner["dcat:contactPoint"] is defined }}'
+    - path: "qsv:catalogId"
+      template: 'cat-{{ pkg.id }}'
+```
+
+The catalog `title_template` also receives both bindings, so titles
+can mix analysis vars and Dataset values:
+`'{{ pkg.publisher }} — Catalog of {{ inner["dct:title"] }}'`.
+
 ## Discovery merge
 
 When the caller provides publisher-side DCAT (via `--initial-context` or

--- a/resources/profiles/dcat-ap-v3.yaml
+++ b/resources/profiles/dcat-ap-v3.yaml
@@ -385,3 +385,16 @@ discovery_merge:
     - "@type"
     - "dcat:distribution"
   default_strategy: fill-if-absent
+  # Per-element merging for the distribution array. See dcat-us-v3.yaml
+  # for the full rationale. DCAT-AP shares the same identity-key
+  # priority because the same dcat:downloadURL / dcat:accessURL terms
+  # are used in both vocabularies.
+  distribution_merge:
+    enabled: true
+    array_key: "dcat:distribution"
+    identity_keys:
+      - "dcat:downloadURL"
+      - "dcat:accessURL"
+      - "@id"
+    field_strategy: fill-if-absent
+    append_unmatched: false

--- a/resources/profiles/dcat-us-v3.yaml
+++ b/resources/profiles/dcat-us-v3.yaml
@@ -548,3 +548,18 @@ discovery_merge:
     - "@type"
     - "dcat:distribution"
   default_strategy: fill-if-absent
+  # Per-element merging for the distribution array. Bypasses the
+  # `never_overwrite` rule for `dcat:distribution` when enabled and
+  # matches each publisher Distribution against an inferred one by
+  # `dcat:downloadURL` or `dcat:accessURL`. Matched fields use
+  # fill-if-absent so qsv-inferred values (mediaType, byteSize,
+  # CSVW schema) always win over publisher overrides.
+  distribution_merge:
+    enabled: true
+    array_key: "dcat:distribution"
+    identity_keys:
+      - "dcat:downloadURL"
+      - "dcat:accessURL"
+      - "@id"
+    field_strategy: fill-if-absent
+    append_unmatched: false

--- a/src/cmd/profile/discovery_merge.rs
+++ b/src/cmd/profile/discovery_merge.rs
@@ -49,12 +49,16 @@ pub fn merge(
     // Resolve the per-distribution merge config (if any). When
     // enabled, the distribution array bypasses the `never_overwrite`
     // early-return below and gets identity-based element merging.
+    // `array_key` defaults to `dcat:distribution` to match the
+    // documented contract (Roborev #2499 finding #2): enabling
+    // `distribution_merge` without spelling out `array_key` must
+    // not silently disable per-distribution merging.
     let dist_cfg = profile
         .discovery_merge
         .distribution_merge
         .as_ref()
         .filter(|d| d.enabled);
-    let dist_key = dist_cfg.and_then(|d| d.array_key.as_deref());
+    let dist_key = dist_cfg.map(|d| d.array_key.as_deref().unwrap_or("dcat:distribution"));
 
     // Handle the distribution array first so `never_overwrite` doesn't
     // block it when per-distribution merging is enabled.
@@ -64,7 +68,7 @@ pub fn merge(
         let inferred_arr = inferred_obj
             .remove(dkey)
             .unwrap_or_else(|| Value::Array(Vec::new()));
-        let merged = merge_distribution_array(inferred_arr, disc_arr, cfg);
+        let merged = merge_distribution_array(inferred_arr, disc_arr, cfg, forced_dcat_paths, dkey);
         inferred_obj.insert(dkey.to_string(), merged);
     }
 
@@ -142,6 +146,13 @@ fn merge_one(out: &mut Map<String, Value>, key: &str, value: Value, strategy: &s
 /// match any inferred entry are appended only when
 /// `append_unmatched: true`.
 ///
+/// `forced_dcat_paths` honors the same `dataset_info` force-override
+/// semantics that the outer `merge` uses for top-level keys: any
+/// publisher field whose pointer matches a forced path exactly, or
+/// is the parent of one (forced sub-key under a publisher field), is
+/// skipped (Roborev #2499 finding #1). Forced paths use the index of
+/// the *inferred* distribution as the array index.
+///
 /// The inferred and discovered values are coerced into arrays
 /// uniformly: a single object becomes a one-element array. The
 /// returned value is always a `Value::Array`.
@@ -149,6 +160,8 @@ fn merge_distribution_array(
     inferred: Value,
     discovered: &Value,
     cfg: &super::profile_spec::DistributionMerge,
+    forced_dcat_paths: &[String],
+    dist_key: &str,
 ) -> Value {
     let mut inferred_arr = coerce_to_array(inferred);
     let disc_arr_iter = match discovered {
@@ -157,6 +170,7 @@ fn merge_distribution_array(
     };
 
     let field_strategy = cfg.field_strategy.as_deref().unwrap_or("fill-if-absent");
+    let dist_prefix = format!("/dcat/{}", escape_token(dist_key));
 
     for disc in disc_arr_iter {
         let Value::Object(disc_obj) = disc else {
@@ -170,6 +184,22 @@ fn merge_distribution_array(
             Some(idx) => {
                 if let Value::Object(inf_obj) = &mut inferred_arr[idx] {
                     for (k, v) in disc_obj {
+                        // Honor dataset_info force overrides: skip
+                        // publisher fields whose JSON pointer
+                        // (`/dcat/<dist_key>/<idx>/<field>`) is
+                        // forced exactly or has a forced sub-key
+                        // beneath it. Mirrors the top-level
+                        // forced-path semantics in `merge` so users
+                        // cannot have their explicit overrides
+                        // silently overwritten by per-distribution
+                        // merging.
+                        let field_path = format!("{dist_prefix}/{idx}/{}", escape_token(&k));
+                        let is_forced = forced_dcat_paths
+                            .iter()
+                            .any(|p| p == &field_path || p.starts_with(&format!("{field_path}/")));
+                        if is_forced {
+                            continue;
+                        }
                         merge_one(inf_obj, &k, v, field_strategy);
                     }
                 }
@@ -686,5 +716,153 @@ discovery_merge:
         assert_eq!(dist.len(), 2);
         assert!(dist[0].get("dct:title").is_none());
         assert_eq!(dist[1].get("dct:title").and_then(Value::as_str), Some("T"));
+    }
+
+    #[test]
+    fn dist_merge_array_key_defaults_to_dcat_distribution() {
+        // Roborev #2499 finding #2: enabling distribution_merge
+        // without spelling out `array_key` must NOT silently disable
+        // per-distribution merging. The default is `dcat:distribution`.
+        let yaml = r#"
+name: t
+dataset:
+  type: dcat:Dataset
+discovery_merge:
+  enabled: true
+  never_overwrite: ["dcat:distribution"]
+  distribution_merge:
+    enabled: true
+    identity_keys: ["dcat:downloadURL"]
+    field_strategy: fill-if-absent
+"#;
+        let profile = load_from_str(yaml, "t").unwrap();
+        assert!(
+            profile
+                .discovery_merge
+                .distribution_merge
+                .as_ref()
+                .unwrap()
+                .array_key
+                .is_none(),
+            "array_key intentionally omitted in fixture",
+        );
+        let inferred = json!({
+            "dcat:distribution": [{
+                "dcat:downloadURL": "https://example.org/x.csv",
+                "dcat:mediaType": "text/csv",
+            }],
+        });
+        let discovered = json!({
+            "dcat:distribution": [{
+                "dcat:downloadURL": "https://example.org/x.csv",
+                "dct:title": "Default Key",
+            }],
+        });
+        let merged = merge(&profile, inferred, Some(&discovered), &[]);
+        let dist = merged.get("dcat:distribution").unwrap().as_array().unwrap();
+        assert_eq!(
+            dist[0].get("dct:title").and_then(Value::as_str),
+            Some("Default Key"),
+            "omitting array_key must default to dcat:distribution, not disable"
+        );
+    }
+
+    #[test]
+    fn dist_merge_honors_forced_path_on_distribution_field() {
+        // Roborev #2499 finding #1: a forced dataset_info path at
+        // /dcat/dcat:distribution/0/<field> must block the publisher
+        // overlay on that field even when the inferred value is
+        // absent. Without the forced-path check, publisher metadata
+        // would silently fill the user's intentional override gap.
+        let profile = load_from_str(PROFILE_WITH_DIST_MERGE, "t").unwrap();
+        let inferred = json!({
+            "dcat:distribution": [{
+                "dcat:downloadURL": "https://example.org/x.csv",
+                // Note: dct:title intentionally absent — the user has
+                // a forced override at this path.
+            }],
+        });
+        let discovered = json!({
+            "dcat:distribution": [{
+                "dcat:downloadURL": "https://example.org/x.csv",
+                "dct:title": "Publisher Title",
+                "dct:license": "https://creativecommons.org/licenses/by/4.0/",
+            }],
+        });
+        // User forced the title on inferred[0] (the leaf they wanted
+        // to override via --initial-context dataset_info).
+        let forced = vec!["/dcat/dcat:distribution/0/dct:title".to_string()];
+        let merged = merge(&profile, inferred, Some(&discovered), &forced);
+        let dist = merged.get("dcat:distribution").unwrap().as_array().unwrap();
+        assert!(
+            dist[0].get("dct:title").is_none(),
+            "forced dist field must block publisher overlay even when inferred is absent"
+        );
+        // Non-forced sibling still flows through.
+        assert_eq!(
+            dist[0].get("dct:license").and_then(Value::as_str),
+            Some("https://creativecommons.org/licenses/by/4.0/"),
+            "forced-path protection is leaf-specific, not whole-element"
+        );
+    }
+
+    #[test]
+    fn dist_merge_honors_forced_nested_path_under_distribution_field() {
+        // A forced path INSIDE a publisher field
+        // (`/dcat/dcat:distribution/0/dcat-us:accessRestriction/some-key`)
+        // must block the publisher from replacing the whole parent
+        // field. Mirrors the top-level
+        // `forced_nested_path_blocks_top_level_merge` semantics for
+        // the per-distribution path.
+        let profile = load_from_str(PROFILE_WITH_DIST_MERGE, "t").unwrap();
+        let inferred = json!({
+            "dcat:distribution": [{
+                "dcat:downloadURL": "https://example.org/x.csv",
+            }],
+        });
+        let discovered = json!({
+            "dcat:distribution": [{
+                "dcat:downloadURL": "https://example.org/x.csv",
+                "dcat-us:accessRestriction": {"label": "PUBLISHER"},
+            }],
+        });
+        let forced = vec!["/dcat/dcat:distribution/0/dcat-us:accessRestriction/label".to_string()];
+        let merged = merge(&profile, inferred, Some(&discovered), &forced);
+        let dist = merged.get("dcat:distribution").unwrap().as_array().unwrap();
+        assert!(
+            dist[0].get("dcat-us:accessRestriction").is_none(),
+            "forced sub-key under publisher field must block parent overlay"
+        );
+    }
+
+    #[test]
+    fn dist_merge_unrelated_forced_path_does_not_block() {
+        // Companion: a forced path on a sibling distribution
+        // (`/dcat/dcat:distribution/1/...`) must NOT block overlay
+        // on index 0. Index-specific guarding is required so a user
+        // override on one resource doesn't silently lock down the
+        // whole array.
+        let profile = load_from_str(PROFILE_WITH_DIST_MERGE, "t").unwrap();
+        let inferred = json!({
+            "dcat:distribution": [{
+                "dcat:downloadURL": "https://example.org/x.csv",
+            }],
+        });
+        let discovered = json!({
+            "dcat:distribution": [{
+                "dcat:downloadURL": "https://example.org/x.csv",
+                "dct:title": "Title for index 0",
+            }],
+        });
+        // Forced path targets index 1, not 0. Has no effect on
+        // matched entry at index 0.
+        let forced = vec!["/dcat/dcat:distribution/1/dct:title".to_string()];
+        let merged = merge(&profile, inferred, Some(&discovered), &forced);
+        let dist = merged.get("dcat:distribution").unwrap().as_array().unwrap();
+        assert_eq!(
+            dist[0].get("dct:title").and_then(Value::as_str),
+            Some("Title for index 0"),
+            "forced path on a different index must not over-match"
+        );
     }
 }

--- a/src/cmd/profile/discovery_merge.rs
+++ b/src/cmd/profile/discovery_merge.rs
@@ -46,7 +46,33 @@ pub fn merge(
         .as_deref()
         .unwrap_or("fill-if-absent");
 
+    // Resolve the per-distribution merge config (if any). When
+    // enabled, the distribution array bypasses the `never_overwrite`
+    // early-return below and gets identity-based element merging.
+    let dist_cfg = profile
+        .discovery_merge
+        .distribution_merge
+        .as_ref()
+        .filter(|d| d.enabled);
+    let dist_key = dist_cfg.and_then(|d| d.array_key.as_deref());
+
+    // Handle the distribution array first so `never_overwrite` doesn't
+    // block it when per-distribution merging is enabled.
+    if let (Some(cfg), Some(dkey)) = (dist_cfg, dist_key)
+        && let Some(disc_arr) = discovered_obj.get(dkey)
+    {
+        let inferred_arr = inferred_obj
+            .remove(dkey)
+            .unwrap_or_else(|| Value::Array(Vec::new()));
+        let merged = merge_distribution_array(inferred_arr, disc_arr, cfg);
+        inferred_obj.insert(dkey.to_string(), merged);
+    }
+
     for (key, value) in discovered_obj {
+        // Already merged above by per-distribution path — skip.
+        if dist_key == Some(key.as_str()) {
+            continue;
+        }
         if never.iter().any(|k| k == key) {
             continue;
         }
@@ -106,6 +132,103 @@ fn merge_one(out: &mut Map<String, Value>, key: &str, value: Value, strategy: &s
             }
         },
     }
+}
+
+/// Per-element merge of the distribution array. For each publisher
+/// Distribution, locate a matching inferred Distribution via
+/// `identity_keys` (first non-empty match wins), then merge each
+/// publisher field into the matched inferred object via the
+/// configured `field_strategy`. Publisher distributions that don't
+/// match any inferred entry are appended only when
+/// `append_unmatched: true`.
+///
+/// The inferred and discovered values are coerced into arrays
+/// uniformly: a single object becomes a one-element array. The
+/// returned value is always a `Value::Array`.
+fn merge_distribution_array(
+    inferred: Value,
+    discovered: &Value,
+    cfg: &super::profile_spec::DistributionMerge,
+) -> Value {
+    let mut inferred_arr = coerce_to_array(inferred);
+    let disc_arr_iter = match discovered {
+        Value::Array(a) => a.to_vec(),
+        other => vec![other.clone()],
+    };
+
+    let field_strategy = cfg.field_strategy.as_deref().unwrap_or("fill-if-absent");
+
+    for disc in disc_arr_iter {
+        let Value::Object(disc_obj) = disc else {
+            // Non-object publisher entry: append only if configured.
+            if cfg.append_unmatched {
+                inferred_arr.push(disc);
+            }
+            continue;
+        };
+        match find_distribution_match(&inferred_arr, &disc_obj, &cfg.identity_keys) {
+            Some(idx) => {
+                if let Value::Object(inf_obj) = &mut inferred_arr[idx] {
+                    for (k, v) in disc_obj {
+                        merge_one(inf_obj, &k, v, field_strategy);
+                    }
+                }
+            },
+            None => {
+                if cfg.append_unmatched {
+                    inferred_arr.push(Value::Object(disc_obj));
+                }
+            },
+        }
+    }
+    Value::Array(inferred_arr)
+}
+
+/// Coerce a JSON value into a `Vec<Value>` so the merge loop can
+/// treat single-object and array-of-object inputs uniformly. `Null`
+/// becomes an empty Vec; objects/scalars become one-element Vecs.
+fn coerce_to_array(v: Value) -> Vec<Value> {
+    match v {
+        Value::Array(a) => a,
+        Value::Null => Vec::new(),
+        other => vec![other],
+    }
+}
+
+/// Find the index of the first inferred distribution that matches
+/// `disc` on any identity key. Match is exact-string equality on a
+/// non-empty value present on both sides. Returns `None` when no
+/// identity key produces a match (e.g. publisher only has a title,
+/// no URL).
+fn find_distribution_match(
+    inferred: &[Value],
+    disc: &Map<String, Value>,
+    identity_keys: &[String],
+) -> Option<usize> {
+    for key in identity_keys {
+        let Some(disc_val) = disc.get(key).and_then(non_empty_string) else {
+            continue;
+        };
+        for (i, inf) in inferred.iter().enumerate() {
+            let Some(inf_val) = inf
+                .as_object()
+                .and_then(|o| o.get(key))
+                .and_then(non_empty_string)
+            else {
+                continue;
+            };
+            if disc_val == inf_val {
+                return Some(i);
+            }
+        }
+    }
+    None
+}
+
+/// Treat empty strings as absent so identity matching doesn't pair
+/// distributions on a shared `""` value.
+fn non_empty_string(v: &Value) -> Option<&str> {
+    v.as_str().filter(|s| !s.is_empty())
 }
 
 #[cfg(test)]
@@ -283,5 +406,285 @@ discovery_merge:
             escape_token("http://purl.org/dc/terms/title"),
             "http:~1~1purl.org~1dc~1terms~1title",
         );
+    }
+
+    const PROFILE_WITH_DIST_MERGE: &str = r#"
+name: test-dist-merge
+dataset:
+  type: dcat:Dataset
+discovery_merge:
+  enabled: true
+  never_overwrite: ["@context", "@type", "dcat:distribution"]
+  default_strategy: fill-if-absent
+  distribution_merge:
+    enabled: true
+    array_key: "dcat:distribution"
+    identity_keys: ["dcat:downloadURL", "dcat:accessURL"]
+    field_strategy: fill-if-absent
+    append_unmatched: false
+"#;
+
+    #[test]
+    fn dist_merge_pairs_on_download_url_and_fills_absent_fields() {
+        let profile = load_from_str(PROFILE_WITH_DIST_MERGE, "t").unwrap();
+        let inferred = json!({
+            "@type": "dcat:Dataset",
+            "dcat:distribution": [{
+                "dcat:downloadURL": "https://example.org/data.csv",
+                "dcat:mediaType": "text/csv",
+                "dcat:byteSize": "42",
+            }],
+        });
+        let discovered = json!({
+            "dcat:distribution": [{
+                "dcat:downloadURL": "https://example.org/data.csv",
+                "dct:title": "Publisher Title",
+                "dct:license": "https://creativecommons.org/licenses/by/4.0/",
+                "dcat:byteSize": "OVERRIDE",
+            }],
+        });
+        let merged = merge(&profile, inferred, Some(&discovered), &[]);
+        let dist = merged
+            .get("dcat:distribution")
+            .and_then(Value::as_array)
+            .expect("distribution array");
+        assert_eq!(dist.len(), 1, "matched into a single element, no append");
+        let entry = &dist[0];
+        // Inferred wins on conflicts (fill-if-absent).
+        assert_eq!(
+            entry.get("dcat:byteSize").and_then(Value::as_str),
+            Some("42"),
+            "qsv-inferred byteSize must win"
+        );
+        // Publisher fields fill absent slots.
+        assert_eq!(
+            entry.get("dct:title").and_then(Value::as_str),
+            Some("Publisher Title")
+        );
+        assert_eq!(
+            entry.get("dct:license").and_then(Value::as_str),
+            Some("https://creativecommons.org/licenses/by/4.0/")
+        );
+        // Inferred-only fields are preserved.
+        assert_eq!(
+            entry.get("dcat:mediaType").and_then(Value::as_str),
+            Some("text/csv")
+        );
+    }
+
+    #[test]
+    fn dist_merge_falls_back_to_access_url_when_download_url_missing() {
+        let profile = load_from_str(PROFILE_WITH_DIST_MERGE, "t").unwrap();
+        let inferred = json!({
+            "dcat:distribution": [{
+                "dcat:accessURL": "https://catalog.example.org/datasets/abc",
+                "qsv:sourcePath": "/local/data.csv",
+            }],
+        });
+        let discovered = json!({
+            "dcat:distribution": [{
+                "dcat:accessURL": "https://catalog.example.org/datasets/abc",
+                "dct:title": "ABC Dataset",
+            }],
+        });
+        let merged = merge(&profile, inferred, Some(&discovered), &[]);
+        let dist = merged
+            .get("dcat:distribution")
+            .and_then(Value::as_array)
+            .unwrap();
+        assert_eq!(dist.len(), 1);
+        assert_eq!(
+            dist[0].get("dct:title").and_then(Value::as_str),
+            Some("ABC Dataset")
+        );
+    }
+
+    #[test]
+    fn dist_merge_drops_unmatched_when_append_disabled() {
+        let profile = load_from_str(PROFILE_WITH_DIST_MERGE, "t").unwrap();
+        let inferred = json!({
+            "dcat:distribution": [{
+                "dcat:downloadURL": "https://example.org/a.csv",
+            }],
+        });
+        let discovered = json!({
+            "dcat:distribution": [
+                {"dcat:downloadURL": "https://example.org/MIRROR.csv", "dct:title": "Mirror"},
+            ],
+        });
+        let merged = merge(&profile, inferred, Some(&discovered), &[]);
+        let dist = merged
+            .get("dcat:distribution")
+            .and_then(Value::as_array)
+            .unwrap();
+        assert_eq!(dist.len(), 1, "unmatched publisher entry is dropped");
+        assert!(
+            dist[0].get("dct:title").is_none(),
+            "the mirror dist should not have leaked title onto the inferred entry"
+        );
+    }
+
+    #[test]
+    fn dist_merge_appends_unmatched_when_configured() {
+        let yaml = r#"
+name: t
+dataset:
+  type: dcat:Dataset
+discovery_merge:
+  enabled: true
+  never_overwrite: ["dcat:distribution"]
+  distribution_merge:
+    enabled: true
+    array_key: "dcat:distribution"
+    identity_keys: ["dcat:downloadURL"]
+    field_strategy: fill-if-absent
+    append_unmatched: true
+"#;
+        let profile = load_from_str(yaml, "t").unwrap();
+        let inferred = json!({
+            "dcat:distribution": [{
+                "dcat:downloadURL": "https://example.org/a.csv",
+                "dcat:mediaType": "text/csv",
+            }],
+        });
+        let discovered = json!({
+            "dcat:distribution": [
+                {"dcat:downloadURL": "https://example.org/MIRROR.csv", "dct:title": "Mirror"},
+            ],
+        });
+        let merged = merge(&profile, inferred, Some(&discovered), &[]);
+        let dist = merged
+            .get("dcat:distribution")
+            .and_then(Value::as_array)
+            .unwrap();
+        assert_eq!(dist.len(), 2, "unmatched publisher entry is appended");
+        // Original inferred entry retained verbatim.
+        assert_eq!(
+            dist[0].get("dcat:mediaType").and_then(Value::as_str),
+            Some("text/csv")
+        );
+        // Publisher-only entry appended.
+        assert_eq!(
+            dist[1].get("dct:title").and_then(Value::as_str),
+            Some("Mirror")
+        );
+    }
+
+    #[test]
+    fn dist_merge_handles_single_object_inputs() {
+        // Inputs may be single objects (not arrays); the helper must
+        // coerce both sides uniformly.
+        let profile = load_from_str(PROFILE_WITH_DIST_MERGE, "t").unwrap();
+        let inferred = json!({
+            "dcat:distribution": {
+                "dcat:downloadURL": "https://example.org/x.csv",
+                "dcat:mediaType": "text/csv",
+            }
+        });
+        let discovered = json!({
+            "dcat:distribution": {
+                "dcat:downloadURL": "https://example.org/x.csv",
+                "dct:license": "CC-BY-4.0",
+            }
+        });
+        let merged = merge(&profile, inferred, Some(&discovered), &[]);
+        let dist = merged
+            .get("dcat:distribution")
+            .and_then(Value::as_array)
+            .unwrap();
+        assert_eq!(dist.len(), 1);
+        assert_eq!(
+            dist[0].get("dct:license").and_then(Value::as_str),
+            Some("CC-BY-4.0")
+        );
+        assert_eq!(
+            dist[0].get("dcat:mediaType").and_then(Value::as_str),
+            Some("text/csv")
+        );
+    }
+
+    #[test]
+    fn dist_merge_bypasses_never_overwrite_when_enabled() {
+        // The outer `never_overwrite` lists `dcat:distribution` —
+        // historically this means "publisher distribution array is
+        // dropped wholesale". With distribution_merge enabled, that
+        // rule is bypassed for the array key so per-element merging
+        // can actually run.
+        let profile = load_from_str(PROFILE_WITH_DIST_MERGE, "t").unwrap();
+        assert!(
+            profile
+                .discovery_merge
+                .never_overwrite
+                .contains(&"dcat:distribution".to_string()),
+            "test profile must list dcat:distribution in never_overwrite"
+        );
+        let inferred = json!({
+            "dcat:distribution": [{
+                "dcat:downloadURL": "https://example.org/x.csv",
+            }],
+        });
+        let discovered = json!({
+            "dcat:distribution": [{
+                "dcat:downloadURL": "https://example.org/x.csv",
+                "dct:title": "Publisher",
+            }],
+        });
+        let merged = merge(&profile, inferred, Some(&discovered), &[]);
+        let dist = merged.get("dcat:distribution").unwrap().as_array().unwrap();
+        assert_eq!(
+            dist[0].get("dct:title").and_then(Value::as_str),
+            Some("Publisher"),
+            "distribution_merge.enabled must override never_overwrite"
+        );
+    }
+
+    #[test]
+    fn dist_merge_disabled_preserves_never_overwrite() {
+        // When the per-distribution config is absent (or enabled:
+        // false), the legacy never_overwrite rule still wins and the
+        // publisher distribution array is dropped wholesale.
+        let profile = load_from_str(PROFILE_WITH_NEVER, "t").unwrap();
+        assert!(profile.discovery_merge.distribution_merge.is_none());
+        let inferred = json!({
+            "dcat:distribution": [{"qsv:sourcePath": "/local/x.csv"}],
+        });
+        let discovered = json!({
+            "dcat:distribution": [{"dct:title": "Publisher"}],
+        });
+        let merged = merge(&profile, inferred, Some(&discovered), &[]);
+        let dist = merged.get("dcat:distribution").unwrap().as_array().unwrap();
+        assert_eq!(dist.len(), 1);
+        assert!(
+            dist[0].get("dct:title").is_none(),
+            "legacy never_overwrite still drops publisher distributions"
+        );
+    }
+
+    #[test]
+    fn dist_merge_empty_identity_keys_treats_all_as_unmatched() {
+        let yaml = r#"
+name: t
+dataset:
+  type: dcat:Dataset
+discovery_merge:
+  enabled: true
+  never_overwrite: ["dcat:distribution"]
+  distribution_merge:
+    enabled: true
+    array_key: "dcat:distribution"
+    identity_keys: []
+    append_unmatched: true
+"#;
+        let profile = load_from_str(yaml, "t").unwrap();
+        let inferred = json!({"dcat:distribution": [{"dcat:downloadURL": "x"}]});
+        let discovered =
+            json!({"dcat:distribution": [{"dcat:downloadURL": "x", "dct:title": "T"}]});
+        let merged = merge(&profile, inferred, Some(&discovered), &[]);
+        let dist = merged.get("dcat:distribution").unwrap().as_array().unwrap();
+        // With no identity keys, the publisher entry can't pair —
+        // so with append_unmatched: true it gets appended, not merged.
+        assert_eq!(dist.len(), 2);
+        assert!(dist[0].get("dct:title").is_none());
+        assert_eq!(dist[1].get("dct:title").and_then(Value::as_str), Some("T"));
     }
 }

--- a/src/cmd/profile/discovery_merge.rs
+++ b/src/cmd/profile/discovery_merge.rs
@@ -154,8 +154,11 @@ fn merge_one(out: &mut Map<String, Value>, key: &str, value: Value, strategy: &s
 /// the *inferred* distribution as the array index.
 ///
 /// The inferred and discovered values are coerced into arrays
-/// uniformly: a single object becomes a one-element array. The
-/// returned value is always a `Value::Array`.
+/// uniformly: a single object becomes a one-element slice. The
+/// returned value is always a `Value::Array`. Iteration is by
+/// reference; per-field clones happen lazily inside the match arms
+/// so large publisher catalogs don't pay an upfront `to_vec`
+/// allocation and unmatched-drop entries are never cloned.
 fn merge_distribution_array(
     inferred: Value,
     discovered: &Value,
@@ -164,23 +167,27 @@ fn merge_distribution_array(
     dist_key: &str,
 ) -> Value {
     let mut inferred_arr = coerce_to_array(inferred);
-    let disc_arr_iter = match discovered {
-        Value::Array(a) => a.to_vec(),
-        other => vec![other.clone()],
+    // Borrow the publisher array as a slice — `from_ref` lets the
+    // scalar case share the same iteration path without allocating
+    // a temporary Vec.
+    let disc_slice: &[Value] = match discovered {
+        Value::Array(a) => a.as_slice(),
+        other => std::slice::from_ref(other),
     };
 
     let field_strategy = cfg.field_strategy.as_deref().unwrap_or("fill-if-absent");
     let dist_prefix = format!("/dcat/{}", escape_token(dist_key));
 
-    for disc in disc_arr_iter {
+    for disc in disc_slice {
         let Value::Object(disc_obj) = disc else {
-            // Non-object publisher entry: append only if configured.
+            // Non-object publisher entry: append only if configured
+            // (clone only at the moment of insertion).
             if cfg.append_unmatched {
-                inferred_arr.push(disc);
+                inferred_arr.push(disc.clone());
             }
             continue;
         };
-        match find_distribution_match(&inferred_arr, &disc_obj, &cfg.identity_keys) {
+        match find_distribution_match(&inferred_arr, disc_obj, &cfg.identity_keys) {
             Some(idx) => {
                 if let Value::Object(inf_obj) = &mut inferred_arr[idx] {
                     for (k, v) in disc_obj {
@@ -193,20 +200,24 @@ fn merge_distribution_array(
                         // cannot have their explicit overrides
                         // silently overwritten by per-distribution
                         // merging.
-                        let field_path = format!("{dist_prefix}/{idx}/{}", escape_token(&k));
+                        let field_path = format!("{dist_prefix}/{idx}/{}", escape_token(k));
                         let is_forced = forced_dcat_paths
                             .iter()
                             .any(|p| p == &field_path || p.starts_with(&format!("{field_path}/")));
                         if is_forced {
                             continue;
                         }
-                        merge_one(inf_obj, &k, v, field_strategy);
+                        // Per-field clone — only the fields that
+                        // actually flow into the inferred record
+                        // pay an allocation, and forced fields are
+                        // already filtered out above.
+                        merge_one(inf_obj, k, v.clone(), field_strategy);
                     }
                 }
             },
             None => {
                 if cfg.append_unmatched {
-                    inferred_arr.push(Value::Object(disc_obj));
+                    inferred_arr.push(Value::Object(disc_obj.clone()));
                 }
             },
         }

--- a/src/cmd/profile/profile_spec.rs
+++ b/src/cmd/profile/profile_spec.rs
@@ -205,18 +205,29 @@ pub struct CatalogBlock {
     #[serde(default, rename = "type")]
     pub type_:                Option<String>,
     /// minijinja template producing the catalog's `dct:title`. The
-    /// inner Dataset is available as `inner["..."]` for inheritance.
+    /// inner Dataset is exposed as `inner["..."]` (e.g.
+    /// `inner["dct:title"]`), and the analysis ctx
+    /// (`pkg`/`res`/`stats`/`dpp`/...) is available too. When unset,
+    /// the title falls back to the legacy
+    /// "Catalog of <inner dct:title>" convention.
     #[serde(default)]
     pub title_template:       Option<String>,
-    /// Top-level Dataset keys to copy into the Catalog envelope
-    /// (typical: `dct:publisher`).
+    /// Top-level Dataset keys to copy onto the Catalog envelope
+    /// verbatim (typical: `dct:publisher`). For renaming,
+    /// transforming, or conditional inheritance use a `fields[]`
+    /// entry whose template references `inner["<key>"]` instead;
+    /// catalog templates have full access to that binding plus the
+    /// analysis ctx.
     #[serde(default)]
     pub inherit_from_dataset: Vec<String>,
     /// The `dct:conformsTo` target IRI.
     #[serde(default)]
     pub conforms_to:          Option<String>,
-    /// Extra catalog-only fields beyond the title/conformsTo/dataset
-    /// trio.
+    /// Catalog-only / template-driven fields. Each entry is a
+    /// regular `FieldDecl`; templates render with `inner` (the
+    /// rendered Dataset block) injected on top of the analysis ctx,
+    /// so you can do `{{ inner["dct:publisher"] | tojson }}` for
+    /// transform-style inheritance.
     #[serde(default)]
     pub fields:               Vec<FieldDecl>,
 }

--- a/src/cmd/profile/profile_spec.rs
+++ b/src/cmd/profile/profile_spec.rs
@@ -275,16 +275,26 @@ pub enum RequiredLevel {
 pub struct DiscoveryMerge {
     /// When `false`, discovery-merge is a no-op for this profile.
     #[serde(default = "default_true")]
-    pub enabled:          bool,
+    pub enabled:            bool,
     /// Top-level keys never overwritten by discovered metadata.
     /// Defaults include `@context`, `@type`, and the distribution array.
     #[serde(default)]
-    pub never_overwrite:  Vec<String>,
+    pub never_overwrite:    Vec<String>,
     /// Strategy applied to keys not in `never_overwrite`.
     /// Possible values: `fill-if-absent` (default), `overlay-array`,
     /// `never`.
     #[serde(default)]
-    pub default_strategy: Option<String>,
+    pub default_strategy:   Option<String>,
+    /// Optional per-element merge config for the distribution array.
+    /// When `Some(cfg)` with `cfg.enabled = true`, the distribution
+    /// key bypasses the `never_overwrite` early-return and each
+    /// publisher Distribution is matched against an inferred
+    /// Distribution by identity keys (e.g. `dcat:accessURL`),
+    /// allowing publisher metadata (titles, rights, formats) to
+    /// flow into the inferred record without losing qsv's stats.
+    /// See `DistributionMerge` for details.
+    #[serde(default)]
+    pub distribution_merge: Option<DistributionMerge>,
 }
 
 // Hand-rolled Default so callers that build a ProfileSpec without
@@ -296,15 +306,64 @@ pub struct DiscoveryMerge {
 impl Default for DiscoveryMerge {
     fn default() -> Self {
         Self {
-            enabled:          true,
-            never_overwrite:  vec![
+            enabled:            true,
+            never_overwrite:    vec![
                 "@context".to_string(),
                 "@type".to_string(),
                 "dcat:distribution".to_string(),
             ],
-            default_strategy: Some("fill-if-absent".to_string()),
+            default_strategy:   Some("fill-if-absent".to_string()),
+            distribution_merge: None,
         }
     }
+}
+
+/// Per-element merge config for the distribution array. When
+/// `enabled = true`, the discovery-merge engine bypasses the outer
+/// `never_overwrite` rule for `array_key` and walks the discovered
+/// distribution array element-by-element, matching each publisher
+/// Distribution against the inferred array via `identity_keys`.
+///
+/// A typical config for DCAT profiles:
+/// ```yaml
+/// distribution_merge:
+///   enabled: true
+///   array_key: "dcat:distribution"
+///   identity_keys: ["dcat:downloadURL", "dcat:accessURL", "@id"]
+///   field_strategy: fill-if-absent
+///   append_unmatched: false
+/// ```
+#[derive(Debug, Clone, Default, Deserialize)]
+#[allow(dead_code)]
+pub struct DistributionMerge {
+    /// Master switch. `false` (default) preserves the legacy
+    /// "inferred-only" behavior.
+    #[serde(default)]
+    pub enabled:          bool,
+    /// Top-level key that holds the distribution array. Defaults
+    /// to `dcat:distribution`. Croissant-style profiles can point
+    /// this at `distribution` (schema.org bare-name).
+    #[serde(default)]
+    pub array_key:        Option<String>,
+    /// Ordered list of fields used to match a publisher distribution
+    /// against an inferred one. The first identity key with a
+    /// non-empty value on both sides triggers the match. Empty
+    /// `identity_keys` disables matching (every publisher dist is
+    /// treated as unmatched).
+    #[serde(default)]
+    pub identity_keys:    Vec<String>,
+    /// Strategy for merging fields within a matched pair. Same
+    /// values as `DiscoveryMerge::default_strategy`: `fill-if-absent`
+    /// (default), `overlay-array`, or `never`.
+    #[serde(default)]
+    pub field_strategy:   Option<String>,
+    /// When `true`, publisher distributions that don't match any
+    /// inferred distribution are appended to the array. Default
+    /// `false` — qsv's inferred distributions are usually canonical
+    /// for the local data, and unmatched publisher entries often
+    /// describe resources we don't see (mirrors, alternate formats).
+    #[serde(default)]
+    pub append_unmatched: bool,
 }
 
 /// Croissant-specific RecordSet declaration. The engine emits one

--- a/src/cmd/profile/profile_spec.rs
+++ b/src/cmd/profile/profile_spec.rs
@@ -436,6 +436,76 @@ dataset:
     }
 
     #[test]
+    fn embedded_dcat_ap_v3_parses_and_dry_compiles() {
+        let spec = load("dcat-ap-v3").expect("embedded load");
+        assert_eq!(spec.name, "dcat-ap-v3");
+        // DCAT-AP ships SHACL upstream; built-in validator is disabled.
+        assert!(!spec.validation.enabled);
+        assert!(spec.discovery_merge.enabled);
+        assert!(!spec.dataset.fields.is_empty());
+        assert!(spec.distribution.is_some());
+        assert!(spec.catalog.is_some());
+        assert_eq!(spec.field_mappings.len(), 28);
+        // EU theme vocab is the AP-specific addition.
+        assert!(spec.vocabularies.contains_key("eu_theme"));
+        assert!(spec.vocabularies.contains_key("license_iri"));
+        assert!(spec.vocabularies.contains_key("accrual_periodicity"));
+        assert!(spec.vocabularies.contains_key("iso_639_1"));
+        assert!(spec.vocabularies.contains_key("csvw_datatype"));
+        super::super::projection::dry_compile(&spec).expect("dry_compile");
+    }
+
+    #[test]
+    fn embedded_croissant_parses_and_dry_compiles() {
+        let spec = load("croissant").expect("embedded load");
+        assert_eq!(spec.name, "croissant");
+        // Croissant relies on the mlcommons Python validator; built-in
+        // validator + discovery merge are both disabled.
+        assert!(!spec.validation.enabled);
+        assert!(!spec.discovery_merge.enabled);
+        assert!(!spec.dataset.fields.is_empty());
+        assert!(spec.distribution.is_some());
+        assert!(spec.catalog.is_some());
+        // Croissant is the only profile that uses the recordsets block
+        // (per-column cr:Field expansion).
+        assert!(!spec.recordsets.is_empty());
+        assert_eq!(spec.field_mappings.len(), 16);
+        assert!(spec.vocabularies.contains_key("license_iri"));
+        assert!(spec.vocabularies.contains_key("croissant_datatype"));
+        super::super::projection::dry_compile(&spec).expect("dry_compile");
+    }
+
+    /// Parametric CI gate: every entry in `EMBEDDED` must parse cleanly
+    /// and `dry_compile` without error. Adding a new profile to the
+    /// bundle automatically inherits this coverage — no per-profile
+    /// test edit required.
+    #[test]
+    fn all_embedded_profiles_parse_and_dry_compile() {
+        assert!(
+            !EMBEDDED.is_empty(),
+            "EMBEDDED must contain at least one profile"
+        );
+        for (name, _) in EMBEDDED {
+            let spec = load(name)
+                .unwrap_or_else(|e| panic!("embedded profile `{name}` failed to load: {e}"));
+            assert_eq!(
+                spec.name.to_ascii_lowercase(),
+                name.to_ascii_lowercase(),
+                "embedded profile `{name}` reports mismatched spec.name `{}`",
+                spec.name
+            );
+            // Every shipped profile must have a non-empty dataset block;
+            // a profile with no dataset fields would produce empty output.
+            assert!(
+                !spec.dataset.fields.is_empty(),
+                "embedded profile `{name}` has no dataset fields"
+            );
+            super::super::projection::dry_compile(&spec)
+                .unwrap_or_else(|e| panic!("embedded profile `{name}` failed dry_compile: {e}"));
+        }
+    }
+
+    #[test]
     fn unknown_name_errors_with_list() {
         let err = load("not-a-real-profile").unwrap_err();
         let msg = err.to_string();

--- a/src/cmd/profile/projection.rs
+++ b/src/cmd/profile/projection.rs
@@ -153,7 +153,7 @@ pub fn project(
     let block = match mode {
         ProjectionMode::Dataset => dataset_value,
         ProjectionMode::Catalog => {
-            wrap_as_catalog(&env, &mj_ctx, profile, dataset_value, &mut warnings)
+            wrap_as_catalog(&env, ctx, profile, dataset_value, &mut warnings)
         },
     };
 
@@ -174,7 +174,8 @@ pub fn project(
 /// environment because the helper only needs it for the optional
 /// `title_template` + any catalog-only fields. `analysis_ctx` flows
 /// through so catalog templates can reach the same `pkg`/`res`/`stats`
-/// values the Dataset templates see.
+/// values the Dataset templates see, plus an injected `inner` (the
+/// rendered Dataset block) for template-driven inheritance.
 pub fn wrap_in_catalog_envelope(
     profile: &ProfileSpec,
     dataset: Value,
@@ -184,9 +185,8 @@ pub fn wrap_in_catalog_envelope(
     env.set_undefined_behavior(minijinja::UndefinedBehavior::Chainable);
     formula_helpers::register(&mut env);
     register_profile_helpers(&mut env, profile);
-    let mj_ctx = minijinja::Value::from_serialize(analysis_ctx);
     let mut warnings: Vec<ProjectionWarning> = Vec::new();
-    let block = wrap_as_catalog(&env, &mj_ctx, profile, dataset, &mut warnings);
+    let block = wrap_as_catalog(&env, analysis_ctx, profile, dataset, &mut warnings);
     Ok((block, warnings))
 }
 
@@ -295,7 +295,7 @@ fn emit_recordset(
 
 pub fn wrap_as_catalog(
     env: &Environment,
-    ctx: &minijinja::Value,
+    analysis_ctx: &Value,
     profile: &ProfileSpec,
     dataset: Value,
     warnings: &mut Vec<ProjectionWarning>,
@@ -305,16 +305,28 @@ pub fn wrap_as_catalog(
         .and_then(|c| c.type_.clone())
         .unwrap_or_else(|| "dcat:Catalog".to_string());
 
+    // Build a ctx that exposes the inner Dataset alongside the regular
+    // analysis vars (pkg/res/stats/dpp/etc.). Catalog templates use
+    // this so they can pull values from the rendered Dataset via
+    // `inner["dct:title"]` while still seeing the underlying source
+    // (`pkg.title`, etc.). The ctx clone is cheap (serde_json::Value
+    // is reference-counted for strings under the hood) and constructed
+    // once per catalog wrap.
+    let ctx_with_inner = build_ctx_with_inner(analysis_ctx, &dataset);
+    let mj_with_inner = minijinja::Value::from_serialize(&ctx_with_inner);
+
     // Title derived from the catalog template if any; otherwise fall back
-    // to the legacy "Catalog of <dct:title>" convention.
+    // to the legacy "Catalog of <dct:title>" convention. The title
+    // template now sees the same ctx_with_inner as catalog.fields, so
+    // it can reference pkg/res/stats in addition to inner[...] (a
+    // backward-compatible superset — legacy templates that only used
+    // `inner` keep working unchanged).
     let title = if let Some(CatalogBlock {
         title_template: Some(tpl),
         ..
     }) = envelope
     {
-        let inner_ctx = json!({ "inner": dataset });
-        let mj_inner = minijinja::Value::from_serialize(&inner_ctx);
-        match render_to_string(env, &mj_inner, tpl) {
+        match render_to_string(env, &mj_with_inner, tpl) {
             Ok(s) if !s.trim().is_empty() => s,
             _ => legacy_catalog_title(&dataset),
         }
@@ -347,7 +359,11 @@ pub fn wrap_as_catalog(
         );
     }
 
-    // Inherit declared keys from the Dataset.
+    // Inherit declared keys from the Dataset (verbatim copy by key).
+    // For template-driven inheritance — renaming, conditional copy,
+    // transforming values — use a `catalog.fields[]` entry instead;
+    // those render with `inner` exposed so they can do
+    // `{{ inner["dct:publisher"] | tojson }}` etc.
     if let Some(envelope) = envelope {
         for key in &envelope.inherit_from_dataset {
             if let Some(v) = dataset.get(key) {
@@ -355,15 +371,33 @@ pub fn wrap_as_catalog(
             }
         }
 
-        // Additional catalog-only fields.
+        // Additional catalog-only / template-driven fields. Render
+        // with the ctx_with_inner so templates can reference both
+        // the analysis vars (`pkg`, `res`, `stats`, `dpp`) and the
+        // rendered Dataset (`inner["..."]`).
         for field in &envelope.fields {
-            emit_field(env, ctx, field, &mut catalog, warnings);
+            emit_field(env, &mj_with_inner, field, &mut catalog, warnings);
         }
     }
 
     catalog.insert("dcat:dataset".to_string(), Value::Array(vec![dataset]));
 
     Value::Object(catalog)
+}
+
+/// Builds a catalog-scope rendering context by cloning the analysis
+/// JSON ctx and inserting `inner` (the rendered Dataset block). Falls
+/// back to a fresh object when the analysis ctx is not an object
+/// (e.g. tests that pass `json!({})` and shouldn't see a panic).
+fn build_ctx_with_inner(analysis_ctx: &Value, dataset: &Value) -> Value {
+    match analysis_ctx {
+        Value::Object(map) => {
+            let mut out = map.clone();
+            out.insert("inner".to_string(), dataset.clone());
+            Value::Object(out)
+        },
+        _ => json!({ "inner": dataset }),
+    }
 }
 
 fn legacy_catalog_title(dataset: &Value) -> String {
@@ -630,6 +664,138 @@ catalog:
             Some("Catalog of Hello")
         );
         assert!(out.get("dcat:dataset").and_then(Value::as_array).is_some());
+    }
+
+    #[test]
+    fn catalog_field_template_can_reference_inner_dataset() {
+        // Template-driven inheritance: a catalog.fields[] entry can
+        // reference `inner["..."]` to pull values from the rendered
+        // Dataset block, supporting rename / conditional copy /
+        // transform that the static `inherit_from_dataset` list
+        // cannot express.
+        let yaml = r#"
+name: catalog-inherit-template
+dataset:
+  type: dcat:Dataset
+  fields:
+    - path: dct:title
+      template: "Hello"
+    - path: dct:publisher
+      template: '{"@type":"foaf:Organization","foaf:name":"GSA"}'
+catalog:
+  type: dcat:Catalog
+  inherit_from_dataset: []
+  fields:
+    # Rename: emit dct:publisher from the Dataset under the
+    # dcat:contactPoint key on the Catalog.
+    - path: "dcat:contactPoint"
+      template: '{{ inner["dct:publisher"] | tojson }}'
+    # Conditional: emit a derived catalog-only key only when the
+    # Dataset has a title.
+    - path: "qsv:datasetTitle"
+      template: '{{ inner["dct:title"] }}'
+      emit_when: '{{ inner["dct:title"] is defined }}'
+"#;
+        let profile = load_from_str(yaml, "test").unwrap();
+        let ctx = json!({});
+        let (out, _) = project(&profile, &ctx, ProjectionMode::Catalog).unwrap();
+        // Renamed key carries the Dataset's publisher object.
+        let cp = out.get("dcat:contactPoint").expect("contactPoint");
+        assert_eq!(
+            cp.get("foaf:name").and_then(Value::as_str),
+            Some("GSA"),
+            "template-driven inheritance must surface nested fields"
+        );
+        // Conditional inheritance fires when inner has the key.
+        assert_eq!(
+            out.get("qsv:datasetTitle").and_then(Value::as_str),
+            Some("Hello")
+        );
+    }
+
+    #[test]
+    fn catalog_field_template_sees_analysis_ctx_alongside_inner() {
+        // ctx_with_inner is the union of the analysis ctx and
+        // `inner`, so catalog templates can mix both (e.g. emit a
+        // catalog-only ID from pkg + a rendered Dataset value).
+        let yaml = r#"
+name: catalog-mixed-ctx
+dataset:
+  type: dcat:Dataset
+  fields:
+    - path: dct:title
+      template: "{{ pkg.title | default('Untitled') }}"
+catalog:
+  type: dcat:Catalog
+  inherit_from_dataset: []
+  fields:
+    - path: "qsv:catalogId"
+      template: 'cat-{{ pkg.id }}-{{ inner["dct:title"] }}'
+"#;
+        let profile = load_from_str(yaml, "test").unwrap();
+        let ctx = json!({ "pkg": { "id": "42", "title": "NYC 311" } });
+        let (out, _) = project(&profile, &ctx, ProjectionMode::Catalog).unwrap();
+        assert_eq!(
+            out.get("qsv:catalogId").and_then(Value::as_str),
+            Some("cat-42-NYC 311"),
+            "catalog template must see both pkg.* and inner[...]"
+        );
+    }
+
+    #[test]
+    fn catalog_field_emit_when_against_inner_skips_empty() {
+        // An emit_when guard that consults `inner` must skip the
+        // field when the guard renders falsy (the Dataset's key is
+        // missing).
+        let yaml = r#"
+name: catalog-guard
+dataset:
+  type: dcat:Dataset
+  fields:
+    - path: dct:title
+      template: "T"
+catalog:
+  type: dcat:Catalog
+  inherit_from_dataset: []
+  fields:
+    - path: "qsv:hasLicense"
+      template: "yes"
+      emit_when: '{{ inner["dct:license"] is defined }}'
+"#;
+        let profile = load_from_str(yaml, "test").unwrap();
+        let (out, _) = project(&profile, &json!({}), ProjectionMode::Catalog).unwrap();
+        assert!(
+            out.get("qsv:hasLicense").is_none(),
+            "emit_when against inner[missing] must skip"
+        );
+    }
+
+    #[test]
+    fn catalog_title_template_can_reference_analysis_ctx() {
+        // Backward-compatible superset: the title template now sees
+        // pkg/res/stats in addition to `inner`. Legacy templates that
+        // only used `inner` keep working — covered by
+        // dcat_us_v3_golden_parity_catalog. This test confirms the
+        // additional context is reachable.
+        let yaml = r#"
+name: catalog-title-ctx
+dataset:
+  type: dcat:Dataset
+  fields:
+    - path: dct:title
+      template: "Inner Title"
+catalog:
+  type: dcat:Catalog
+  title_template: '{{ pkg.publisher }} — Catalog of {{ inner["dct:title"] }}'
+  inherit_from_dataset: []
+"#;
+        let profile = load_from_str(yaml, "test").unwrap();
+        let ctx = json!({ "pkg": { "publisher": "Acme" } });
+        let (out, _) = project(&profile, &ctx, ProjectionMode::Catalog).unwrap();
+        assert_eq!(
+            out.get("dct:title").and_then(Value::as_str),
+            Some("Acme — Catalog of Inner Title")
+        );
     }
 
     #[test]

--- a/src/cmd/profile/projection.rs
+++ b/src/cmd/profile/projection.rs
@@ -309,9 +309,12 @@ pub fn wrap_as_catalog(
     // analysis vars (pkg/res/stats/dpp/etc.). Catalog templates use
     // this so they can pull values from the rendered Dataset via
     // `inner["dct:title"]` while still seeing the underlying source
-    // (`pkg.title`, etc.). The ctx clone is cheap (serde_json::Value
-    // is reference-counted for strings under the hood) and constructed
-    // once per catalog wrap.
+    // (`pkg.title`, etc.). `serde_json::Value::clone` is a deep copy
+    // (it allocates for nested objects/arrays/strings), but we do it
+    // once per catalog wrap and the analysis ctx is small in typical
+    // use. A future optimization could avoid the clone entirely by
+    // layering contexts inside minijinja instead of merging at the
+    // JSON layer.
     let ctx_with_inner = build_ctx_with_inner(analysis_ctx, &dataset);
     let mj_with_inner = minijinja::Value::from_serialize(&ctx_with_inner);
 


### PR DESCRIPTION
## Summary
Picks up the §6 queued follow-ups from `profile3-handoff.md` for the YAML-driven projection engine. Four stacked commits, each scoped to one item:

- **`3d1e2f7d3`** — CI gate: parametric `cargo test embedded_*` smoke covers every entry in `EMBEDDED` for `load + dry_compile`, so any future profile YAML inherits coverage automatically.
- **`6e0508b2c`** — Per-distribution identity-based discovery merge: new `DistributionMerge` config lets publisher DCAT contribute per-Distribution metadata (titles, rights, licenses) without losing qsv's inferred stats. Matches by `dcat:downloadURL` / `dcat:accessURL` / `@id`.
- **`f16603dc4`** — Template-driven catalog inheritance: exposes the rendered Dataset as `inner` on `catalog.fields[]` + `title_template` ctx, so users can rename / transform / conditionally copy via the existing `FieldDecl` machinery. `inherit_from_dataset: [...]` stays as the verbatim-copy shortcut.
- **`c827da5c2`** — Roborev #2499 fix: per-dist merge now honors `forced_dcat_paths` at `/dcat/<dist_key>/<idx>/<field>` (exact + nested-parent), and `array_key` actually defaults to `dcat:distribution` when omitted.

Engine net change: ~1003 LOC added, ~23 removed across 6 files. All knowledge stays in the YAML profiles (`dcat-us-v3.yaml`, `dcat-ap-v3.yaml`) — no hardcoded behavior added.

§6 items still queued (not in this PR — both need external-dep decisions):
- SHACL validation backend for DCAT-AP v3
- Croissant `mlcroissant` Python validator integration

## Test plan
- [x] `cargo test --bin qsv -F profile,feature_capable cmd::profile::` — **141 unit tests pass** (16 new across the 4 commits)
- [x] `cargo test --test tests -F profile,feature_capable -- test_profile::` — **49 integration tests pass** (golden parity byte-exact, no shape drift)
- [x] `cargo build` for all 4 binaries: `qsv` (-F all_features), `qsvmcp` (-F qsvmcp), `qsvlite` (-F lite), `qsvdp` (-F datapusher_plus) — all green
- [x] `cargo clippy --bin qsv -F profile,feature_capable` — no new warnings
- [x] `cargo +nightly fmt` applied
- [x] `python3 scripts/docs-drift-check.py` — no drift detected
- [x] `resources/profiles/README.md` updated with "Catalog envelope" + "Discovery merge" sections (incl. `distribution_merge` sub-block)
- [x] Roborev #2499 closed (`closed=true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)