### PR TITLE
feat(profile): Croissant mlcroissant validator + generic external validator framework

### DIFF
--- a/docs/help/profile.md
+++ b/docs/help/profile.md
@@ -50,7 +50,7 @@ qsv profile --help
 
 ## Profile Options [↩](#nav)
 
-| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Option&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Type | Description | Default |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Option&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Type | Description | Default |
 |--------|------|-------------|--------|
 | &nbsp;`‑‑spec`&nbsp; | string | CKAN scheming YAML spec file. If omitted, only the inferred `dpp` block (lat/lon/date columns, dataset stats) is emitted; no formulas are evaluated. |  |
 | &nbsp;`‑‑initial‑context`&nbsp; | string | JSON file providing seed values for the package / resource dicts plus optional JSON-Pointer overrides for the final DCAT block. Replaces the older --package-meta / --resource-meta flags. Top-level keys: `package`, `resource`, `dataset_info`. Each leaf value may be wrapped as {"value": ..., "force": true} to mark it as overriding any value discovered from URL DCAT markup AND any value qsv inferred. Force is honored across all three subtrees: dataset_info entries override their target path verbatim; package / resource entries route through the active profile's `field_mappings:` table (e.g. `package.title force=true` lands at `/dcat/dct:title`, beating inference and discovery). Forced values for slots the profile does not surface are silently dropped (no-op). See tests/resources/profile/dcat-init-context.README.md for a fully-populated example. |  |
@@ -61,6 +61,7 @@ qsv profile --help
 | &nbsp;`‑‑dcat‑discovery‑timeout`&nbsp; | integer | Per-request timeout for DCAT-markup discovery probes. Default: 5. |  |
 | &nbsp;`‑‑validate‑dcat`&nbsp; | flag | Validate the emitted dcat block against the vendored GSA DCAT-US v3 JSON Schema bundle (see resources/dcat-us-v3/). Catches missing mandatory fields, cardinality issues, and shape violations across the full v3 spec. Violations append to dcat_warnings by default. |  |
 | &nbsp;`‑‑strict‑dcat`&nbsp; | flag | With --validate-dcat, fail the command on any schema violation instead of warning. |  |
+| &nbsp;`‑‑allow‑external‑validator`&nbsp; | flag | Opt in to spawning the validator binary declared by `validation.external` when the profile was loaded from an arbitrary YAML file. Bundled profiles (dcat-us-v3, dcat-ap-v3, croissant) always run their declared external validators because the profile content is vetted at qsv release time. Without this flag, file-loaded profiles emit a Recommended-severity warning instead of running the binary, so an untrusted YAML can't silently execute arbitrary commands. Default: off. |  |
 | &nbsp;`‑‑catalog`&nbsp; | flag | Wrap the emitted DCAT-US v3 Dataset inside a dcat:Catalog envelope (Catalog{dataset:[...]}). Useful for federation harvesters (data.gov, CKAN ingest) that expect Catalog-shaped top-level metadata. Default: off (Dataset-only, backwards-compatible). |  |
 | &nbsp;`‑‑profile`&nbsp; | string | Metadata projection profile to use. Embedded names: dcat-us-v3 (default), dcat-ap-v3, croissant. A path to a custom YAML profile is also accepted; embedded names always win over same-named files. See resources/profiles/README.md for the schema and authoring guide. |  |
 | &nbsp;`‑‑force`&nbsp; | flag | Force recomputing cardinality and unique values even if a stats cache file exists. |  |

--- a/resources/profiles/README.md
+++ b/resources/profiles/README.md
@@ -113,3 +113,45 @@ fields flow into the inferred record via `field_strategy`.
 DCAT-US v3 and DCAT-AP v3 enable this with `dcat:downloadURL` →
 `dcat:accessURL` → `@id` as the identity-key priority. Croissant
 disables `discovery_merge` entirely.
+
+## Validation
+
+Two orthogonal validators are available on every profile:
+
+* **`validation.enabled` (JSON Schema)** — when `true`, the engine
+  validates the rendered block against the vendored GSA DCAT-US v3
+  bundle under `resources/dcat-us-v3/`. Today only the DCAT-US v3
+  bundle ships with qsv; any other `schema_dir` emits a heads-up
+  warning. Triggered by `--validate-dcat`.
+* **`validation.external`** — an out-of-process validator (e.g.
+  `mlcroissant`, `pyshacl`) spawned with the rendered JSON-LD on
+  disk. Runs orthogonal to JSON Schema: a profile may use either,
+  both, or neither. Also gated by `--validate-dcat`.
+
+### External validator config
+
+| Key | Meaning |
+|---|---|
+| `command` | Command to spawn (resolved via `PATH`). When not found, validation emits one `Info`-severity warning and continues — projection still ships. |
+| `args` | Arguments. The literal token `{file}` is replaced with the path to a tempfile holding the rendered JSON-LD. Without `{file}`, the path is appended as the last positional arg. |
+| `default_severity` | Severity for each surfaced finding. One of `required` / `recommended` (default) / `optional` / `info`. |
+| `label` | Friendly name used in warning messages instead of the raw `command` value. Useful when the command is e.g. `python3 -m mlcroissant ...`. |
+| `install_hint` | Optional free-form text appended to the missing-binary warning (typically a one-line install command + project URL). |
+
+A non-zero exit code surfaces one warning per non-empty stderr line
+(falling back to stdout when stderr is empty). Exit 0 = empty Vec.
+Findings respect `--strict-dcat`: when set, a non-`Info` external
+finding fails the command the same way a JSON Schema violation does.
+
+Croissant uses this to wire up the canonical Python validator:
+
+```yaml
+validation:
+  enabled: false
+  external:
+    command: "mlcroissant"
+    args: ["validate", "--jsonld", "{file}"]
+    label: "mlcroissant"
+    default_severity: "recommended"
+    install_hint: "pip install mlcroissant (https://github.com/mlcommons/croissant/tree/main/python/mlcroissant)"
+```

--- a/resources/profiles/croissant.yaml
+++ b/resources/profiles/croissant.yaml
@@ -71,11 +71,27 @@ field_mappings:
 # Schema validation: disabled
 # =========================================================================
 # Croissant uses a Python validator (mlcroissant); JSON Schema isn't
-# upstream. Future enhancement: invoke the Python validator
-# out-of-process when available.
+# upstream. `enabled: false` keeps the built-in JSON-Schema validator
+# off; the `external` block wires up the canonical Python validator
+# when it's installed locally (graceful skip with an Info-severity
+# warning when it isn't).
 validation:
   enabled: false
   strippable_curie_prefixes: []
+  # `mlcroissant` is the reference validator shipped by MLCommons
+  # (https://github.com/mlcommons/croissant/tree/main/python/mlcroissant).
+  # Install via `pip install mlcroissant`. qsv runs it under
+  # `--validate-dcat`; findings surface as ProjectionWarnings at
+  # `default_severity`. Missing-binary cases never fail the run.
+  external:
+    command: "mlcroissant"
+    args: ["validate", "--jsonld", "{file}"]
+    label: "mlcroissant"
+    default_severity: "recommended"
+    # Shown in the missing-binary warning so users see the install
+    # path at the exact moment they need it. Free-form — typically
+    # a one-line install command + the project URL.
+    install_hint: "pip install mlcroissant (https://github.com/mlcommons/croissant/tree/main/python/mlcroissant)"
 
 # =========================================================================
 # Dataset projection

--- a/src/cmd/profile.rs
+++ b/src/cmd/profile.rs
@@ -116,6 +116,7 @@ mod context;
 mod dcat_discover;
 mod dcat_validate;
 mod discovery_merge;
+mod external_validate;
 mod formula_engine;
 mod formula_helpers;
 mod profile_spec;
@@ -494,6 +495,32 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                 )));
             }
             dcat_warnings.extend(validation);
+
+            // Out-of-process validator (e.g. mlcroissant, pyshacl).
+            // Runs in parallel to the built-in JSON-Schema validator;
+            // a profile may use either, both, or neither. Findings
+            // surface as ProjectionWarnings; missing-binary cases
+            // degrade gracefully to a single Info-severity notice.
+            // Strict mode treats external findings the same as
+            // schema violations — if you've opted in to validation,
+            // you've opted in to all of it.
+            let external = external_validate::validate(&profile, final_dcat);
+            let external_findings: Vec<_> = external
+                .iter()
+                .filter(|w| !matches!(w.severity, projection::Severity::Info))
+                .collect();
+            if !external_findings.is_empty() && args.flag_strict_dcat {
+                let summary = external_findings
+                    .iter()
+                    .map(|w| format!("  - {}: {}", w.field, w.message))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                return Err(CliError::Other(format!(
+                    "qsv profile --strict-dcat: {} external validator finding(s):\n{summary}",
+                    external_findings.len()
+                )));
+            }
+            dcat_warnings.extend(external);
         }
 
         // §5.8: profile-driven validation. When the spec opts in by

--- a/src/cmd/profile.rs
+++ b/src/cmd/profile.rs
@@ -72,6 +72,19 @@ profile options:
                               Violations append to dcat_warnings by default.
     --strict-dcat             With --validate-dcat, fail the command on
                               any schema violation instead of warning.
+    --allow-external-validator
+                              Opt in to spawning the validator binary
+                              declared by `validation.external` when the
+                              profile was loaded from an arbitrary YAML
+                              file. Bundled profiles (dcat-us-v3,
+                              dcat-ap-v3, croissant) always run their
+                              declared external validators because the
+                              profile content is vetted at qsv release
+                              time. Without this flag, file-loaded
+                              profiles emit a Recommended-severity
+                              warning instead of running the binary, so
+                              an untrusted YAML can't silently execute
+                              arbitrary commands. Default: off.
     --catalog                 Wrap the emitted DCAT-US v3 Dataset inside a
                               dcat:Catalog envelope (Catalog{dataset:[...]}).
                               Useful for federation harvesters (data.gov,
@@ -126,24 +139,25 @@ mod sql_backend;
 
 #[derive(Debug, Deserialize)]
 struct Args {
-    arg_input:                   Option<String>,
-    flag_spec:                   Option<String>,
-    flag_initial_context:        Option<String>,
-    flag_no_dcat:                bool,
-    flag_dcat_legacy_license:    bool,
-    flag_no_dcat_discovery:      bool,
-    flag_dcat_discovery_timeout: Option<u64>,
-    flag_validate_dcat:          bool,
-    flag_strict_dcat:            bool,
-    flag_catalog:                bool,
-    flag_profile:                Option<String>,
-    flag_no_ckan:                bool,
-    flag_force:                  bool,
-    flag_jobs:                   Option<usize>,
-    flag_output:                 Option<String>,
-    flag_no_headers:             bool,
-    flag_delimiter:              Option<crate::config::Delimiter>,
-    flag_memcheck:               bool,
+    arg_input:                     Option<String>,
+    flag_spec:                     Option<String>,
+    flag_initial_context:          Option<String>,
+    flag_no_dcat:                  bool,
+    flag_dcat_legacy_license:      bool,
+    flag_no_dcat_discovery:        bool,
+    flag_dcat_discovery_timeout:   Option<u64>,
+    flag_validate_dcat:            bool,
+    flag_strict_dcat:              bool,
+    flag_allow_external_validator: bool,
+    flag_catalog:                  bool,
+    flag_profile:                  Option<String>,
+    flag_no_ckan:                  bool,
+    flag_force:                    bool,
+    flag_jobs:                     Option<usize>,
+    flag_output:                   Option<String>,
+    flag_no_headers:               bool,
+    flag_delimiter:                Option<crate::config::Delimiter>,
+    flag_memcheck:                 bool,
 }
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
@@ -498,29 +512,54 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
             // Out-of-process validator (e.g. mlcroissant, pyshacl).
             // Runs in parallel to the built-in JSON-Schema validator;
-            // a profile may use either, both, or neither. Findings
-            // surface as ProjectionWarnings; missing-binary cases
-            // degrade gracefully to a single Info-severity notice.
-            // Strict mode treats external findings the same as
-            // schema violations — if you've opted in to validation,
-            // you've opted in to all of it.
-            let external = external_validate::validate(&profile, final_dcat);
-            let external_findings: Vec<_> = external
-                .iter()
-                .filter(|w| !matches!(w.severity, projection::Severity::Info))
-                .collect();
-            if !external_findings.is_empty() && args.flag_strict_dcat {
-                let summary = external_findings
+            // a profile may use either, both, or neither.
+            //
+            // Trust gate: a `--profile <path>` argument can load an
+            // arbitrary YAML file from disk, and that file controls
+            // `validation.external.command`. Spawning whatever the
+            // file says would let an untrusted profile execute
+            // arbitrary commands. So: embedded profiles always run
+            // their declared external validators (qsv release vets
+            // those YAMLs); file-loaded profiles need an explicit
+            // `--allow-external-validator` opt-in, otherwise we skip
+            // the spawn and emit a Recommended-severity warning that
+            // tells the user what would have run and how to opt in.
+            // Strict mode honors external findings the same way it
+            // honors schema violations — once you've opted in to
+            // validation, all findings escalate.
+            let allow_external = profile.source.is_embedded() || args.flag_allow_external_validator;
+            if profile.validation.external.is_some() && !allow_external {
+                let cfg = profile.validation.external.as_ref().unwrap();
+                let label = cfg.label.as_deref().unwrap_or(cfg.command.as_str());
+                dcat_warnings.push(projection::ProjectionWarning {
+                    field:    "external_validate".to_string(),
+                    severity: projection::Severity::Recommended,
+                    message:  format!(
+                        "external validator `{label}` declared by file-loaded profile `{}` was \
+                         NOT run. Spawning arbitrary commands from untrusted profiles is gated \
+                         for safety. Pass --allow-external-validator to opt in.",
+                        profile.name,
+                    ),
+                });
+            } else if allow_external {
+                let external = external_validate::validate(&profile, final_dcat);
+                let external_findings: Vec<_> = external
                     .iter()
-                    .map(|w| format!("  - {}: {}", w.field, w.message))
-                    .collect::<Vec<_>>()
-                    .join("\n");
-                return Err(CliError::Other(format!(
-                    "qsv profile --strict-dcat: {} external validator finding(s):\n{summary}",
-                    external_findings.len()
-                )));
+                    .filter(|w| !matches!(w.severity, projection::Severity::Info))
+                    .collect();
+                if !external_findings.is_empty() && args.flag_strict_dcat {
+                    let summary = external_findings
+                        .iter()
+                        .map(|w| format!("  - {}: {}", w.field, w.message))
+                        .collect::<Vec<_>>()
+                        .join("\n");
+                    return Err(CliError::Other(format!(
+                        "qsv profile --strict-dcat: {} external validator finding(s):\n{summary}",
+                        external_findings.len()
+                    )));
+                }
+                dcat_warnings.extend(external);
             }
-            dcat_warnings.extend(external);
         }
 
         // §5.8: profile-driven validation. When the spec opts in by

--- a/src/cmd/profile/external_validate.rs
+++ b/src/cmd/profile/external_validate.rs
@@ -22,7 +22,11 @@
 //! `wait-timeout` is a queued follow-up if validators start hanging
 //! on huge inputs.
 
-use std::{io::Write, process::Command};
+use std::{
+    ffi::{OsStr, OsString},
+    io::Write,
+    process::Command,
+};
 
 use serde_json::Value;
 use tempfile::NamedTempFile;
@@ -32,18 +36,6 @@ use super::{
     projection::{ProjectionWarning, Severity},
 };
 
-/// Run the profile's external validator (if any) against `block`.
-///
-/// Returns an empty Vec when:
-///
-/// * `profile.validation.external` is `None` (validator not configured).
-/// * The validator command exits with status 0.
-///
-/// Returns one or more `ProjectionWarning`s when the validator is
-/// configured but: (a) the binary isn't on PATH (single `Info`-level
-/// notice), (b) spawn fails (single `Recommended`-level OS error), or
-/// (c) the command exits non-zero (one warning per non-empty stderr
-/// or stdout line).
 pub fn validate(profile: &ProfileSpec, block: &Value) -> Vec<ProjectionWarning> {
     let Some(cfg) = profile.validation.external.as_ref() else {
         return Vec::new();
@@ -66,8 +58,13 @@ pub fn validate(profile: &ProfileSpec, block: &Value) -> Vec<ProjectionWarning> 
         },
     };
 
-    let path_str = tmp.path().to_string_lossy().to_string();
-    let resolved_args = resolve_args(&cfg.args, &path_str);
+    // Keep the tempfile path as an `OsString` so non-UTF-8 paths
+    // (legal on Unix, possible on Windows) pass through to the
+    // spawned validator verbatim. `to_string_lossy()` would silently
+    // mangle such paths and the validator would then complain that
+    // the file doesn't exist.
+    let path_os = tmp.path().as_os_str().to_owned();
+    let resolved_args = resolve_args(&cfg.args, &path_os);
 
     let mut cmd = Command::new(&cfg.command);
     cmd.args(&resolved_args);
@@ -123,9 +120,17 @@ pub fn validate(profile: &ProfileSpec, block: &Value) -> Vec<ProjectionWarning> 
             continue;
         }
         warnings.push(ProjectionWarning {
-            field: format!("external_validate/{label}"),
+            // Keep `field` stable. The rest of the projection
+            // pipeline treats it as a JSON-LD key / pointer;
+            // encoding a user-configurable label here (which may
+            // contain `/` or whitespace) would make it look like
+            // a JSON pointer and confuse downstream filtering.
+            // The validator label is already carried in the
+            // message so users can still trace findings back to
+            // their source.
+            field: "external_validate".to_string(),
             severity,
-            message: trimmed.to_string(),
+            message: format!("{label}: {trimmed}"),
         });
     }
 
@@ -162,15 +167,39 @@ fn write_tempfile(block: &Value) -> Result<NamedTempFile, std::io::Error> {
 /// no arg contains the token, append `path` as a final argument so
 /// validators that take "file as last positional" still work without
 /// explicit templating.
-fn resolve_args(args: &[String], path: &str) -> Vec<String> {
+///
+/// Args themselves come from YAML and are guaranteed UTF-8, but the
+/// substituted path is an `OsStr` so non-UTF-8 tempfile paths flow
+/// through to the spawned process unchanged. The output is
+/// `Vec<OsString>`, which `Command::args` accepts directly.
+fn resolve_args(args: &[String], path: &OsStr) -> Vec<OsString> {
     let has_token = args.iter().any(|a| a.contains("{file}"));
     if has_token {
-        args.iter().map(|a| a.replace("{file}", path)).collect()
+        args.iter()
+            .map(|a| substitute_file_token(a, path))
+            .collect()
     } else {
-        let mut out: Vec<String> = args.to_vec();
-        out.push(path.to_string());
+        let mut out: Vec<OsString> = args.iter().map(OsString::from).collect();
+        out.push(path.to_os_string());
         out
     }
+}
+
+/// Build a single arg by splitting around the literal `{file}`
+/// markers and stitching the OsStr `path` in between, so the path
+/// segment retains its native (potentially non-UTF-8) bytes while
+/// the surrounding template chars come from the (always UTF-8)
+/// YAML arg string.
+fn substitute_file_token(arg: &str, path: &OsStr) -> OsString {
+    let parts: Vec<&str> = arg.split("{file}").collect();
+    let mut out = OsString::new();
+    for (i, part) in parts.iter().enumerate() {
+        if i > 0 {
+            out.push(path);
+        }
+        out.push(part);
+    }
+    out
 }
 
 /// Parse the configured severity string ("required" / "recommended"
@@ -336,9 +365,13 @@ validation:
         let warnings = validate(&profile, &json!({}));
         assert_eq!(warnings.len(), 2);
         assert!(matches!(warnings[0].severity, Severity::Required));
-        assert_eq!(warnings[0].message, "first issue");
-        assert_eq!(warnings[1].message, "second issue");
-        assert_eq!(warnings[0].field, "external_validate/fake-validator");
+        // Field stays stable so downstream filters can target a
+        // single string; the validator label lives in the message
+        // so users can still trace findings back to source.
+        assert_eq!(warnings[0].field, "external_validate");
+        assert_eq!(warnings[1].field, "external_validate");
+        assert_eq!(warnings[0].message, "fake-validator: first issue");
+        assert_eq!(warnings[1].message, "fake-validator: second issue");
     }
 
     #[test]
@@ -361,7 +394,9 @@ validation:
         let profile = load_from_str(yaml, "t").unwrap();
         let warnings = validate(&profile, &json!({}));
         assert_eq!(warnings.len(), 1);
-        assert_eq!(warnings[0].message, "stdout-finding");
+        // Default label is the command name when none is configured.
+        assert_eq!(warnings[0].message, "sh: stdout-finding");
+        assert_eq!(warnings[0].field, "external_validate");
     }
 
     #[test]
@@ -411,14 +446,16 @@ validation:
 "#;
         let profile = load_from_str(yaml, "t").unwrap();
         let warnings = validate(&profile, &json!({"@type": "dcat:Dataset"}));
-        // First stdout line carries the substituted path.
+        // First stdout line carries the substituted path (now
+        // prefixed with the label-as-command + ": " per the stable
+        // message format).
         assert!(
-            warnings.iter().any(|w| w.message.starts_with("got: /")),
+            warnings.iter().any(|w| w.message.starts_with("sh: got: /")),
             "{{file}} substitution must place the tempfile path in arg slot"
         );
         // Second confirms the file is non-empty (block was serialized).
         assert!(
-            warnings.iter().any(|w| w.message == "nonempty"),
+            warnings.iter().any(|w| w.message == "sh: nonempty"),
             "tempfile must contain the serialized JSON-LD"
         );
     }
@@ -442,10 +479,13 @@ validation:
         let warnings = validate(&profile, &json!({}));
         // The tempfile path was appended as the final positional arg
         // after "_", and `$1` (counting from the script's first arg
-        // after `-c <script>`) prints it.
+        // after `-c <script>`) prints it. Message format is
+        // "<label>: <line>"; no label set so the command name `sh`
+        // is used.
         assert!(
-            warnings[0].message.starts_with("last arg: /"),
-            "missing {{file}} token must append path as last arg"
+            warnings[0].message.starts_with("sh: last arg: /"),
+            "missing {{file}} token must append path as last arg; got `{}`",
+            warnings[0].message
         );
     }
 
@@ -479,14 +519,44 @@ validation:
             "--input".to_string(),
             "{file}".to_string(),
         ];
-        let out = resolve_args(&args, "/tmp/x.json");
-        assert_eq!(out, vec!["validate", "--input", "/tmp/x.json"]);
+        let out = resolve_args(&args, OsStr::new("/tmp/x.json"));
+        let expected: Vec<OsString> = ["validate", "--input", "/tmp/x.json"]
+            .iter()
+            .map(OsString::from)
+            .collect();
+        assert_eq!(out, expected);
     }
 
     #[test]
     fn resolve_args_appends_when_token_absent() {
         let args = vec!["validate".to_string(), "--strict".to_string()];
-        let out = resolve_args(&args, "/tmp/x.json");
-        assert_eq!(out, vec!["validate", "--strict", "/tmp/x.json"]);
+        let out = resolve_args(&args, OsStr::new("/tmp/x.json"));
+        let expected: Vec<OsString> = ["validate", "--strict", "/tmp/x.json"]
+            .iter()
+            .map(OsString::from)
+            .collect();
+        assert_eq!(out, expected);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_args_preserves_non_utf8_path_bytes() {
+        // Unix paths can contain arbitrary bytes including invalid
+        // UTF-8 sequences. The substituted path must reach
+        // Command::args verbatim — using to_string_lossy() instead
+        // (the pre-fix code path) would replace those bytes with
+        // U+FFFD and the spawned validator would then get a path
+        // that doesn't exist on disk.
+        use std::os::unix::ffi::OsStrExt;
+        let raw = b"/tmp/\xFFnon-utf8\xFE.json";
+        let path = OsStr::from_bytes(raw);
+        let args = vec!["--input".to_string(), "{file}".to_string()];
+        let out = resolve_args(&args, path);
+        // The second arg must be exactly the original byte sequence.
+        assert_eq!(
+            out[1].as_bytes(),
+            raw,
+            "non-UTF-8 path bytes must survive substitution"
+        );
     }
 }

--- a/src/cmd/profile/external_validate.rs
+++ b/src/cmd/profile/external_validate.rs
@@ -1,0 +1,492 @@
+//! Out-of-process validator integration.
+//!
+//! Some profiles ship with reference validators that live outside
+//! Rust — Croissant uses `mlcroissant` (Python), DCAT-AP uses
+//! `pyshacl`, etc. Rather than rebuild each one natively (the Rust
+//! ecosystem for SHACL/JSON-LD validators is sparse), profiles can
+//! declare an external command in `validation.external` and the
+//! engine spawns it with the rendered JSON-LD on disk.
+//!
+//! Graceful degradation is the design goal:
+//!
+//! * Missing binary → one `Severity::Info` warning ("`<cmd>` not installed; skipped validation"),
+//!   projection still ships.
+//! * Spawn error → one `Severity::Recommended` warning with the OS error message.
+//! * Non-zero exit → each non-empty stderr line becomes one warning with the configured
+//!   `default_severity`. Stdout content is surfaced separately when stderr is empty (some
+//!   validators emit findings on stdout).
+//! * Exit code zero → empty Vec (success).
+//!
+//! No timeout is enforced today. `run_profile_validation` (the
+//! sibling RFC4180 validator) follows the same convention; adding
+//! `wait-timeout` is a queued follow-up if validators start hanging
+//! on huge inputs.
+
+use std::{io::Write, process::Command};
+
+use serde_json::Value;
+use tempfile::NamedTempFile;
+
+use super::{
+    profile_spec::ProfileSpec,
+    projection::{ProjectionWarning, Severity},
+};
+
+/// Run the profile's external validator (if any) against `block`.
+///
+/// Returns an empty Vec when:
+///
+/// * `profile.validation.external` is `None` (validator not configured).
+/// * The validator command exits with status 0.
+///
+/// Returns one or more `ProjectionWarning`s when the validator is
+/// configured but: (a) the binary isn't on PATH (single `Info`-level
+/// notice), (b) spawn fails (single `Recommended`-level OS error), or
+/// (c) the command exits non-zero (one warning per non-empty stderr
+/// or stdout line).
+pub fn validate(profile: &ProfileSpec, block: &Value) -> Vec<ProjectionWarning> {
+    let Some(cfg) = profile.validation.external.as_ref() else {
+        return Vec::new();
+    };
+
+    let severity = parse_severity(cfg.default_severity.as_deref());
+    let label = cfg.label.as_deref().unwrap_or(cfg.command.as_str());
+
+    // Write the rendered JSON-LD to a tempfile. mlcroissant + pyshacl
+    // both accept a file path; piping on stdin would need per-tool
+    // flags. Keep the contract uniform.
+    let mut tmp = match write_tempfile(block) {
+        Ok(t) => t,
+        Err(e) => {
+            return vec![ProjectionWarning {
+                field:    "external_validate".to_string(),
+                severity: Severity::Recommended,
+                message:  format!("could not write JSON-LD tempfile for `{label}`: {e}"),
+            }];
+        },
+    };
+
+    let path_str = tmp.path().to_string_lossy().to_string();
+    let resolved_args = resolve_args(&cfg.args, &path_str);
+
+    let mut cmd = Command::new(&cfg.command);
+    cmd.args(&resolved_args);
+    let output = match cmd.output() {
+        Ok(o) => o,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // Graceful skip — the canonical validator simply isn't
+            // installed on this machine. The install hint (when
+            // provided) gives the user a one-line path to fixing
+            // the gap without leaving the terminal.
+            let _ = tmp.flush();
+            let hint = cfg
+                .install_hint
+                .as_deref()
+                .map(|h| format!(" Install: {h}"))
+                .unwrap_or_default();
+            return vec![ProjectionWarning {
+                field:    "external_validate".to_string(),
+                severity: Severity::Info,
+                message:  format!(
+                    "`{label}` not installed; skipped {} validation.{hint}",
+                    profile.name
+                ),
+            }];
+        },
+        Err(e) => {
+            return vec![ProjectionWarning {
+                field:    "external_validate".to_string(),
+                severity: Severity::Recommended,
+                message:  format!("failed to spawn `{label}`: {e}"),
+            }];
+        },
+    };
+
+    if output.status.success() {
+        return Vec::new();
+    }
+
+    // Non-zero exit: surface findings. Prefer stderr (most validators
+    // log there); fall back to stdout when stderr is empty.
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let blob = if stderr.trim().is_empty() {
+        stdout.as_ref()
+    } else {
+        stderr.as_ref()
+    };
+
+    let mut warnings = Vec::new();
+    for line in blob.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        warnings.push(ProjectionWarning {
+            field: format!("external_validate/{label}"),
+            severity,
+            message: trimmed.to_string(),
+        });
+    }
+
+    // Defensive fallback: validator exited non-zero with no output.
+    if warnings.is_empty() {
+        warnings.push(ProjectionWarning {
+            field: "external_validate".to_string(),
+            severity,
+            message: format!(
+                "`{label}` exited with status {} but produced no output",
+                output
+                    .status
+                    .code()
+                    .map_or_else(|| "unknown".to_string(), |c| c.to_string())
+            ),
+        });
+    }
+    warnings
+}
+
+/// Write `block` to a `NamedTempFile` as pretty-printed JSON so the
+/// validator's error line numbers line up with something a human can
+/// actually grep. The tempfile is returned so its `Drop` only fires
+/// after the caller has spawned and waited on the validator.
+fn write_tempfile(block: &Value) -> Result<NamedTempFile, std::io::Error> {
+    let mut tmp = NamedTempFile::with_suffix(".json")?;
+    let bytes = serde_json::to_vec_pretty(block).unwrap_or_else(|_| b"{}".to_vec());
+    tmp.write_all(&bytes)?;
+    tmp.flush()?;
+    Ok(tmp)
+}
+
+/// Substitute the literal `{file}` token in each arg with `path`. If
+/// no arg contains the token, append `path` as a final argument so
+/// validators that take "file as last positional" still work without
+/// explicit templating.
+fn resolve_args(args: &[String], path: &str) -> Vec<String> {
+    let has_token = args.iter().any(|a| a.contains("{file}"));
+    if has_token {
+        args.iter().map(|a| a.replace("{file}", path)).collect()
+    } else {
+        let mut out: Vec<String> = args.to_vec();
+        out.push(path.to_string());
+        out
+    }
+}
+
+/// Parse the configured severity string ("required" / "recommended"
+/// / "optional" / "info"), case-insensitive. Unknown or absent
+/// values default to `Recommended` — non-fatal but visible.
+fn parse_severity(raw: Option<&str>) -> Severity {
+    match raw.map(str::to_ascii_lowercase).as_deref() {
+        Some("required") => Severity::Required,
+        Some("optional") => Severity::Optional,
+        Some("info") => Severity::Info,
+        _ => Severity::Recommended,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::cmd::profile::profile_spec::load_from_str;
+
+    #[test]
+    fn no_external_config_returns_empty() {
+        let yaml = r#"
+name: t
+dataset:
+  type: dcat:Dataset
+validation:
+  enabled: false
+"#;
+        let profile = load_from_str(yaml, "t").unwrap();
+        assert!(validate(&profile, &json!({})).is_empty());
+    }
+
+    #[test]
+    fn missing_binary_yields_info_warning_not_failure() {
+        let yaml = r#"
+name: t
+dataset:
+  type: dcat:Dataset
+validation:
+  enabled: false
+  external:
+    command: "qsv-no-such-validator-binary-12345"
+    args: ["validate", "{file}"]
+"#;
+        let profile = load_from_str(yaml, "t").unwrap();
+        let warnings = validate(&profile, &json!({"@type": "dcat:Dataset"}));
+        assert_eq!(warnings.len(), 1);
+        assert!(matches!(warnings[0].severity, Severity::Info));
+        assert!(
+            warnings[0].message.contains("not installed"),
+            "graceful-skip warning must say so explicitly: got `{}`",
+            warnings[0].message
+        );
+    }
+
+    #[test]
+    fn missing_binary_warning_includes_install_hint() {
+        // The install_hint field surfaces in the missing-binary
+        // message so users see the install command at the moment
+        // they discover the validator is absent.
+        let yaml = r#"
+name: t
+dataset:
+  type: dcat:Dataset
+validation:
+  enabled: false
+  external:
+    command: "qsv-no-such-validator-binary-12345"
+    label: "mlcroissant"
+    args: ["validate"]
+    install_hint: "pip install mlcroissant (https://github.com/mlcommons/croissant)"
+"#;
+        let profile = load_from_str(yaml, "t").unwrap();
+        let warnings = validate(&profile, &json!({}));
+        assert_eq!(warnings.len(), 1);
+        assert!(matches!(warnings[0].severity, Severity::Info));
+        assert!(
+            warnings[0].message.contains("pip install mlcroissant"),
+            "install_hint must appear verbatim in the warning: got `{}`",
+            warnings[0].message
+        );
+        assert!(
+            warnings[0]
+                .message
+                .contains("github.com/mlcommons/croissant"),
+            "install_hint URL must reach the user: got `{}`",
+            warnings[0].message
+        );
+        assert!(
+            warnings[0].message.contains("Install:"),
+            "install hint must be prefixed so the user knows it's an action: got `{}`",
+            warnings[0].message
+        );
+    }
+
+    #[test]
+    fn label_overrides_command_in_message() {
+        let yaml = r#"
+name: t
+dataset:
+  type: dcat:Dataset
+validation:
+  enabled: false
+  external:
+    command: "qsv-no-such-validator-binary-12345"
+    label: "mlcroissant"
+    args: ["validate"]
+"#;
+        let profile = load_from_str(yaml, "t").unwrap();
+        let warnings = validate(&profile, &json!({}));
+        assert!(
+            warnings[0].message.starts_with("`mlcroissant`"),
+            "label must shadow command in user-facing message"
+        );
+    }
+
+    #[test]
+    fn successful_exit_yields_empty_findings() {
+        // `true` is a Unix builtin that exits 0 with no output —
+        // perfect stand-in for a validator that passes.
+        if !cfg!(unix) {
+            return;
+        }
+        let yaml = r#"
+name: t
+dataset:
+  type: dcat:Dataset
+validation:
+  enabled: false
+  external:
+    command: "true"
+    args: []
+"#;
+        let profile = load_from_str(yaml, "t").unwrap();
+        assert!(validate(&profile, &json!({})).is_empty());
+    }
+
+    #[test]
+    fn non_zero_exit_surfaces_one_warning_per_stderr_line() {
+        // `sh -c 'printf "first issue\nsecond issue\n" 1>&2; exit 1'`
+        // exits non-zero with two stderr lines, simulating a validator
+        // that found two findings.
+        if !cfg!(unix) {
+            return;
+        }
+        let yaml = r#"
+name: t
+dataset:
+  type: dcat:Dataset
+validation:
+  enabled: false
+  external:
+    command: "sh"
+    args:
+      - "-c"
+      - 'printf "first issue\nsecond issue\n" 1>&2; exit 1'
+    default_severity: "required"
+    label: "fake-validator"
+"#;
+        let profile = load_from_str(yaml, "t").unwrap();
+        let warnings = validate(&profile, &json!({}));
+        assert_eq!(warnings.len(), 2);
+        assert!(matches!(warnings[0].severity, Severity::Required));
+        assert_eq!(warnings[0].message, "first issue");
+        assert_eq!(warnings[1].message, "second issue");
+        assert_eq!(warnings[0].field, "external_validate/fake-validator");
+    }
+
+    #[test]
+    fn falls_back_to_stdout_when_stderr_empty() {
+        // Some validators log on stdout. When stderr is empty AND
+        // exit is non-zero, stdout becomes the finding source.
+        if !cfg!(unix) {
+            return;
+        }
+        let yaml = r#"
+name: t
+dataset:
+  type: dcat:Dataset
+validation:
+  enabled: false
+  external:
+    command: "sh"
+    args: ["-c", 'echo stdout-finding; exit 2']
+"#;
+        let profile = load_from_str(yaml, "t").unwrap();
+        let warnings = validate(&profile, &json!({}));
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].message, "stdout-finding");
+    }
+
+    #[test]
+    fn non_zero_exit_with_no_output_yields_one_diagnostic() {
+        if !cfg!(unix) {
+            return;
+        }
+        let yaml = r#"
+name: t
+dataset:
+  type: dcat:Dataset
+validation:
+  enabled: false
+  external:
+    command: "sh"
+    args: ["-c", "exit 3"]
+"#;
+        let profile = load_from_str(yaml, "t").unwrap();
+        let warnings = validate(&profile, &json!({}));
+        assert_eq!(warnings.len(), 1);
+        assert!(
+            warnings[0].message.contains("exited with status 3"),
+            "diagnostic must include the exit code"
+        );
+    }
+
+    #[test]
+    fn args_substitute_file_token() {
+        // The {file} token must be replaced with the tempfile path.
+        // Echo the substituted arg on stdout so we can verify.
+        if !cfg!(unix) {
+            return;
+        }
+        let yaml = r#"
+name: t
+dataset:
+  type: dcat:Dataset
+validation:
+  enabled: false
+  external:
+    command: "sh"
+    args:
+      - "-c"
+      - 'echo "got: $1"; test -s "$1" && echo "nonempty"; exit 1'
+      - "_"
+      - "{file}"
+"#;
+        let profile = load_from_str(yaml, "t").unwrap();
+        let warnings = validate(&profile, &json!({"@type": "dcat:Dataset"}));
+        // First stdout line carries the substituted path.
+        assert!(
+            warnings.iter().any(|w| w.message.starts_with("got: /")),
+            "{{file}} substitution must place the tempfile path in arg slot"
+        );
+        // Second confirms the file is non-empty (block was serialized).
+        assert!(
+            warnings.iter().any(|w| w.message == "nonempty"),
+            "tempfile must contain the serialized JSON-LD"
+        );
+    }
+
+    #[test]
+    fn args_without_token_get_file_appended() {
+        if !cfg!(unix) {
+            return;
+        }
+        let yaml = r#"
+name: t
+dataset:
+  type: dcat:Dataset
+validation:
+  enabled: false
+  external:
+    command: "sh"
+    args: ["-c", 'echo "last arg: $1"; exit 1', "_"]
+"#;
+        let profile = load_from_str(yaml, "t").unwrap();
+        let warnings = validate(&profile, &json!({}));
+        // The tempfile path was appended as the final positional arg
+        // after "_", and `$1` (counting from the script's first arg
+        // after `-c <script>`) prints it.
+        assert!(
+            warnings[0].message.starts_with("last arg: /"),
+            "missing {{file}} token must append path as last arg"
+        );
+    }
+
+    #[test]
+    fn parse_severity_handles_known_levels() {
+        assert!(matches!(
+            parse_severity(Some("required")),
+            Severity::Required
+        ));
+        assert!(matches!(
+            parse_severity(Some("RECOMMENDED")),
+            Severity::Recommended
+        ));
+        assert!(matches!(
+            parse_severity(Some("Optional")),
+            Severity::Optional
+        ));
+        assert!(matches!(parse_severity(Some("info")), Severity::Info));
+        // Unknown / absent default to Recommended.
+        assert!(matches!(parse_severity(None), Severity::Recommended));
+        assert!(matches!(
+            parse_severity(Some("bogus")),
+            Severity::Recommended
+        ));
+    }
+
+    #[test]
+    fn resolve_args_substitutes_token_when_present() {
+        let args = vec![
+            "validate".to_string(),
+            "--input".to_string(),
+            "{file}".to_string(),
+        ];
+        let out = resolve_args(&args, "/tmp/x.json");
+        assert_eq!(out, vec!["validate", "--input", "/tmp/x.json"]);
+    }
+
+    #[test]
+    fn resolve_args_appends_when_token_absent() {
+        let args = vec!["validate".to_string(), "--strict".to_string()];
+        let out = resolve_args(&args, "/tmp/x.json");
+        assert_eq!(out, vec!["validate", "--strict", "/tmp/x.json"]);
+    }
+}

--- a/src/cmd/profile/profile_spec.rs
+++ b/src/cmd/profile/profile_spec.rs
@@ -136,6 +136,15 @@ pub struct ProfileSpec {
     /// profiles can round-trip vendor extensions.
     #[serde(flatten)]
     pub extras: Map<String, Value>,
+
+    /// Where this profile was loaded from. NOT deserialized — set
+    /// by `load()` after parsing. Direct `load_from_str` callers
+    /// (tests, in-memory construction) get the `Embedded` default
+    /// so unit tests don't trip the orchestrator's untrusted-source
+    /// gate; real CLI usage always goes through `load()`, which
+    /// overrides this with the resolved source.
+    #[serde(skip)]
+    pub source: ProfileSource,
 }
 
 // -----------------------------------------------------------------------
@@ -332,6 +341,34 @@ pub enum RequiredLevel {
     Optional,
 }
 
+/// Tag identifying where the profile was loaded from. Set by
+/// `load()`; used by the orchestrator to gate trust-sensitive
+/// features (e.g. spawning external validators).
+///
+/// The `Embedded` default is for tests / direct `load_from_str`
+/// callers that bypass `load()`. Real CLI invocations always go
+/// through `load()`, which sets the source explicitly.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ProfileSource {
+    /// Bundled with the qsv binary (`EMBEDDED` table). Trusted at
+    /// build time; safe to spawn declared validators without an
+    /// explicit per-invocation opt-in.
+    #[default]
+    Embedded,
+    /// Loaded from a YAML file on disk. Treated as untrusted: the
+    /// orchestrator requires an explicit CLI opt-in
+    /// (`--allow-external-validator`) before spawning any binary
+    /// the file declares.
+    FilePath,
+}
+
+impl ProfileSource {
+    /// True when the profile shipped with the qsv binary.
+    pub fn is_embedded(self) -> bool {
+        matches!(self, Self::Embedded)
+    }
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[allow(dead_code)]
 pub struct DiscoveryMerge {
@@ -458,27 +495,29 @@ pub struct RecordSetSpec {
 /// Returns a `CliError::Other` with a helpful list of bundled names when
 /// neither lookup succeeds.
 ///
-/// The returned profile is also `dry_compile`-validated — every
-/// template inside the profile is parsed by minijinja so a malformed
-/// embedded YAML (or a user-supplied file with a typo) fails at
-/// `load` time rather than mid-projection. This matches the doc
-/// claim on the `EMBEDDED` constant. Tests + low-level call sites
-/// that want raw parsing without compilation can still use
-/// `load_from_str` directly.
+/// The returned profile is `dry_compile`-validated (every template
+/// is parsed by minijinja so a malformed YAML fails here rather
+/// than mid-projection) and has its `source` field stamped with
+/// the resolution path — `Embedded` for bundled profiles, `FilePath`
+/// for on-disk YAML. The orchestrator reads `source` to gate
+/// trust-sensitive features such as external validator spawn.
+/// Tests + low-level callers that want raw parsing without
+/// compilation can still use `load_from_str` directly (those keep
+/// the `Embedded` default).
 pub fn load(arg: &str) -> CliResult<ProfileSpec> {
     let needle = arg.to_ascii_lowercase();
-    let profile = if let Some((_, raw)) = EMBEDDED
+    let (mut profile, source) = if let Some((_, raw)) = EMBEDDED
         .iter()
         .find(|(n, _)| n.eq_ignore_ascii_case(&needle))
     {
-        load_from_str(raw, arg)?
+        (load_from_str(raw, arg)?, ProfileSource::Embedded)
     } else {
         let path = std::path::Path::new(arg);
         if path.is_file() {
             let raw = std::fs::read_to_string(path).map_err(|e| {
                 CliError::Other(format!("could not read --profile file `{arg}`: {e}"))
             })?;
-            load_from_str(&raw, arg)?
+            (load_from_str(&raw, arg)?, ProfileSource::FilePath)
         } else {
             return Err(CliError::Other(format!(
                 "unknown --profile `{arg}`; embedded profiles: [{}]. To use a file path, point at \
@@ -487,6 +526,7 @@ pub fn load(arg: &str) -> CliResult<ProfileSpec> {
             )));
         }
     };
+    profile.source = source;
     // Validate every template at load time — malformed profiles
     // surface here, not deep inside a render. Errors are wrapped to
     // include the profile name + label.

--- a/src/cmd/profile/profile_spec.rs
+++ b/src/cmd/profile/profile_spec.rs
@@ -168,6 +168,57 @@ pub struct Validation {
     /// `STRIPPABLE_PREFIXES` const.
     #[serde(default)]
     pub strippable_curie_prefixes: Vec<String>,
+    /// Optional out-of-process validator (e.g. `mlcroissant`,
+    /// `pyshacl`). Runs orthogonal to the built-in JSON-Schema
+    /// validator gated by `enabled`: a profile may set
+    /// `enabled: false` (no JSON Schema) but still configure
+    /// `external` for vocabulary-specific validation. When the
+    /// configured `command` isn't on `PATH`, validation degrades
+    /// gracefully to a single `Severity::Info` warning rather than
+    /// failing the projection.
+    #[serde(default)]
+    pub external:                  Option<ExternalValidator>,
+}
+
+/// Out-of-process validator config. The command is spawned with the
+/// rendered JSON-LD written to a tempfile; the file path is
+/// substituted for the literal `{file}` token in `args`, or appended
+/// as the last argument when no `{file}` token is present.
+///
+/// A non-zero exit code is treated as "validation failed" — each
+/// non-empty stderr line becomes one `ProjectionWarning` with
+/// severity `default_severity`. Exit code zero is treated as
+/// success regardless of stdout/stderr content.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[allow(dead_code)]
+pub struct ExternalValidator {
+    /// Command to spawn. Resolved via `PATH`. When the command
+    /// isn't found, validation emits a single `Info`-severity
+    /// warning ("`<command>` not installed; skipped validation")
+    /// rather than failing — keeps profiles that rely on an
+    /// optional Python tool usable in plain-Rust environments.
+    pub command:          String,
+    /// Arguments. The literal token `{file}` is replaced with the
+    /// tempfile path holding the rendered JSON-LD. When no `{file}`
+    /// token is present, the path is appended as the last argument.
+    #[serde(default)]
+    pub args:             Vec<String>,
+    /// Severity assigned to each surfaced finding. One of
+    /// `"required"`, `"recommended"` (default), `"optional"`,
+    /// `"info"`. Case-insensitive.
+    #[serde(default)]
+    pub default_severity: Option<String>,
+    /// Optional label used in warning messages instead of the raw
+    /// command name. Lets a profile show "mlcroissant" even when
+    /// the command is actually `python3 -m mlcroissant ...`.
+    #[serde(default)]
+    pub label:            Option<String>,
+    /// Optional install hint appended to the missing-binary
+    /// warning. Free-form text — typically a short install
+    /// command and/or a URL pointing at the validator's homepage.
+    /// E.g. "pip install mlcroissant (https://github.com/mlcommons/croissant)".
+    #[serde(default)]
+    pub install_hint:     Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -530,9 +581,18 @@ dataset:
         let spec = load("croissant").expect("embedded load");
         assert_eq!(spec.name, "croissant");
         // Croissant relies on the mlcommons Python validator; built-in
-        // validator + discovery merge are both disabled.
+        // JSON-Schema validator + discovery merge are both disabled.
         assert!(!spec.validation.enabled);
         assert!(!spec.discovery_merge.enabled);
+        // External validator is configured (mlcroissant).
+        let external = spec
+            .validation
+            .external
+            .as_ref()
+            .expect("croissant should declare external validator");
+        assert_eq!(external.command, "mlcroissant");
+        assert!(external.args.iter().any(|a| a == "validate"));
+        assert!(external.args.iter().any(|a| a.contains("{file}")));
         assert!(!spec.dataset.fields.is_empty());
         assert!(spec.distribution.is_some());
         assert!(spec.catalog.is_some());

--- a/tests/test_profile.rs
+++ b/tests/test_profile.rs
@@ -2117,3 +2117,221 @@ fn dcat_us_v3_bundle_pin_manifest_matches_files() {
         );
     }
 }
+
+// =========================================================================
+// External validator trust gate (Roborev #2509)
+// =========================================================================
+// The `validation.external` block can spawn arbitrary commands. Bundled
+// profiles are vetted at qsv release time and run frictionlessly; file-
+// loaded profiles must opt in via `--allow-external-validator`. These
+// tests lock in the gate so a future refactor can't silently regress
+// the security boundary.
+
+/// Write a minimal profile YAML to the workdir that declares a
+/// stderr-emitting `validation.external` command (so we can both
+/// confirm the spawn happened and see the parsed finding). Returns
+/// the path the test should pass via `--profile`.
+fn write_external_validator_profile(wrk: &Workdir, label: &str) -> std::path::PathBuf {
+    // sh -c '...; exit 1' is portable on macOS and Linux CI runners.
+    // The findings include a recognizable marker string so the test
+    // can verify the validator actually ran.
+    let yaml = format!(
+        r#"name: ext-gate-test
+dataset:
+  type: dcat:Dataset
+  fields:
+    - path: dct:title
+      template: "{{{{ pkg.title | default('Untitled') }}}}"
+validation:
+  enabled: false
+  external:
+    command: "sh"
+    args: ["-c", "echo SPAWNED-{label} 1>&2; exit 1"]
+    label: "{label}"
+    default_severity: "recommended"
+"#
+    );
+    let path = wrk.path("ext-gate.yaml");
+    std::fs::write(&path, yaml).expect("write ext-gate.yaml");
+    path
+}
+
+#[cfg(unix)]
+#[test]
+fn external_validator_gated_for_file_loaded_profile_without_flag() {
+    let wrk = Workdir::new("ext_gate_file_no_flag");
+    let src = std::env::current_dir()
+        .unwrap()
+        .join("tests/resources/profile/golden/nyc-311-subset.csv");
+    std::fs::copy(&src, wrk.path("in.csv")).expect("copy fixture");
+    let yaml_path = write_external_validator_profile(&wrk, "fake-validator");
+
+    let mut cmd = wrk.command("profile");
+    cmd.args([
+        "in.csv",
+        "--profile",
+        yaml_path.to_str().unwrap(),
+        "--validate-dcat",
+        "-o",
+        "out.json",
+    ]);
+    wrk.assert_success(&mut cmd);
+
+    let out = read_output(&wrk, "out.json");
+    let warnings = out
+        .get("dcat_warnings")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    // The gate warning must be present.
+    let gate_warning = warnings.iter().find(|w| {
+        w.get("field").and_then(|v| v.as_str()) == Some("external_validate")
+            && w.get("message").and_then(|v| v.as_str()).is_some_and(|m| {
+                m.contains("was NOT run") && m.contains("--allow-external-validator")
+            })
+    });
+    assert!(
+        gate_warning.is_some(),
+        "file-loaded profile must emit the gate warning explaining the opt-in; got warnings: \
+         {warnings:#?}"
+    );
+
+    // The validator must NOT have spawned — no SPAWNED- marker anywhere.
+    let any_spawn_evidence = warnings.iter().any(|w| {
+        w.get("message")
+            .and_then(|v| v.as_str())
+            .is_some_and(|m| m.contains("SPAWNED-"))
+    });
+    assert!(
+        !any_spawn_evidence,
+        "validator command must NOT have been spawned without --allow-external-validator; got \
+         warnings: {warnings:#?}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn external_validator_runs_for_file_loaded_profile_with_flag() {
+    let wrk = Workdir::new("ext_gate_file_with_flag");
+    let src = std::env::current_dir()
+        .unwrap()
+        .join("tests/resources/profile/golden/nyc-311-subset.csv");
+    std::fs::copy(&src, wrk.path("in.csv")).expect("copy fixture");
+    let yaml_path = write_external_validator_profile(&wrk, "fake-validator");
+
+    let mut cmd = wrk.command("profile");
+    cmd.args([
+        "in.csv",
+        "--profile",
+        yaml_path.to_str().unwrap(),
+        "--validate-dcat",
+        "--allow-external-validator",
+        "-o",
+        "out.json",
+    ]);
+    wrk.assert_success(&mut cmd);
+
+    let out = read_output(&wrk, "out.json");
+    let warnings = out
+        .get("dcat_warnings")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    // The gate warning must NOT be present.
+    let any_gate_warning = warnings.iter().any(|w| {
+        w.get("message")
+            .and_then(|v| v.as_str())
+            .is_some_and(|m| m.contains("was NOT run") && m.contains("--allow-external-validator"))
+    });
+    assert!(
+        !any_gate_warning,
+        "opt-in flag must skip the gate warning; got warnings: {warnings:#?}"
+    );
+
+    // Validator output must surface with the `<label>: <line>` format
+    // and the stable `external_validate` field.
+    let finding = warnings.iter().find(|w| {
+        w.get("field").and_then(|v| v.as_str()) == Some("external_validate")
+            && w.get("message")
+                .and_then(|v| v.as_str())
+                .is_some_and(|m| m == "fake-validator: SPAWNED-fake-validator")
+    });
+    assert!(
+        finding.is_some(),
+        "validator must have spawned and produced a finding; got warnings: {warnings:#?}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn external_validator_strict_dcat_fails_on_file_loaded_findings() {
+    // With --strict-dcat AND --allow-external-validator, non-Info
+    // findings (Recommended/Required) from an external validator
+    // must fail the command the same way schema violations do.
+    let wrk = Workdir::new("ext_gate_strict");
+    let src = std::env::current_dir()
+        .unwrap()
+        .join("tests/resources/profile/golden/nyc-311-subset.csv");
+    std::fs::copy(&src, wrk.path("in.csv")).expect("copy fixture");
+    let yaml_path = write_external_validator_profile(&wrk, "fake-validator");
+
+    let mut cmd = wrk.command("profile");
+    cmd.args([
+        "in.csv",
+        "--profile",
+        yaml_path.to_str().unwrap(),
+        "--validate-dcat",
+        "--allow-external-validator",
+        "--strict-dcat",
+        "-o",
+        "out.json",
+    ]);
+    let got_err = wrk.output_stderr(&mut cmd);
+    assert!(
+        got_err.contains("external validator finding"),
+        "strict mode must surface the external validator failure: got `{got_err}`"
+    );
+}
+
+#[test]
+fn external_validator_embedded_profile_skips_gate_warning() {
+    // Embedded profiles (Croissant ships `validation.external` for
+    // mlcroissant) MUST NOT emit the file-loaded gate warning. The
+    // mlcroissant binary itself may or may not be installed on CI;
+    // either outcome is acceptable here — we're locking in that the
+    // gate doesn't accidentally apply to vetted bundled profiles.
+    let wrk = Workdir::new("ext_gate_embedded");
+    let src = std::env::current_dir()
+        .unwrap()
+        .join("tests/resources/profile/golden/nyc-311-subset.csv");
+    std::fs::copy(&src, wrk.path("in.csv")).expect("copy fixture");
+
+    let mut cmd = wrk.command("profile");
+    cmd.args([
+        "in.csv",
+        "--profile",
+        "croissant",
+        "--validate-dcat",
+        "-o",
+        "out.json",
+    ]);
+    wrk.assert_success(&mut cmd);
+
+    let out = read_output(&wrk, "out.json");
+    let warnings = out
+        .get("dcat_warnings")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let gate_warning_present = warnings.iter().any(|w| {
+        w.get("message")
+            .and_then(|v| v.as_str())
+            .is_some_and(|m| m.contains("was NOT run") && m.contains("--allow-external-validator"))
+    });
+    assert!(
+        !gate_warning_present,
+        "embedded profile must not trip the file-loaded gate; got warnings: {warnings:#?}"
+    );
+}


### PR DESCRIPTION
## Summary
The Croissant 1.0 spec ships no JSON Schema — its canonical validator is the `mlcroissant` Python package. Until now `resources/profiles/croissant.yaml` had `validation.enabled: false` because the engine had no way to run anything but the bundled GSA JSON Schema validator.

This PR adds a generic out-of-process validator path so any profile can declare a `validation.external` block pointing at a binary on PATH, wires Croissant up to `mlcroissant` by default, and sets the same pattern up for a future DCAT-AP SHACL backend (pyshacl) with no further engine work.

**Engine**
- New `ExternalValidator` struct on `Validation`: `command`, `args` (with `{file}` token substitution), `default_severity`, `label`, `install_hint`. Independent of `Validation::enabled` (JSON Schema gate) — both can coexist.
- New `src/cmd/profile/external_validate.rs` (~300 LOC + 13 tests): writes block to a `.json` tempfile, spawns the configured command, captures stderr/stdout. Missing binary → single `Severity::Info` warning including the configured `install_hint` so users see the install path at the moment they need it. Non-zero exit → one warning per non-empty stderr line (stdout fallback when stderr empty). Exit 0 → empty Vec.
- Orchestrator (`src/cmd/profile.rs`) wires external validation next to `dcat_validate::validate` under `--validate-dcat`. Strict mode filters out `Info`-severity findings — only actual violations can trip `--strict-dcat`, never missing-binary notices.

**Profile YAML**
- `resources/profiles/croissant.yaml` opts in with `command: mlcroissant`, `args: [validate, --jsonld, {file}]`, and an `install_hint` carrying the pip command + project URL.

**End-to-end verified.** On a system without `mlcroissant` installed:

```text
$ qsv profile <input> --profile croissant --validate-dcat -o out.json
$ jq '.dcat_warnings[] | select(.field=="external_validate")' out.json
{
  "field": "external_validate",
  "severity": "info",
  "message": "\`mlcroissant\` not installed; skipped croissant validation. Install: pip install mlcroissant (https://github.com/mlcommons/croissant/tree/main/python/mlcroissant)"
}
```

## Test plan
- [x] `cargo test --bin qsv -F profile,feature_capable cmd::profile::` — **154 unit tests pass** (13 new in `external_validate::tests`)
- [x] `cargo test --test tests -F profile,feature_capable -- test_profile::` — **49 integration tests pass**, no regressions in `dcat_us_v3_golden_parity_*`
- [x] All 4 binaries build clean: `qsv` (-F all_features), `qsvmcp` (-F qsvmcp), `qsvlite` (-F lite), `qsvdp` (-F datapusher_plus)
- [x] `cargo clippy --bin qsv -F profile,feature_capable` — no new warnings
- [x] `cargo +nightly fmt` applied
- [x] `python3 scripts/docs-drift-check.py` — no drift
- [x] `resources/profiles/README.md` updated with new "Validation" section + `external` config table + Croissant example
- [x] Smoke test on `tests/resources/profile/golden/nyc-311-subset.csv` confirms install hint surfaces with `--validate-dcat` when binary is absent

## Notes
The same `external_validate` module is ready to host a `pyshacl` config for DCAT-AP v3 in a follow-up PR — no further engine work needed, just YAML wiring + a small `install_hint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)