### PR TITLE
chore(profile): sweep pre-existing clippy warnings

### DIFF
--- a/src/cmd/profile.rs
+++ b/src/cmd/profile.rs
@@ -528,8 +528,9 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             // honors schema violations — once you've opted in to
             // validation, all findings escalate.
             let allow_external = profile.source.is_embedded() || args.flag_allow_external_validator;
-            if profile.validation.external.is_some() && !allow_external {
-                let cfg = profile.validation.external.as_ref().unwrap();
+            if let Some(cfg) = profile.validation.external.as_ref()
+                && !allow_external
+            {
                 let label = cfg.label.as_deref().unwrap_or(cfg.command.as_str());
                 dcat_warnings.push(projection::ProjectionWarning {
                     field:    "external_validate".to_string(),
@@ -927,6 +928,7 @@ fn url_title_default(url: &str) -> Option<String> {
 ///   * canonical RFC 4122 form: 8-4-4-4-12 hex with dashes (e.g.
 ///     `5202679a-d243-402e-b82a-63189995a942`);
 ///   * compact form: 32 contiguous hex characters (e.g. `5202679ad243402eb82a63189995a942`).
+///
 /// Case-insensitive. Other ID-like patterns (MongoDB ObjectId at 24
 /// hex, ULIDs, slugified IDs) are intentionally NOT matched — UUIDs
 /// dominate CKAN/data.gov URLs, and over-eager matching would walk
@@ -935,6 +937,11 @@ fn is_uuid_like(s: &str) -> bool {
     let bytes = s.as_bytes();
     if bytes.len() == 36 {
         // Canonical: 8-4-4-4-12 with dashes at fixed positions.
+        // Explicit length assert (already implied by the outer
+        // `len() == 36` check) lets the compiler elide bounds
+        // checks on the byte indexes below and satisfies
+        // `clippy::missing_asserts_for_indexing`.
+        assert!(bytes.len() > 23);
         if bytes[8] != b'-' || bytes[13] != b'-' || bytes[18] != b'-' || bytes[23] != b'-' {
             return false;
         }
@@ -1004,14 +1011,6 @@ fn apply_force_overrides(root: &mut Value, forced_values: &[(String, Value)]) {
         }
         set_by_pointer(root, ptr, new_value.clone());
     }
-}
-
-/// Escape a single token for use inside a JSON Pointer per RFC 6901
-/// section 4 (`~` → `~0`, `/` → `~1`). The `~`-replacement MUST happen
-/// first; doing it after `/`→`~1` would double-escape the newly
-/// introduced `~`.
-fn escape_json_pointer_token(token: &str) -> String {
-    token.replace('~', "~0").replace('/', "~1")
 }
 
 /// Returns true when the final dcat block carries a non-null,
@@ -1182,25 +1181,10 @@ mod tests {
     // unit tests plus the new integration tests in tests/test_profile.rs
     // (Roborev PR-#3908 Copilot finding).
 
-    use super::escape_json_pointer_token;
-
-    #[test]
-    fn escape_json_pointer_token_matches_rfc6901() {
-        // RFC 6901 section 4: ~ → ~0, / → ~1. Order matters: ~ must be
-        // escaped first to avoid double-escaping the ~ introduced by /.
-        assert_eq!(escape_json_pointer_token(""), "");
-        assert_eq!(escape_json_pointer_token("plain"), "plain");
-        assert_eq!(escape_json_pointer_token("a/b"), "a~1b");
-        assert_eq!(escape_json_pointer_token("a~b"), "a~0b");
-        // The ordering trap: input "a~/b" must become "a~0~1b", NOT
-        // "a~01b" (which would be the result of the wrong order).
-        assert_eq!(escape_json_pointer_token("a~/b"), "a~0~1b");
-        // Full IRI: each `/` → `~1`, `:` is unescaped.
-        assert_eq!(
-            escape_json_pointer_token("http://purl.org/dc/terms/title"),
-            "http:~1~1purl.org~1dc~1terms~1title",
-        );
-    }
+    // RFC 6901 escape coverage lives in
+    // `discovery_merge::tests::escape_token_handles_rfc6901_round_trip`;
+    // profile.rs's own escape helper was deleted (PR follow-up
+    // sweep) since it had no non-test callers.
 
     use super::tempfile_suffix_for_url;
 

--- a/src/cmd/profile/projection.rs
+++ b/src/cmd/profile/projection.rs
@@ -28,12 +28,20 @@ use crate::{CliError, CliResult};
 
 /// Which top-level shape the engine assembles.
 ///
-/// `Dataset` produces the bare Dataset block (default); `Catalog` wraps
-/// the Dataset inside the profile's `catalog:` envelope (used by
-/// `--catalog`).
+/// `Dataset` produces the bare Dataset block (default); `Catalog`
+/// wraps the Dataset inside the profile's `catalog:` envelope. At
+/// the binary level today only `Dataset` is constructed — the
+/// orchestrator calls `wrap_in_catalog_envelope` after
+/// `discovery_merge` for `--catalog` mode so discovered metadata
+/// lands on the inner Dataset, not the outer envelope (Roborev
+/// #2490 finding #1). `Catalog` remains in the API so `project`
+/// stays usable by tests and downstream callers that want the
+/// pre-merge wrap; without `#[allow(dead_code)]` the variant
+/// would trip the never-constructed lint in non-test builds.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProjectionMode {
     Dataset,
+    #[allow(dead_code)]
     Catalog,
 }
 
@@ -437,12 +445,11 @@ fn render_truthy(env: &Environment, ctx: &minijinja::Value, src: &str) -> bool {
 /// parsed as JSON; anything else is taken as a literal string.
 pub fn coerce_json_or_string(rendered: &str) -> Value {
     let trimmed = rendered.trim();
-    if (trimmed.starts_with('{') && trimmed.ends_with('}'))
-        || (trimmed.starts_with('[') && trimmed.ends_with(']'))
+    if ((trimmed.starts_with('{') && trimmed.ends_with('}'))
+        || (trimmed.starts_with('[') && trimmed.ends_with(']')))
+        && let Ok(v) = serde_json::from_str::<Value>(trimmed)
     {
-        if let Ok(v) = serde_json::from_str::<Value>(trimmed) {
-            return v;
-        }
+        return v;
     }
     Value::String(rendered.to_string())
 }


### PR DESCRIPTION
## Summary
Nine clippy warnings have been visible in every `cargo +nightly clippy -F all_features` run since the YAML projection engine landed. None affect behavior, but they crowd the lint output and make new findings harder to spot. This sweep clears all nine in two files (net −9 LOC).

| # | Warning | Fix |
|---|---|---|
| 1 | `escape_json_pointer_token` never used | Deleted the helper and its self-referential test (RFC 6901 escape coverage lives in `discovery_merge::tests`). |
| 2 | `ProjectionMode::Catalog` never constructed | `#[allow(dead_code)]` on the variant with explanatory doc — orchestrator uses `wrap_in_catalog_envelope` (post-merge wrap, Roborev #2490 finding #1); only tests construct `Catalog` directly. |
| 3 | `collapsible_if` in `coerce_json_or_string` | Rust 2024 let-chain collapse: `if (...) && let Ok(v) = ...`. |
| 4 | `unnecessary_unwrap` on `profile.validation.external` | Refactored the trust-gate orchestrator path (introduced in #3911) from `is_some() && ... .unwrap()` to `if let Some(cfg) = ... && !allow_external` via let-chain. |
| 5 | `missing_asserts_for_indexing` in `is_uuid_like` | Added `assert!(bytes.len() > 23)` before the fixed-offset byte index reads. The existing `len() == 36` guard already made the access safe; the assert documents the contract and lets the compiler elide bounds checks. |
| 6–9 | `doc_lazy_continuation` ×4 on `is_uuid_like` | Inserted a blank line between the list items and the descriptive paragraph below. |

## Test plan
- [x] `cargo +nightly clippy --bin qsv -F all_features -- -W clippy::perf` exits clean (the only remaining notice is "src/main.rs found in multiple build targets", a harmless Cargo workspace artifact from qsv/qsvmcp sharing main.rs).
- [x] `cargo test --bin qsv -F profile,feature_capable cmd::profile::` — **160 unit tests pass** (was 161; the orphan `escape_json_pointer_token_matches_rfc6901` test went with its helper).
- [x] `cargo test --test tests -F profile,feature_capable -- test_profile::` — **53 integration tests pass**.
- [x] `cargo +nightly fmt` applied.
- [x] `python3 scripts/docs-drift-check.py` — no drift.
- [x] All four binaries build clean (`qsv`, `qsvlite`, `qsvmcp`, `qsvdp`).

## Notes
Files don't overlap with the in-flight PR #3912 (DCAT-AP v3 SHACL validator), so these can land in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)