### PR TITLE
feat(help-md): render NOTE/WARNING/IMPORTANT as GitHub Alerts

### DIFF
--- a/docs/help/describegpt.md
+++ b/docs/help/describegpt.md
@@ -57,7 +57,8 @@ It was also tested with OpenAI, TogetherAI, OpenRouter and Google Gemini cloud p
 For Gemini, use the base URL "<https://generativelanguage.googleapis.com/v1beta/openai">.
 Local LLMs tested include Ollama, Jan and LM Studio.
 
-NOTE: LLMs are prone to inaccurate information being produced. Verify output results before using them.
+> [!NOTE]
+> LLMs are prone to inaccurate information being produced. Verify output results before using them.
 
 CACHING:  
 As LLM inferencing takes time and can be expensive, describegpt caches the LLM inferencing results

--- a/docs/help/diff.md
+++ b/docs/help/diff.md
@@ -13,8 +13,9 @@
 
 Find the difference between two CSVs with ludicrous speed.
 
-NOTE: diff does not support stdin. A file path is required for both arguments.
-Further, PRIMARY KEY VALUES MUST BE UNIQUE WITHIN EACH CSV.
+> [!NOTE]
+> diff does not support stdin. A file path is required for both arguments.
+> Further, PRIMARY KEY VALUES MUST BE UNIQUE WITHIN EACH CSV.
 
 To check if a CSV has unique primary key values, use `qsv extdedup`
 with the same key columns using the `--select` option:  

--- a/docs/help/foreach.md
+++ b/docs/help/foreach.md
@@ -13,13 +13,15 @@
 
 Execute a shell command once per record in a given CSV file.
 
-NOTE: Windows users are recommended to use Git Bash as their terminal when
-running this command. Download it from <https://git-scm.com/downloads>. When installing,
-be sure to select "Use Git from the Windows Command Prompt" to ensure that the
-necessary Unix tools are available in the terminal.
+> [!NOTE]
+> Windows users are recommended to use Git Bash as their terminal when
+> running this command. Download it from <https://git-scm.com/downloads>. When installing,
+> be sure to select "Use Git from the Windows Command Prompt" to ensure that the
+> necessary Unix tools are available in the terminal.
 
-WARNING: This command can be dangerous. Be careful when using it with
-untrusted input.
+> [!WARNING]
+> This command can be dangerous. Be careful when using it with
+> untrusted input.
 
 Or per @thadguidry: 😉
 Please ensure when using foreach to use trusted arguments, variables, scripts, etc.

--- a/docs/help/frequency.md
+++ b/docs/help/frequency.md
@@ -57,7 +57,8 @@ You can override this behavior by setting the QSV_FREQ_CHUNK_MEMORY_MB environme
 or any non-u64 value (e.g. -1 or "auto") for CPU-based chunking (1 chunk = num records/number of
 CPUs)), or by setting the --jobs option.
 
-NOTE: "Complete" Frequency Tables:  
+> [!NOTE]
+> "Complete" Frequency Tables:
 
 By default, ID columns will have an "<ALL UNIQUE>" value with count equal to
 rowcount and percentage set to 100 with a rank of 0. This is done by using the

--- a/docs/help/json.md
+++ b/docs/help/json.md
@@ -54,9 +54,9 @@ fruit,price,calories
 apple,2.5,95
 banana,3.0,105
 
-IMPORTANT:  
-The order of the columns in the CSV file will be the same as the order of the keys in the first JSON object.
-The order of the rows in the CSV file will be the same as the order of the objects in the JSON array.
+> [!IMPORTANT]
+> The order of the columns in the CSV file will be the same as the order of the keys in the first JSON object.
+> The order of the rows in the CSV file will be the same as the order of the objects in the JSON array.
 
 Additional keys not present in the first JSON object will be appended as additional columns in the
 output CSV in the order they appear.

--- a/docs/help/sniff.md
+++ b/docs/help/sniff.md
@@ -28,9 +28,10 @@ See <https://opensource.googleblog.com/2025/11/announcing-magika-10-now-faster-s
 When the `magika` feature is not enabled in a build (e.g., MUSL builds, qsvlite, qsvdp), it falls back
 to the file-format library which provides basic MIME type detection.
 
-NOTE: This command "sniffs" a CSV's schema by sampling the first n rows (default: 1000)
-of a file. Its inferences are sometimes wrong if the the file is too small to infer a pattern
-or if the CSV has unusual formatting - with atypical delimiters, quotes, etc.
+> [!NOTE]
+> This command "sniffs" a CSV's schema by sampling the first n rows (default: 1000)
+> of a file. Its inferences are sometimes wrong if the the file is too small to infer a pattern
+> or if the CSV has unusual formatting - with atypical delimiters, quotes, etc.
 
 In such cases, selectively use the --sample, --delimiter and --quote options to improve
 the accuracy of the sniffed schema.

--- a/docs/help/stats.md
+++ b/docs/help/stats.md
@@ -13,12 +13,14 @@
 
 Compute summary statistics & infers data types for each column in a CSV.
 
-> IMPORTANT: `stats` is heavily optimized for speed. It ASSUMES the CSV is well-formed & UTF-8 encoded.
+> [!IMPORTANT]
+> `stats` is heavily optimized for speed. It ASSUMES the CSV is well-formed & UTF-8 encoded.
 > This allows it to employ numerous performance optimizations (skip repetitive UTF-8 validation, skip
 > bounds checks, cache results, etc.) that may result in undefined behavior if the CSV is not well-formed.
 > All these optimizations are GUARANTEED to work with well-formed CSVs.
 > If you encounter problems generating stats, use `qsv validate` FIRST to confirm the CSV is valid.
 
+> [!NOTE]
 > For MAXIMUM PERFORMANCE, create an index for the CSV first with 'qsv index' to enable multithreading,
 > or set --cache-threshold option or set the QSV_AUTOINDEX_SIZE environment variable to automatically
 > create an index when the file size is greater than the specified size (in bytes).

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -1,15 +1,15 @@
 static USAGE: &str = r#"
 Compute summary statistics & infers data types for each column in a CSV.
 
-> IMPORTANT: `stats` is heavily optimized for speed. It ASSUMES the CSV is well-formed & UTF-8 encoded.
-> This allows it to employ numerous performance optimizations (skip repetitive UTF-8 validation, skip
-> bounds checks, cache results, etc.) that may result in undefined behavior if the CSV is not well-formed.
-> All these optimizations are GUARANTEED to work with well-formed CSVs.
-> If you encounter problems generating stats, use `qsv validate` FIRST to confirm the CSV is valid.
+IMPORTANT: `stats` is heavily optimized for speed. It ASSUMES the CSV is well-formed & UTF-8 encoded.
+This allows it to employ numerous performance optimizations (skip repetitive UTF-8 validation, skip
+bounds checks, cache results, etc.) that may result in undefined behavior if the CSV is not well-formed.
+All these optimizations are GUARANTEED to work with well-formed CSVs.
+If you encounter problems generating stats, use `qsv validate` FIRST to confirm the CSV is valid.
 
-> For MAXIMUM PERFORMANCE, create an index for the CSV first with 'qsv index' to enable multithreading,
-> or set --cache-threshold option or set the QSV_AUTOINDEX_SIZE environment variable to automatically
-> create an index when the file size is greater than the specified size (in bytes).
+NOTE: For MAXIMUM PERFORMANCE, create an index for the CSV first with 'qsv index' to enable multithreading,
+or set --cache-threshold option or set the QSV_AUTOINDEX_SIZE environment variable to automatically
+create an index when the file size is greater than the specified size (in bytes).
 
 Summary stats include sum, min/max/range, sort order/sortiness, min/max/sum/avg/stddev/variance/cv length,
 mean, standard error of the mean (SEM), geometric mean, harmonic mean, stddev, variance, coefficient of

--- a/src/help_markdown_gen.rs
+++ b/src/help_markdown_gen.rs
@@ -1050,6 +1050,24 @@ fn maybe_append_colon_break(md: &mut String, trimmed: &str) {
     }
 }
 
+/// If a trimmed line begins with a `NOTE:`, `WARNING:`, or `IMPORTANT:` marker,
+/// return the corresponding GitHub Alert keyword and the remaining text after
+/// the marker (trimmed). Used to render these admonitions as GitHub Alerts:
+/// <https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts>
+fn match_alert_marker(trimmed: &str) -> Option<(&'static str, &str)> {
+    const MARKERS: [(&str, &str); 3] = [
+        ("NOTE:", "NOTE"),
+        ("WARNING:", "WARNING"),
+        ("IMPORTANT:", "IMPORTANT"),
+    ];
+    for (marker, kind) in MARKERS {
+        if let Some(rest) = trimmed.strip_prefix(marker) {
+            return Some((kind, rest.trim()));
+        }
+    }
+    None
+}
+
 /// Format description lines into markdown
 fn format_description(lines: &[String]) -> String {
     let mut md = String::new();
@@ -1057,6 +1075,10 @@ fn format_description(lines: &[String]) -> String {
     let mut in_fenced_block = false;
     let mut prev_empty = false;
     let mut prev_was_heading = false;
+    // Whether we are currently inside a GitHub Alert blockquote (started by a
+    // NOTE:/WARNING:/IMPORTANT: marker). Continuation lines are emitted as
+    // blockquote lines until the next blank line closes the alert.
+    let mut in_alert = false;
 
     for (i, line) in lines.iter().enumerate() {
         let trimmed = line.trim();
@@ -1068,6 +1090,24 @@ fn format_description(lines: &[String]) -> String {
             &mut in_code_block,
             &mut in_fenced_block,
         ) {
+            prev_empty = false;
+            continue;
+        }
+
+        // Continuation of a GitHub Alert: keep absorbing non-empty lines as
+        // blockquote lines; a blank line ends the alert. This takes precedence
+        // over heading/code/list detection so the whole admonition stays in one
+        // blockquote.
+        if in_alert {
+            if trimmed.is_empty() {
+                in_alert = false;
+                md.push('\n');
+                prev_empty = true;
+                continue;
+            }
+            md.push_str("> ");
+            md.push_str(&linkify_bare_urls(trimmed));
+            md.push('\n');
             prev_empty = false;
             continue;
         }
@@ -1162,6 +1202,25 @@ fn format_description(lines: &[String]) -> String {
                 md.push('\n');
                 prev_empty = true;
             }
+            continue;
+        }
+
+        // GitHub Alert markers (NOTE:/WARNING:/IMPORTANT:) at the start of a
+        // line are rendered as GitHub Alerts. A blank line must precede the
+        // blockquote for it to render, so emit one if the previous output isn't
+        // already blank.
+        if let Some((kind, rest)) = match_alert_marker(trimmed) {
+            if !md.is_empty() && !prev_empty {
+                md.push('\n');
+            }
+            let _ = writeln!(md, "> [!{kind}]");
+            if !rest.is_empty() {
+                md.push_str("> ");
+                md.push_str(&linkify_bare_urls(rest));
+                md.push('\n');
+            }
+            in_alert = true;
+            prev_empty = false;
             continue;
         }
 
@@ -2511,6 +2570,50 @@ mod tests {
         assert!(
             md.contains("> First comment\n> Second comment\n\n"),
             "Consecutive comments should be in one blockquote, got:\n{md}"
+        );
+    }
+
+    #[test]
+    fn test_format_description_note_marker_becomes_github_alert() {
+        // A NOTE: marker at the start of a line becomes a GitHub Alert, with
+        // continuation lines absorbed into the blockquote until a blank line.
+        let input = lines(&[
+            "Find the difference between two CSVs.",
+            "",
+            "NOTE: diff does not support stdin.",
+            "      Keys must be unique within each CSV.",
+            "",
+            "Following prose.",
+        ]);
+        let md = format_description(&input);
+        assert!(
+            md.contains(
+                "> [!NOTE]\n> diff does not support stdin.\n> Keys must be unique within each \
+                 CSV.\n\nFollowing prose."
+            ),
+            "NOTE: marker should become a GitHub Alert, got:\n{md}"
+        );
+    }
+
+    #[test]
+    fn test_format_description_marker_only_line_alert() {
+        // A bare `IMPORTANT:` line (no trailing text) still opens the alert and
+        // absorbs the following lines.
+        let input = lines(&["IMPORTANT:", "Column order is preserved.", "", "After."]);
+        let md = format_description(&input);
+        assert!(
+            md.contains("> [!IMPORTANT]\n> Column order is preserved.\n\nAfter."),
+            "bare IMPORTANT: line should open an alert, got:\n{md}"
+        );
+    }
+
+    #[test]
+    fn test_format_description_warning_marker_alert() {
+        let input = lines(&["WARNING: This command can be dangerous.", "", "More text."]);
+        let md = format_description(&input);
+        assert!(
+            md.contains("> [!WARNING]\n> This command can be dangerous.\n\nMore text."),
+            "WARNING: marker should become a GitHub Alert, got:\n{md}"
         );
     }
 


### PR DESCRIPTION
## What

When generating Markdown help via `qsv --generate-help-md`, lines in a command's **description** that start with `NOTE:`, `WARNING:`, or `IMPORTANT:` are now rendered as [GitHub Alerts](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-syntax#alerts):

- `NOTE:` → `> [!NOTE]`
- `WARNING:` → `> [!WARNING]`
- `IMPORTANT:` → `> [!IMPORTANT]`

### Before
```
NOTE: diff does not support stdin. A file path is required for both arguments.
      Further, PRIMARY KEY VALUES MUST BE UNIQUE WITHIN EACH CSV.
```

### After
> [!NOTE]
> diff does not support stdin. A file path is required for both arguments.
> Further, PRIMARY KEY VALUES MUST BE UNIQUE WITHIN EACH CSV.

## How

- Add `match_alert_marker()` mapping a line-start marker to its alert keyword.
- `format_description()` opens an alert blockquote on a marker, ensures a preceding blank line (required for GitHub to render the alert), and absorbs indented continuation lines until a blank line closes the block.

## Scope / safety

- **Option help text** markers (rendered inside Markdown table cells, where blockquotes aren't valid) are left inline — untouched.
- Markers inside **code/fenced blocks** are left untouched.
- `stats.rs`: converted hand-rolled `>` blockquotes into real `IMPORTANT:`/`NOTE:` markers so they now render as proper alerts.

## Generated docs

Regenerated `docs/help/` via `qsv --generate-help-md` — affected: `describegpt`, `diff`, `foreach`, `frequency`, `json`, `sniff`, `stats`.

## Tests

Added unit tests covering marker→alert conversion, bare-marker-only lines, and multi-line continuation. `cargo test help_markdown -F all_features` passes (30 tests); clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)