### PR TITLE
docs(help): add per-command Wiki "See also" links to command usage text

### DIFF
--- a/docs/help/apply.md
+++ b/docs/help/apply.md
@@ -316,6 +316,7 @@ qsv apply calcconv --formatstr '{col1} Billion Trillion * {col2} quadrillion vig
 
 For more examples, see [tests](https://github.com/dathere/qsv/blob/master/tests/test_apply.rs).
 
+See also <https://github.com/dathere/qsv/wiki/Transform-and-Reshape#apply>
 
 <a name="usage"></a>
 

--- a/docs/help/applydp.md
+++ b/docs/help/applydp.md
@@ -181,6 +181,7 @@ qsv applydp dynfmt --formatstr 'Sir/Madam {FirstName} {MI}. {LastName}' -c FullN
 
 For more examples, see [tests](https://github.com/dathere/qsv/blob/master/tests/test_applydp.rs).
 
+See also <https://github.com/dathere/qsv/wiki/Transform-and-Reshape#applydp>
 
 <a name="usage"></a>
 

--- a/docs/help/behead.md
+++ b/docs/help/behead.md
@@ -13,6 +13,8 @@
 
 Drop a CSV file's header.
 
+See also <https://github.com/dathere/qsv/wiki/Transform-and-Reshape#behead>
+
 
 <a name="usage"></a>
 

--- a/docs/help/blake3.md
+++ b/docs/help/blake3.md
@@ -18,6 +18,7 @@ of one or more files. It supports keyed hashing, key derivation, variable-length
 and checksum verification. When no file is given, or when "-" is given, reads stdin.
 
 For examples, see <https://github.com/dathere/qsv/blob/master/tests/test_blake3.rs>.
+See also <https://github.com/dathere/qsv/wiki/Indexing-Compression-Diff#blake3>
 
 
 <a name="usage"></a>

--- a/docs/help/cat.md
+++ b/docs/help/cat.md
@@ -71,6 +71,7 @@ qsv cat rows path/to/files_to_combine.infile-list -o combined.csv
 
 For more examples, see [tests](https://github.com/dathere/qsv/blob/master/tests/test_cat.rs).
 
+See also <https://github.com/dathere/qsv/wiki/Transform-and-Reshape#cat>
 
 <a name="usage"></a>
 

--- a/docs/help/clipboard.md
+++ b/docs/help/clipboard.md
@@ -32,6 +32,7 @@ pipe into qsv clipboard using the --save or -s flag:
 qsv clipboard | qsv stats | qsv clipboard -s
 ```
 
+See also <https://github.com/dathere/qsv/wiki/Selection-and-Inspection#clipboard>
 
 <a name="usage"></a>
 

--- a/docs/help/color.md
+++ b/docs/help/color.md
@@ -28,6 +28,8 @@ The color theme is detected based on the current terminal background color
 if possible. Set QSV_THEME to DARK or LIGHT to skip detection. QSV_TERMWIDTH
 can be used to override terminal size.
 
+See also <https://github.com/dathere/qsv/wiki/Selection-and-Inspection#color>
+
 
 <a name="usage"></a>
 

--- a/docs/help/count.md
+++ b/docs/help/count.md
@@ -72,6 +72,7 @@ qsv count --width --json data.csv
 
 For more examples, see [tests](https://github.com/dathere/qsv/blob/master/tests/test_count.rs).
 
+See also <https://github.com/dathere/qsv/wiki/Selection-and-Inspection#count>
 
 <a name="usage"></a>
 

--- a/docs/help/datefmt.md
+++ b/docs/help/datefmt.md
@@ -71,6 +71,7 @@ qsv datefmt OpenDate,CloseDate --formatstr '%u' --rename Open_weekday,Close_week
 
 For more examples, see [tests](https://github.com/dathere/qsv/blob/master/tests/test_datefmt.rs).
 
+See also <https://github.com/dathere/qsv/wiki/Transform-and-Reshape#datefmt>
 
 <a name="usage"></a>
 

--- a/docs/help/dedup.md
+++ b/docs/help/dedup.md
@@ -67,6 +67,7 @@ qsv dedup -s col1,col2 --dupes-output dupes.csv unsorted.csv -o deduped.csv
 
 For more examples, see [tests](https://github.com/dathere/qsv/blob/master/tests/test_dedup.rs).
 
+See also <https://github.com/dathere/qsv/wiki/Aggregation-and-Statistics#dedup>
 
 <a name="usage"></a>
 

--- a/docs/help/describegpt.md
+++ b/docs/help/describegpt.md
@@ -191,7 +191,8 @@ qsv describegpt data.csv --all --stats-options "file:my_stats.csv" --freq-option
 For more examples, see [tests](https://github.com/dathere/qsv/blob/master/tests/test_describegpt.rs).
 
 For more detailed info on how describegpt works and how to prepare a prompt file,
-see <https://github.com/dathere/qsv/blob/master/docs/Describegpt.md>
+see <https://github.com/dathere/qsv/blob/master/docs/Describegpt.md> and
+<https://github.com/dathere/qsv/wiki/AI-and-Documentation#describegpt>
 
 <a name="usage"></a>
 

--- a/docs/help/diff.md
+++ b/docs/help/diff.md
@@ -100,6 +100,7 @@ qsv diff --no-headers-left --no-headers-right left.csv right.csv
 
 For more examples, see [tests](https://github.com/dathere/qsv/blob/master/tests/test_diff.rs).
 
+See also <https://github.com/dathere/qsv/wiki/Indexing-Compression-Diff#diff>
 
 <a name="usage"></a>
 

--- a/docs/help/edit.md
+++ b/docs/help/edit.md
@@ -40,6 +40,7 @@ flashlight,gray
 You may also choose to specify the column name by its index (in this case 1).
 Specifying a column as a number is prioritized by index rather than name.
 If there is no newline (\n) at the end of the input data, it may be added to the output.
+See also <https://github.com/dathere/qsv/wiki/Transform-and-Reshape#edit>
 
 <a name="usage"></a>
 

--- a/docs/help/enum.md
+++ b/docs/help/enum.md
@@ -158,6 +158,7 @@ qsv enum --hash "/record|name|address/" data.csv
 
 For more examples, see [tests](https://github.com/dathere/qsv/blob/master/tests/test_enumerate.rs).
 
+See also <https://github.com/dathere/qsv/wiki/Transform-and-Reshape#enum>
 
 <a name="usage"></a>
 

--- a/docs/help/excel.md
+++ b/docs/help/excel.md
@@ -141,6 +141,7 @@ qsv excel --metadata Short input.xlsx
 
 For more examples, see [tests](https://github.com/dathere/qsv/blob/master/tests/test_excel.rs).
 
+See also <https://github.com/dathere/qsv/wiki/Conversion-and-IO#excel>
 
 <a name="usage"></a>
 

--- a/docs/help/exclude.md
+++ b/docs/help/exclude.md
@@ -99,6 +99,7 @@ qsv --sorted dedup > new-sorted-deduped-records.csv
 
 For more examples, see [tests](https://github.com/dathere/qsv/blob/master/tests/test_exclude.rs).
 
+See also <https://github.com/dathere/qsv/wiki/Joins-and-Set-Ops#exclude>
 
 <a name="usage"></a>
 

--- a/docs/help/explode.md
+++ b/docs/help/explode.md
@@ -38,6 +38,7 @@ John,yellow
 Mary,red
 ```
 
+See also <https://github.com/dathere/qsv/wiki/Transform-and-Reshape#explode>
 
 <a name="usage"></a>
 

--- a/docs/help/extdedup.md
+++ b/docs/help/extdedup.md
@@ -30,6 +30,8 @@ line-by-line basis.
 
 A duplicate count will be sent to <stderr>.
 
+See also <https://github.com/dathere/qsv/wiki/Aggregation-and-Statistics#extdedup>
+
 
 <a name="usage"></a>
 

--- a/docs/help/extsort.md
+++ b/docs/help/extsort.md
@@ -23,6 +23,8 @@ when --select is NOT set, it sorts any input text file (not just CSVs) on a
 line-by-line basis. If sorting a non-CSV file, be sure to set --no-headers,
 otherwise, the first line will not be included in the external sort.
 
+See also <https://github.com/dathere/qsv/wiki/Aggregation-and-Statistics#extsort>
+
 
 <a name="usage"></a>
 

--- a/docs/help/fetch.md
+++ b/docs/help/fetch.md
@@ -179,6 +179,7 @@ qsv fetch URL data.csv --http-header "X-Api-Key:TEST_KEY" -H "X-Api-Secret:ABC12
 
 For more examples, see [tests](https://github.com/dathere/qsv/blob/master/tests/test_fetch.rs).
 
+See also <https://github.com/dathere/qsv/wiki/HTTP-and-Web#fetch>
 
 <a name="usage"></a>
 

--- a/docs/help/fetchpost.md
+++ b/docs/help/fetchpost.md
@@ -165,6 +165,7 @@ $ qsv fetchpost https://httpbin.org/post col1-col3 data.csv -H "X-Api-Key:TEST_K
 
 
 For more extensive examples, see <https://github.com/dathere/qsv/blob/master/tests/test_fetch.rs>.
+See also <https://github.com/dathere/qsv/wiki/HTTP-and-Web#fetchpost>
 
 
 <a name="usage"></a>

--- a/docs/help/fill.md
+++ b/docs/help/fill.md
@@ -44,6 +44,7 @@ re-ordered during output due to the buffering of rows
 collected before the first valid value.
 
 For examples, see <https://github.com/dathere/qsv/blob/master/tests/test_fill.rs>.
+See also <https://github.com/dathere/qsv/wiki/Transform-and-Reshape#fill>
 
 
 <a name="usage"></a>

--- a/docs/help/fixlengths.md
+++ b/docs/help/fixlengths.md
@@ -22,6 +22,8 @@ given must be a file and not stdin.
 Alternatively, if --length is set, then all records are forced to that length.
 This requires a single pass and can be done with stdin.
 
+See also <https://github.com/dathere/qsv/wiki/Transform-and-Reshape#fixlengths>
+
 
 <a name="usage"></a>
 

--- a/docs/help/flatten.md
+++ b/docs/help/flatten.md
@@ -20,6 +20,7 @@ There is also a condensed view (-c or --condense) that will shorten the
 contents of each field to provide a summary view.
 
 For examples, see <https://github.com/dathere/qsv/blob/master/tests/test_flatten.rs>.
+See also <https://github.com/dathere/qsv/wiki/Selection-and-Inspection#flatten>
 
 
 <a name="usage"></a>

--- a/docs/help/fmt.md
+++ b/docs/help/fmt.md
@@ -20,6 +20,7 @@ have a specific delimiter or record separator, and this is where 'qsv fmt' is
 useful.
 
 For examples, see <https://github.com/dathere/qsv/blob/master/tests/test_fmt.rs>.
+See also <https://github.com/dathere/qsv/wiki/Transform-and-Reshape#fmt>
 
 
 <a name="usage"></a>

--- a/docs/help/foreach.md
+++ b/docs/help/foreach.md
@@ -52,6 +52,7 @@ qsv foreach query -u -c from_query 'search {}' queries.csv > results.csv
 
 For more examples, see [tests](https://github.com/dathere/qsv/blob/master/tests/test_foreach.rs).
 
+See also <https://github.com/dathere/qsv/wiki/Scripting-Luau-Python#foreach>
 If any child command exits with a non-zero status, foreach finishes processing
 all rows but then exits with a non-zero status of its own.
 

--- a/docs/help/frequency.md
+++ b/docs/help/frequency.md
@@ -80,6 +80,7 @@ This is useful when you want to apply limits only to columns with a large number
 of unique items and not to columns with a small number of unique items.
 
 For examples, see <https://github.com/dathere/qsv/blob/master/tests/test_frequency.rs>.
+See also <https://github.com/dathere/qsv/wiki/Aggregation-and-Statistics#frequency>
 
 
 <a name="usage"></a>

--- a/docs/help/geocode.md
+++ b/docs/help/geocode.md
@@ -457,6 +457,7 @@ input_data.csv -o output_data_with_fips.csv
 
 For more examples, see [tests](https://github.com/dathere/qsv/blob/master/tests/test_geocode.rs).
 
+See also <https://github.com/dathere/qsv/wiki/Geospatial#geocode>
 
 <a name="usage"></a>
 

--- a/docs/help/geoconvert.md
+++ b/docs/help/geoconvert.md
@@ -41,6 +41,8 @@ $ qsv geoconvert file.csv csv geojson --latitude lat --longitude lon
 ```
 
 
+See also <https://github.com/dathere/qsv/wiki/Geospatial#geoconvert>
+
 
 <a name="usage"></a>
 

--- a/docs/help/headers.md
+++ b/docs/help/headers.md
@@ -20,6 +20,7 @@ Note that multiple CSV files may be given to this command. This is useful with
 the --union flag.
 
 For examples, see <https://github.com/dathere/qsv/blob/master/tests/test_headers.rs>.
+See also <https://github.com/dathere/qsv/wiki/Selection-and-Inspection#headers>
 
 
 <a name="usage"></a>

--- a/docs/help/implode.md
+++ b/docs/help/implode.md
@@ -57,6 +57,7 @@ By default, all input rows are buffered in memory and groups are emitted in the
 order keys are first seen. If the input is already sorted by the key column(s),
 use --sorted to stream groups as they are seen (memory proportional to the
 largest group, not the whole input).
+See also <https://github.com/dathere/qsv/wiki/Transform-and-Reshape#implode>
 
 <a name="usage"></a>
 

--- a/docs/help/index.md
+++ b/docs/help/index.md
@@ -24,6 +24,8 @@ However, if the environment variable QSV_AUTOINDEX_SIZE is set, qsv will
 automatically create an index when the input file size >= specified size (bytes).
 It will also automatically update stale indices as well.
 
+See also <https://github.com/dathere/qsv/wiki/Indexing-Compression-Diff#index>
+
 
 <a name="usage"></a>
 

--- a/docs/help/input.md
+++ b/docs/help/input.md
@@ -36,6 +36,7 @@ This command is typically used at the beginning of a data pipeline (thus the nam
 to normalize & prepare CSVs for further processing with other qsv commands.
 
 For examples, see <https://github.com/dathere/qsv/blob/master/tests/test_input.rs>.
+See also <https://github.com/dathere/qsv/wiki/Transform-and-Reshape#input>
 
 
 <a name="usage"></a>

--- a/docs/help/join.md
+++ b/docs/help/join.md
@@ -21,6 +21,7 @@ joins are done case sensitively, but this can be disabled with the --ignore-case
 flag.
 
 For examples, see <https://github.com/dathere/qsv/blob/master/tests/test_join.rs>.
+See also <https://github.com/dathere/qsv/wiki/Joins-and-Set-Ops#join>
 
 
 <a name="usage"></a>

--- a/docs/help/joinp.md
+++ b/docs/help/joinp.md
@@ -23,6 +23,7 @@ non-equi & asof joins and its output columns can be coalesced (no duplicate colu
 Returns the shape of the join result (number of rows, number of columns) to stderr.
 
 For examples, see <https://github.com/dathere/qsv/blob/master/tests/test_joinp.rs>.
+See also <https://github.com/dathere/qsv/wiki/Joins-and-Set-Ops#joinp>
 
 
 <a name="usage"></a>

--- a/docs/help/json.md
+++ b/docs/help/json.md
@@ -150,6 +150,7 @@ $ qsv prompt -F json | qsv json --jaq .data
 
 
 For more examples, see <https://github.com/dathere/qsv/blob/master/tests/test_json.rs>.
+See also <https://github.com/dathere/qsv/wiki/Conversion-and-IO#json>
 
 
 <a name="usage"></a>

--- a/docs/help/jsonl.md
+++ b/docs/help/jsonl.md
@@ -21,6 +21,7 @@ Also, it will fail if the JSON documents are not consistent with one another,
 as the first JSON line will be used to infer the headers of the CSV output.
 
 For examples, see <https://github.com/dathere/qsv/blob/master/tests/test_jsonl.rs>.
+See also <https://github.com/dathere/qsv/wiki/Conversion-and-IO#jsonl>
 
 
 <a name="usage"></a>

--- a/docs/help/lens.md
+++ b/docs/help/lens.md
@@ -22,6 +22,8 @@ its snappy-compressed variants (CSV.sz, TSV.sz, Tab.sz & SSV.sz).
 
 Press 'q' to exit. Press '?' for help.
 
+See also <https://github.com/dathere/qsv/wiki/Selection-and-Inspection#lens>
+
 
 <a name="examples"></a>
 

--- a/docs/help/luau.md
+++ b/docs/help/luau.md
@@ -229,6 +229,7 @@ Detailed descriptions of these helpers can be found in the "setup_helpers" secti
 the bottom of this file and on the Wiki (<https://github.com/dathere/qsv/wiki>)
 
 For more detailed examples, see <https://github.com/dathere/qsv/blob/master/tests/test_luau.rs>.
+See also <https://github.com/dathere/qsv/wiki/Scripting-Luau-Python#luau>
 
 
 <a name="usage"></a>

--- a/docs/help/moarstats.md
+++ b/docs/help/moarstats.md
@@ -283,6 +283,7 @@ qsv moarstats data.csv --bivariate --join-inputs customers.csv,products.csv --jo
 
 For more examples, see [tests](https://github.com/dathere/qsv/blob/master/tests/test_moarstats.rs).
 
+See also <https://github.com/dathere/qsv/wiki/Aggregation-and-Statistics#moarstats>
 
 <a name="usage"></a>
 

--- a/docs/help/partition.md
+++ b/docs/help/partition.md
@@ -40,6 +40,7 @@ nyc311-Queens.csv
 nyc311-Staten_Island.csv
 
 For more examples, see <https://github.com/dathere/qsv/blob/master/tests/test_partition.rs>.
+See also <https://github.com/dathere/qsv/wiki/Joins-and-Set-Ops#partition>
 
 
 <a name="usage"></a>

--- a/docs/help/pivotp.md
+++ b/docs/help/pivotp.md
@@ -28,6 +28,7 @@ The none aggregation is not supported in group-by mode.
 If --values is omitted, a single "count" column is produced.
 
 For examples, see <https://github.com/dathere/qsv/blob/master/tests/test_pivotp.rs>.
+See also <https://github.com/dathere/qsv/wiki/SQL-and-Polars#pivotp>
 
 
 <a name="usage"></a>

--- a/docs/help/pragmastat.md
+++ b/docs/help/pragmastat.md
@@ -181,6 +181,7 @@ qsv pragmastat --standalone --subsample 10000 --no-bounds data.csv
 Full Pragmastat manual:  
 <https://github.com/AndreyAkinshin/pragmastat/releases/download/v12.1.0/pragmastat-v12.1.0.pdf>
 <https://pragmastat.dev/> (latest version)
+See also <https://github.com/dathere/qsv/wiki/Aggregation-and-Statistics#pragmastat>
 
 <a name="usage"></a>
 

--- a/docs/help/pro.md
+++ b/docs/help/pro.md
@@ -20,6 +20,8 @@ The qsv pro command has subcommands:
 lens:     Run csvlens on a local file in a new Alacritty terminal emulator window (Windows only).
 workflow: Import a local file into the qsv pro Workflow (Workflow must be open).
 
+See also <https://github.com/dathere/qsv/wiki/Integrations#qsv-pro-bridge>
+
 
 <a name="usage"></a>
 

--- a/docs/help/prompt.md
+++ b/docs/help/prompt.md
@@ -39,6 +39,7 @@ qsv prompt -m 'Select a spreadsheet to export to CSV' -F xlsx,xls,ods | \
 qsv excel - | qsv prompt -m 'Save exported CSV to...' --fd-output
 ```
 
+See also <https://github.com/dathere/qsv/wiki/Conversion-and-IO#prompt>
 
 <a name="usage"></a>
 

--- a/docs/help/pseudo.md
+++ b/docs/help/pseudo.md
@@ -58,6 +58,7 @@ ID-1000,cyan
 
 
 For more examples, see <https://github.com/dathere/qsv/blob/master/tests/test_pseudo.rs>.
+See also <https://github.com/dathere/qsv/wiki/Transform-and-Reshape#pseudo>
 
 
 <a name="usage"></a>

--- a/docs/help/py.md
+++ b/docs/help/py.md
@@ -120,6 +120,7 @@ With "py filter", if the expression is invalid for a record, that record is not 
 If any record has an invalid result, an exitcode of 1 is returned and an error count is logged.
 
 For more extensive examples, see <https://github.com/dathere/qsv/blob/master/tests/test_py.rs>.
+See also <https://github.com/dathere/qsv/wiki/Scripting-Luau-Python#py>
 
 
 <a name="usage"></a>

--- a/docs/help/rename.md
+++ b/docs/help/rename.md
@@ -54,6 +54,7 @@ qsv rename '"Date - Opening","Date - Actual Closing"'
 
 For more examples, see [tests](https://github.com/dathere/qsv/blob/master/tests/test_rename.rs).
 
+See also <https://github.com/dathere/qsv/wiki/Transform-and-Reshape#rename>
 
 <a name="usage"></a>
 

--- a/docs/help/replace.md
+++ b/docs/help/replace.md
@@ -63,6 +63,7 @@ qsv replace '([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})' \
 
 For more examples, see [tests](https://github.com/dathere/qsv/blob/master/tests/test_replace.rs).
 
+See also <https://github.com/dathere/qsv/wiki/Transform-and-Reshape#replace>
 
 <a name="usage"></a>
 

--- a/docs/help/reverse.md
+++ b/docs/help/reverse.md
@@ -19,6 +19,8 @@ or when keys are not unique and order of rows with the same key needs to be pres
 Note that if the CSV is not indexed, this operation will require reading all of the
 CSV data into memory
 
+See also <https://github.com/dathere/qsv/wiki/Transform-and-Reshape#reverse>
+
 
 <a name="usage"></a>
 

--- a/docs/help/safenames.md
+++ b/docs/help/safenames.md
@@ -82,6 +82,7 @@ It is discouraged because the embedded spaces can cause problems later on.
 (see <https://lerner.co.il/2013/11/30/quoting-postgresql/> for more info).
 
 For more examples, see <https://github.com/dathere/qsv/blob/master/tests/test_safenames.rs>.
+See also <https://github.com/dathere/qsv/wiki/Transform-and-Reshape#safenames>
 
 
 <a name="usage"></a>

--- a/docs/help/sample.md
+++ b/docs/help/sample.md
@@ -203,6 +203,7 @@ qsv sample --sketch-in a.sk,b.sk 1000 -o merged.csv
 
 For more examples, see [tests](https://github.com/dathere/qsv/blob/master/tests/test_sample.rs).
 
+See also <https://github.com/dathere/qsv/wiki/Selection-and-Inspection#sample>
 
 <a name="usage"></a>
 

--- a/docs/help/schema.md
+++ b/docs/help/schema.md
@@ -63,6 +63,7 @@ Polars to optimize the query and gives the user the option to tailor the schema 
 query needs (e.g. using a Decimal type with explicit precision and scale instead of a Float type).
 
 For examples, see <https://github.com/dathere/qsv/blob/master/tests/test_schema.rs>.
+See also <https://github.com/dathere/qsv/wiki/Validation-and-Schema#schema>
 
 
 <a name="usage"></a>

--- a/docs/help/scoresql.md
+++ b/docs/help/scoresql.md
@@ -72,6 +72,7 @@ qsv scoresql data.csv script.sql
 
 For more examples, see [tests](https://github.com/dathere/qsv/blob/master/tests/test_scoresql.rs).
 
+See also <https://github.com/dathere/qsv/wiki/SQL-and-Polars#scoresql>
 
 <a name="usage"></a>
 

--- a/docs/help/search.md
+++ b/docs/help/search.md
@@ -83,6 +83,7 @@ qsv search --preview-match 5 'warning' data.csv
 
 For more examples, see [tests](https://github.com/dathere/qsv/blob/master/tests/test_search.rs).
 
+See also <https://github.com/dathere/qsv/wiki/Selection-and-Inspection#search>
 
 <a name="usage"></a>
 

--- a/docs/help/searchset.md
+++ b/docs/help/searchset.md
@@ -39,6 +39,7 @@ the first match.
 When the CSV is indexed, a faster parallel search is used.
 
 For examples, see <https://github.com/dathere/qsv/blob/master/tests/test_searchset.rs>.
+See also <https://github.com/dathere/qsv/wiki/Selection-and-Inspection#searchset>
 
 
 <a name="usage"></a>

--- a/docs/help/select.md
+++ b/docs/help/select.md
@@ -134,6 +134,7 @@ qsv select '\"Date - Opening\",\"Date - Actual Closing\"'
 
 For more examples, see [tests](https://github.com/dathere/qsv/blob/master/tests/test_select.rs).
 
+See also <https://github.com/dathere/qsv/wiki/Selection-and-Inspection#select>
 
 <a name="usage"></a>
 

--- a/docs/help/slice.md
+++ b/docs/help/slice.md
@@ -98,6 +98,7 @@ qsv slice --start 9 --len 10 --invert --json data.csv
 
 For more examples, see [tests](https://github.com/dathere/qsv/blob/master/tests/test_slice.rs).
 
+See also <https://github.com/dathere/qsv/wiki/Selection-and-Inspection#slice>
 
 <a name="usage"></a>
 

--- a/docs/help/snappy.md
+++ b/docs/help/snappy.md
@@ -34,6 +34,7 @@ single-threaded compression.
 Also, this command is not specific to CSV data, it can compress/decompress ANY file.
 
 For examples, see <https://github.com/dathere/qsv/blob/master/tests/test_snappy.rs>.
+See also <https://github.com/dathere/qsv/wiki/Conversion-and-IO#snappy>
 
 
 <a name="usage"></a>

--- a/docs/help/sniff.md
+++ b/docs/help/sniff.md
@@ -72,6 +72,7 @@ qsv sniff --sample 0.20 data.ssv
 
 For more examples, see [tests](https://github.com/dathere/qsv/blob/master/tests/test_sniff.rs).
 
+See also <https://github.com/dathere/qsv/wiki/Selection-and-Inspection#sniff>
 
 <a name="usage"></a>
 

--- a/docs/help/sort.md
+++ b/docs/help/sort.md
@@ -18,6 +18,7 @@ you need to sort a large file that may not fit into memory, use the
 extsort command instead.
 
 For examples, see <https://github.com/dathere/qsv/blob/master/tests/test_sort.rs>.
+See also <https://github.com/dathere/qsv/wiki/Transform-and-Reshape#sort>
 
 
 <a name="usage"></a>

--- a/docs/help/sortcheck.md
+++ b/docs/help/sortcheck.md
@@ -67,6 +67,7 @@ qsv sortcheck --natural --json file.csv
 
 For more examples, see [tests](https://github.com/dathere/qsv/blob/master/tests/test_sortcheck.rs).
 
+See also <https://github.com/dathere/qsv/wiki/Transform-and-Reshape#sortcheck>
 
 <a name="usage"></a>
 

--- a/docs/help/split.md
+++ b/docs/help/split.md
@@ -106,6 +106,7 @@ qsv split outdir --filter "powershell Compress-Archive -Path $FILE -Destination 
 
 For more examples, see [tests](https://github.com/dathere/qsv/blob/master/tests/test_split.rs).
 
+See also <https://github.com/dathere/qsv/wiki/Joins-and-Set-Ops#split>
 
 <a name="usage"></a>
 

--- a/docs/help/sqlp.md
+++ b/docs/help/sqlp.md
@@ -297,6 +297,7 @@ qsv sqlp data.csv 'explain select * from data where col1 > 10 order by col2 desc
 
 For more examples, see [tests](https://github.com/dathere/qsv/blob/master/tests/test_sqlp.rs).
 
+See also <https://github.com/dathere/qsv/wiki/SQL-and-Polars#sqlp>
 
 <a name="usage"></a>
 

--- a/docs/help/stats.md
+++ b/docs/help/stats.md
@@ -179,6 +179,7 @@ qsv stats -E --cache-threshold -5000005 nyc311.csv
 
 For more examples, see [tests](https://github.com/dathere/qsv/tree/master/resources/test).
 
+See also <https://github.com/dathere/qsv/wiki/Aggregation-and-Statistics#stats>
 If the polars feature is enabled, support additional tabular file formats and
 compression formats:  
 ```console

--- a/docs/help/synthesize.md
+++ b/docs/help/synthesize.md
@@ -105,6 +105,7 @@ qsv synthesize data.csv --dictionary dict.json -n 1000 > synthetic.csv
 
 For more examples, see [tests](https://github.com/dathere/qsv/blob/master/tests/test_synthesize.rs).
 
+See also <https://github.com/dathere/qsv/wiki/AI-and-Documentation#synthesize>
 
 <a name="usage"></a>
 

--- a/docs/help/table.md
+++ b/docs/help/table.md
@@ -27,6 +27,8 @@ Note that formatting a table requires buffering all CSV data into memory.
 Therefore, you should use the 'sample' or 'slice' command to trim down large
 CSV data before formatting it with this command.
 
+See also <https://github.com/dathere/qsv/wiki/Selection-and-Inspection#table>
+
 
 <a name="usage"></a>
 

--- a/docs/help/template.md
+++ b/docs/help/template.md
@@ -93,6 +93,7 @@ coalesce(a, b, ...)                  First argument that is not undefined/none/e
 
 For more examples, see [tests](https://github.com/dathere/qsv/blob/master/tests/test_template.rs).
 
+See also <https://github.com/dathere/qsv/wiki/Scripting-Luau-Python#template>
 For a relatively complex MiniJinja template, see <https://github.com/dathere/qsv/blob/master/scripts/template.tpl>
 
 <a name="usage"></a>

--- a/docs/help/to.md
+++ b/docs/help/to.md
@@ -243,6 +243,7 @@ qsv to xlsx datapackage.xlsx --stats --print-package file1.csv file2.csv
 
 For more examples, see [tests](https://github.com/dathere/qsv/blob/master/tests/test_to.rs).
 
+See also <https://github.com/dathere/qsv/wiki/Conversion-and-IO#to>
 
 <a name="usage"></a>
 

--- a/docs/help/tojsonl.md
+++ b/docs/help/tojsonl.md
@@ -25,6 +25,7 @@ current (i.e. stats generated with --cardinality and --infer-dates options) and 
 skip recomputing stats.
 
 For examples, see <https://github.com/dathere/qsv/blob/master/tests/test_tojsonl.rs>.
+See also <https://github.com/dathere/qsv/wiki/Conversion-and-IO#tojsonl>
 
 
 <a name="usage"></a>

--- a/docs/help/transpose.md
+++ b/docs/help/transpose.md
@@ -61,6 +61,7 @@ qsv transpose --long /^name/ data.csv
 ```
 
 See <https://github.com/dathere/qsv/blob/master/tests/test_transpose.rs> for more examples.
+See also <https://github.com/dathere/qsv/wiki/Transform-and-Reshape#transpose>
 
 <a name="usage"></a>
 

--- a/docs/help/validate.md
+++ b/docs/help/validate.md
@@ -210,6 +210,7 @@ qsv validate files.infile-list schema.json
 For more examples, see the tests included in this file (denoted by '#[test]') or see
 
 <https://github.com/dathere/qsv/blob/master/tests/test_validate.rs>.
+See also <https://github.com/dathere/qsv/wiki/Validation-and-Schema#validate>
 
 <a name="usage"></a>
 

--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -217,6 +217,7 @@ Examples:
   qsv apply calcconv --formatstr '{col1} Billion Trillion * {col2} quadrillion vigintillion' -c num_atoms file.csv
 
 For more extensive examples, see https://github.com/dathere/qsv/blob/master/tests/test_apply.rs.
+See also https://github.com/dathere/qsv/wiki/Transform-and-Reshape#apply
 
 Usage:
 qsv apply operations <operations> [options] <column> [<input>]

--- a/src/cmd/applydp.rs
+++ b/src/cmd/applydp.rs
@@ -119,6 +119,7 @@ Examples:
   qsv applydp dynfmt --formatstr 'Sir/Madam {FirstName} {MI}. {LastName}' -c FullName file.csv
 
 For more extensive examples, see https://github.com/dathere/qsv/blob/master/tests/test_applydp.rs.
+See also https://github.com/dathere/qsv/wiki/Transform-and-Reshape#applydp
 
 Usage:
 qsv applydp operations <operations> [options] <column> [<input>]

--- a/src/cmd/behead.rs
+++ b/src/cmd/behead.rs
@@ -1,6 +1,8 @@
 static USAGE: &str = r#"
 Drop a CSV file's header.
 
+See also https://github.com/dathere/qsv/wiki/Transform-and-Reshape#behead
+
 Usage:
     qsv behead [options] [<input>]
     qsv behead --help

--- a/src/cmd/blake3.rs
+++ b/src/cmd/blake3.rs
@@ -6,6 +6,7 @@ of one or more files. It supports keyed hashing, key derivation, variable-length
 and checksum verification. When no file is given, or when "-" is given, reads stdin.
 
 For examples, see https://github.com/dathere/qsv/blob/master/tests/test_blake3.rs.
+See also https://github.com/dathere/qsv/wiki/Indexing-Compression-Diff#blake3
 
 Usage:
     qsv blake3 [options] [<input>...]

--- a/src/cmd/cat.rs
+++ b/src/cmd/cat.rs
@@ -40,6 +40,7 @@ Examples:
   qsv cat rows path/to/files_to_combine.infile-list -o combined.csv
 
 For examples, see https://github.com/dathere/qsv/blob/master/tests/test_cat.rs.
+See also https://github.com/dathere/qsv/wiki/Transform-and-Reshape#cat
 
 Usage:
     qsv cat rows    [options] [<input>...]

--- a/src/cmd/clipboard.rs
+++ b/src/cmd/clipboard.rs
@@ -14,6 +14,8 @@ pipe into qsv clipboard using the --save or -s flag:
 
   $ qsv clipboard | qsv stats | qsv clipboard -s
 
+See also https://github.com/dathere/qsv/wiki/Selection-and-Inspection#clipboard
+
 Usage:
     qsv clipboard [options]
     qsv clipboard --help

--- a/src/cmd/color.rs
+++ b/src/cmd/color.rs
@@ -16,6 +16,8 @@ The color theme is detected based on the current terminal background color
 if possible. Set QSV_THEME to DARK or LIGHT to skip detection. QSV_TERMWIDTH
 can be used to override terminal size.
 
+See also https://github.com/dathere/qsv/wiki/Selection-and-Inspection#color
+
 Usage:
     qsv color [options] [<input>]
     qsv color --help

--- a/src/cmd/count.rs
+++ b/src/cmd/count.rs
@@ -39,6 +39,7 @@ Examples:
   qsv count --width --json data.csv
 
 For examples, see https://github.com/dathere/qsv/blob/master/tests/test_count.rs.
+See also https://github.com/dathere/qsv/wiki/Selection-and-Inspection#count
 
 Usage:
     qsv count [options] [<input>]

--- a/src/cmd/datefmt.rs
+++ b/src/cmd/datefmt.rs
@@ -34,6 +34,7 @@ Examples:
   qsv datefmt OpenDate,CloseDate --formatstr '%u' --rename Open_weekday,Close_weekday file.csv
 
 For more extensive examples, see https://github.com/dathere/qsv/blob/master/tests/test_datefmt.rs.
+See also https://github.com/dathere/qsv/wiki/Transform-and-Reshape#datefmt
 
 Usage:
 qsv datefmt [--formatstr=<string>] [options] <column> [<input>]

--- a/src/cmd/dedup.rs
+++ b/src/cmd/dedup.rs
@@ -33,6 +33,7 @@ Examples:
   qsv dedup -s col1,col2 --dupes-output dupes.csv unsorted.csv -o deduped.csv
 
 For examples, see https://github.com/dathere/qsv/blob/master/tests/test_dedup.rs.
+See also https://github.com/dathere/qsv/wiki/Aggregation-and-Statistics#dedup
 
 Usage:
     qsv dedup [options] [<input>]

--- a/src/cmd/describegpt.rs
+++ b/src/cmd/describegpt.rs
@@ -127,7 +127,8 @@ Examples:
 For more examples, see https://github.com/dathere/qsv/blob/master/tests/test_describegpt.rs.
 
 For more detailed info on how describegpt works and how to prepare a prompt file,
-see https://github.com/dathere/qsv/blob/master/docs/Describegpt.md
+see https://github.com/dathere/qsv/blob/master/docs/Describegpt.md and
+https://github.com/dathere/qsv/wiki/AI-and-Documentation#describegpt
 
 Usage:
     qsv describegpt [options] [<input>]

--- a/src/cmd/diff.rs
+++ b/src/cmd/diff.rs
@@ -47,6 +47,7 @@ qsv diff --no-headers-output left.csv right.csv
 qsv diff --no-headers-left --no-headers-right left.csv right.csv
 
 For more examples, see https://github.com/dathere/qsv/blob/master/tests/test_diff.rs
+See also https://github.com/dathere/qsv/wiki/Indexing-Compression-Diff#diff
 
 Usage:
     qsv diff [options] [<input-left>] [<input-right>]

--- a/src/cmd/edit.rs
+++ b/src/cmd/edit.rs
@@ -23,6 +23,8 @@ You may also choose to specify the column name by its index (in this case 1).
 Specifying a column as a number is prioritized by index rather than name.
 If there is no newline (\n) at the end of the input data, it may be added to the output.
 
+See also https://github.com/dathere/qsv/wiki/Transform-and-Reshape#edit
+
 Usage:
     qsv edit [options] <input> <column> <row> <value>
     qsv edit --help

--- a/src/cmd/enumerate.rs
+++ b/src/cmd/enumerate.rs
@@ -76,6 +76,7 @@ Examples:
   qsv enum --hash "/record|name|address/" data.csv
 
 For more examples, see https://github.com/dathere/qsv/blob/master/tests/test_enumerate.rs.
+See also https://github.com/dathere/qsv/wiki/Transform-and-Reshape#enum
 
 Usage:
     qsv enum [options] [<input>]

--- a/src/cmd/excel.rs
+++ b/src/cmd/excel.rs
@@ -68,6 +68,7 @@ qsv excel --metadata JSON input.xlsx
 qsv excel --metadata Short input.xlsx
 
 For more examples, see https://github.com/dathere/qsv/blob/master/tests/test_excel.rs.
+See also https://github.com/dathere/qsv/wiki/Conversion-and-IO#excel
 
 Usage:
     qsv excel [options] [<input>]

--- a/src/cmd/exclude.rs
+++ b/src/cmd/exclude.rs
@@ -53,6 +53,7 @@ Examples:
       qsv --sorted dedup > new-sorted-deduped-records.csv
 
 For more examples, see https://github.com/dathere/qsv/blob/master/tests/test_exclude.rs.
+See also https://github.com/dathere/qsv/wiki/Joins-and-Set-Ops#exclude
 
 Usage:
     qsv exclude [options] <columns1> <input1> <columns2> <input2>

--- a/src/cmd/explode.rs
+++ b/src/cmd/explode.rs
@@ -20,6 +20,8 @@ John,yellow
 Mary,red
 ```
 
+See also https://github.com/dathere/qsv/wiki/Transform-and-Reshape#explode
+
 Usage:
     qsv explode [options] <column> <separator> [<input>]
     qsv explode --help

--- a/src/cmd/extdedup.rs
+++ b/src/cmd/extdedup.rs
@@ -18,6 +18,8 @@ This command has TWO modes of operation.
 
 A duplicate count will be sent to <stderr>.
 
+See also https://github.com/dathere/qsv/wiki/Aggregation-and-Statistics#extdedup
+
 Usage:
     qsv extdedup [options] [<input>] [<output>]
     qsv extdedup --help

--- a/src/cmd/extsort.rs
+++ b/src/cmd/extsort.rs
@@ -11,6 +11,8 @@ This command has TWO modes of operation.
    line-by-line basis. If sorting a non-CSV file, be sure to set --no-headers, 
    otherwise, the first line will not be included in the external sort.
 
+See also https://github.com/dathere/qsv/wiki/Aggregation-and-Statistics#extsort
+
 Usage:
     qsv extsort [options] [<input>] [<output>]
     qsv extsort --help

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -148,6 +148,7 @@ Note that you can pass as many key-value pairs by using --http-header option rep
   $ qsv fetch URL data.csv --http-header "X-Api-Key:TEST_KEY" -H "X-Api-Secret:ABC123XYZ" -H "Accept-Language: fr-FR"
 
 For more extensive examples, see https://github.com/dathere/qsv/blob/master/tests/test_fetch.rs.
+See also https://github.com/dathere/qsv/wiki/HTTP-and-Web#fetch
 
 Usage:
     qsv fetch [<url-column> | --url-template <template>] [--jaq <selector> | --jaqfile <file>] [--http-header <k:v>...] [options] [<input>]

--- a/src/cmd/fetchpost.rs
+++ b/src/cmd/fetchpost.rs
@@ -139,6 +139,7 @@ Note that you can pass as many key-value pairs by using --http-header option rep
   $ qsv fetchpost https://httpbin.org/post col1-col3 data.csv -H "X-Api-Key:TEST_KEY" -H "X-Api-Secret:ABC123XYZ"
 
 For more extensive examples, see https://github.com/dathere/qsv/blob/master/tests/test_fetch.rs.
+See also https://github.com/dathere/qsv/wiki/HTTP-and-Web#fetchpost
 
 Usage:
     qsv fetchpost (<url-column>) (<column-list> | --payload-tpl <file>) [--jaq <selector> | --jaqfile <file>] [--http-header <k:v>...] [options] [<input>]

--- a/src/cmd/fill.rs
+++ b/src/cmd/fill.rs
@@ -32,6 +32,7 @@ re-ordered during output due to the buffering of rows
 collected before the first valid value.
 
 For examples, see https://github.com/dathere/qsv/blob/master/tests/test_fill.rs.
+See also https://github.com/dathere/qsv/wiki/Transform-and-Reshape#fill
 
 Usage:
     qsv fill [options] [--] <selection> [<input>]

--- a/src/cmd/fixlengths.rs
+++ b/src/cmd/fixlengths.rs
@@ -10,6 +10,8 @@ given must be a file and not stdin.
 Alternatively, if --length is set, then all records are forced to that length.
 This requires a single pass and can be done with stdin.
 
+See also https://github.com/dathere/qsv/wiki/Transform-and-Reshape#fixlengths
+
 Usage:
     qsv fixlengths [options] [<input>]
     qsv fixlengths --help

--- a/src/cmd/flatten.rs
+++ b/src/cmd/flatten.rs
@@ -8,6 +8,7 @@ There is also a condensed view (-c or --condense) that will shorten the
 contents of each field to provide a summary view.
 
 For examples, see https://github.com/dathere/qsv/blob/master/tests/test_flatten.rs.
+See also https://github.com/dathere/qsv/wiki/Selection-and-Inspection#flatten
 
 Usage:
     qsv flatten [options] [<input>]

--- a/src/cmd/fmt.rs
+++ b/src/cmd/fmt.rs
@@ -8,6 +8,7 @@ have a specific delimiter or record separator, and this is where 'qsv fmt' is
 useful.
 
 For examples, see https://github.com/dathere/qsv/blob/master/tests/test_fmt.rs.
+See also https://github.com/dathere/qsv/wiki/Transform-and-Reshape#fmt
 
 Usage:
     qsv fmt [options] [<input>]

--- a/src/cmd/foreach.rs
+++ b/src/cmd/foreach.rs
@@ -31,6 +31,7 @@ Same as above but with an additional column containing the current value:
   $ qsv foreach query -u -c from_query 'search {}' queries.csv > results.csv
 
 For more examples, see https://github.com/dathere/qsv/blob/master/tests/test_foreach.rs.
+See also https://github.com/dathere/qsv/wiki/Scripting-Luau-Python#foreach
 
 If any child command exits with a non-zero status, foreach finishes processing
 all rows but then exits with a non-zero status of its own.

--- a/src/cmd/frequency.rs
+++ b/src/cmd/frequency.rs
@@ -69,6 +69,7 @@ This is useful when you want to apply limits only to columns with a large number
 of unique items and not to columns with a small number of unique items.
 
 For examples, see https://github.com/dathere/qsv/blob/master/tests/test_frequency.rs.
+See also https://github.com/dathere/qsv/wiki/Aggregation-and-Statistics#frequency
 
 Usage:
     qsv frequency [options] [<input>]

--- a/src/cmd/geocode.rs
+++ b/src/cmd/geocode.rs
@@ -287,6 +287,7 @@ qsv geocode reverse wgs84_coordinate_col --country US -f \
     input_data.csv -o output_data_with_fips.csv
 
 For more examples, see https://github.com/dathere/qsv/blob/master/tests/test_geocode.rs.
+See also https://github.com/dathere/qsv/wiki/Geospatial#geocode
 
 Usage:
 qsv geocode suggest [--formatstr=<string>] [options] <column> [<input>]

--- a/src/cmd/geoconvert.rs
+++ b/src/cmd/geoconvert.rs
@@ -17,6 +17,8 @@ Alternatively specify the latitude and longitude columns with the --latitude and
 
   $ qsv geoconvert file.csv csv geojson --latitude lat --longitude lon
 
+See also https://github.com/dathere/qsv/wiki/Geospatial#geoconvert
+
 Usage:
     qsv geoconvert [options] (<input>) (<input-format>) (<output-format>)
     qsv geoconvert --help

--- a/src/cmd/headers.rs
+++ b/src/cmd/headers.rs
@@ -8,6 +8,7 @@ Note that multiple CSV files may be given to this command. This is useful with
 the --union flag.
 
 For examples, see https://github.com/dathere/qsv/blob/master/tests/test_headers.rs.
+See also https://github.com/dathere/qsv/wiki/Selection-and-Inspection#headers
 
 Usage:
     qsv headers [options] [<input>...]

--- a/src/cmd/implode.rs
+++ b/src/cmd/implode.rs
@@ -38,6 +38,8 @@ order keys are first seen. If the input is already sorted by the key column(s),
 use --sorted to stream groups as they are seen (memory proportional to the
 largest group, not the whole input).
 
+See also https://github.com/dathere/qsv/wiki/Transform-and-Reshape#implode
+
 Usage:
     qsv implode [options] -k <keys> -v <value> <separator> [<input>]
     qsv implode --help

--- a/src/cmd/index.rs
+++ b/src/cmd/index.rs
@@ -12,6 +12,8 @@ However, if the environment variable QSV_AUTOINDEX_SIZE is set, qsv will
 automatically create an index when the input file size >= specified size (bytes).
 It will also automatically update stale indices as well.
 
+See also https://github.com/dathere/qsv/wiki/Indexing-Compression-Diff#index
+
 Usage:
     qsv index [options] <input>
     qsv index --help

--- a/src/cmd/input.rs
+++ b/src/cmd/input.rs
@@ -24,6 +24,7 @@ This command is typically used at the beginning of a data pipeline (thus the nam
 to normalize & prepare CSVs for further processing with other qsv commands.
 
 For examples, see https://github.com/dathere/qsv/blob/master/tests/test_input.rs.
+See also https://github.com/dathere/qsv/wiki/Transform-and-Reshape#input
 
 Usage:
     qsv input [options] [<input>]

--- a/src/cmd/join.rs
+++ b/src/cmd/join.rs
@@ -9,6 +9,7 @@ joins are done case sensitively, but this can be disabled with the --ignore-case
 flag.
 
 For examples, see https://github.com/dathere/qsv/blob/master/tests/test_join.rs.
+See also https://github.com/dathere/qsv/wiki/Joins-and-Set-Ops#join
 
 Usage:
     qsv join [options] <columns1> <input1> <columns2> <input2>

--- a/src/cmd/joinp.rs
+++ b/src/cmd/joinp.rs
@@ -11,6 +11,7 @@ non-equi & asof joins and its output columns can be coalesced (no duplicate colu
 Returns the shape of the join result (number of rows, number of columns) to stderr.
 
 For examples, see https://github.com/dathere/qsv/blob/master/tests/test_joinp.rs.
+See also https://github.com/dathere/qsv/wiki/Joins-and-Set-Ops#joinp
 
 Usage:
     qsv joinp [options] <columns1> <input1> <columns2> <input2>

--- a/src/cmd/json.rs
+++ b/src/cmd/json.rs
@@ -123,6 +123,7 @@ We may run the following to select the JSON file and convert the nested array to
   $ qsv prompt -F json | qsv json --jaq .data
 
 For more examples, see https://github.com/dathere/qsv/blob/master/tests/test_json.rs.
+See also https://github.com/dathere/qsv/wiki/Conversion-and-IO#json
 
 Usage:
     qsv json [options] [<input>]

--- a/src/cmd/jsonl.rs
+++ b/src/cmd/jsonl.rs
@@ -9,6 +9,7 @@ Also, it will fail if the JSON documents are not consistent with one another,
 as the first JSON line will be used to infer the headers of the CSV output.
 
 For examples, see https://github.com/dathere/qsv/blob/master/tests/test_jsonl.rs.
+See also https://github.com/dathere/qsv/wiki/Conversion-and-IO#jsonl
 
 Usage:
     qsv jsonl [options] [<input>]

--- a/src/cmd/lens.rs
+++ b/src/cmd/lens.rs
@@ -10,6 +10,8 @@ its snappy-compressed variants (CSV.sz, TSV.sz, Tab.sz & SSV.sz).
 
 Press 'q' to exit. Press '?' for help.
 
+See also https://github.com/dathere/qsv/wiki/Selection-and-Inspection#lens
+
 Usage:
     qsv lens [options] [<input>]
     qsv lens --help

--- a/src/cmd/luau.rs
+++ b/src/cmd/luau.rs
@@ -166,6 +166,7 @@ Detailed descriptions of these helpers can be found in the "setup_helpers" secti
 the bottom of this file and on the Wiki (https://github.com/dathere/qsv/wiki)
 
 For more detailed examples, see https://github.com/dathere/qsv/blob/master/tests/test_luau.rs.
+See also https://github.com/dathere/qsv/wiki/Scripting-Luau-Python#luau
 
 Usage:
     qsv luau map [options] -n <main-script> [<input>]

--- a/src/cmd/moarstats.rs
+++ b/src/cmd/moarstats.rs
@@ -249,6 +249,7 @@ Examples:
   qsv moarstats data.csv --bivariate --join-inputs customers.csv,products.csv --join-keys cust_id,prod_id --join-type left
 
 For more examples, see https://github.com/dathere/qsv/blob/master/tests/test_moarstats.rs.
+See also https://github.com/dathere/qsv/wiki/Aggregation-and-Statistics#moarstats
 
 Usage:
     qsv moarstats [options] [<input>]

--- a/src/cmd/partition.rs
+++ b/src/cmd/partition.rs
@@ -25,6 +25,7 @@ will create the following files, each containing the data for each borough:
     nyc311-Staten_Island.csv
 
 For more examples, see https://github.com/dathere/qsv/blob/master/tests/test_partition.rs.
+See also https://github.com/dathere/qsv/wiki/Joins-and-Set-Ops#partition
 
 Usage:
     qsv partition [options] <column> <outdir> [<input>]

--- a/src/cmd/pivotp.rs
+++ b/src/cmd/pivotp.rs
@@ -16,6 +16,7 @@ GROUP-BY MODE (without <on-cols>):
   If --values is omitted, a single "count" column is produced.
 
 For examples, see https://github.com/dathere/qsv/blob/master/tests/test_pivotp.rs.
+See also https://github.com/dathere/qsv/wiki/SQL-and-Polars#pivotp
 
 Usage:
     qsv pivotp [options] <on-cols> <input>

--- a/src/cmd/pragmastat.rs
+++ b/src/cmd/pragmastat.rs
@@ -128,6 +128,8 @@ Full Pragmastat manual:
   https://github.com/AndreyAkinshin/pragmastat/releases/download/v12.1.0/pragmastat-v12.1.0.pdf
   https://pragmastat.dev/ (latest version)
 
+See also https://github.com/dathere/qsv/wiki/Aggregation-and-Statistics#pragmastat
+
 Usage:
     qsv pragmastat [options] [<input>]
     qsv pragmastat --help

--- a/src/cmd/pro.rs
+++ b/src/cmd/pro.rs
@@ -8,6 +8,8 @@ The qsv pro command has subcommands:
     lens:     Run csvlens on a local file in a new Alacritty terminal emulator window (Windows only).
     workflow: Import a local file into the qsv pro Workflow (Workflow must be open).
 
+See also https://github.com/dathere/qsv/wiki/Integrations#qsv-pro-bridge
+
 Usage:
     qsv pro lens [options] [<input>]
     qsv pro workflow [options] [<input>]

--- a/src/cmd/prompt.rs
+++ b/src/cmd/prompt.rs
@@ -15,6 +15,8 @@ Examples:
   qsv prompt -m 'Select a spreadsheet to export to CSV' -F xlsx,xls,ods | \
       qsv excel - | qsv prompt -m 'Save exported CSV to...' --fd-output
 
+See also https://github.com/dathere/qsv/wiki/Conversion-and-IO#prompt
+
 Usage:
     qsv prompt [options]
     qsv prompt --help

--- a/src/cmd/pseudo.rs
+++ b/src/cmd/pseudo.rs
@@ -41,6 +41,7 @@ ID-1000,cyan
 ```
 
 For more examples, see https://github.com/dathere/qsv/blob/master/tests/test_pseudo.rs.
+See also https://github.com/dathere/qsv/wiki/Transform-and-Reshape#pseudo
 
 Usage:
     qsv pseudo [options] <column> [<input>]

--- a/src/cmd/python.rs
+++ b/src/cmd/python.rs
@@ -81,6 +81,7 @@ Some usage examples:
   If any record has an invalid result, an exitcode of 1 is returned and an error count is logged.
 
 For more extensive examples, see https://github.com/dathere/qsv/blob/master/tests/test_py.rs.
+See also https://github.com/dathere/qsv/wiki/Scripting-Luau-Python#py
 
 Usage:
     qsv py map [options] -n <expression> [<input>]

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -27,6 +27,7 @@ Examples:
   $ qsv rename '"Date - Opening","Date - Actual Closing"'
 
 For more examples, see https://github.com/dathere/qsv/blob/master/tests/test_rename.rs.
+See also https://github.com/dathere/qsv/wiki/Transform-and-Reshape#rename
 
 Usage:
     qsv rename [options] [--] <headers> [<input>]

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -38,6 +38,7 @@ with '<EMAIL>' in the file.csv file.
 
 
 For more examples, see https://github.com/dathere/qsv/blob/master/tests/test_replace.rs.
+See also https://github.com/dathere/qsv/wiki/Transform-and-Reshape#replace
 
 Usage:
     qsv replace [options] <pattern> <replacement> [<input>]

--- a/src/cmd/reverse.rs
+++ b/src/cmd/reverse.rs
@@ -7,6 +7,8 @@ or when keys are not unique and order of rows with the same key needs to be pres
 Note that if the CSV is not indexed, this operation will require reading all of the
 CSV data into memory
 
+See also https://github.com/dathere/qsv/wiki/Transform-and-Reshape#reverse
+
 Usage:
     qsv reverse [options] [<input>]
     qsv reverse --help

--- a/src/cmd/safenames.rs
+++ b/src/cmd/safenames.rs
@@ -58,6 +58,7 @@ It is discouraged because the embedded spaces can cause problems later on.
 (see https://lerner.co.il/2013/11/30/quoting-postgresql/ for more info).
 
 For more examples, see https://github.com/dathere/qsv/blob/master/tests/test_safenames.rs.
+See also https://github.com/dathere/qsv/wiki/Transform-and-Reshape#safenames
 
 Usage:
     qsv safenames [options] [<input>]

--- a/src/cmd/sample.rs
+++ b/src/cmd/sample.rs
@@ -154,6 +154,7 @@ Examples:
   qsv sample --sketch-in a.sk,b.sk 1000 -o merged.csv
 
 For more examples, see https://github.com/dathere/qsv/blob/master/tests/test_sample.rs.
+See also https://github.com/dathere/qsv/wiki/Selection-and-Inspection#sample
 
 Usage:
     qsv sample [options] <sample-size> [<input>]

--- a/src/cmd/schema.rs
+++ b/src/cmd/schema.rs
@@ -48,6 +48,7 @@ Polars to optimize the query and gives the user the option to tailor the schema 
 query needs (e.g. using a Decimal type with explicit precision and scale instead of a Float type).
 
 For examples, see https://github.com/dathere/qsv/blob/master/tests/test_schema.rs.
+See also https://github.com/dathere/qsv/wiki/Validation-and-Schema#schema
 
 Usage:
     qsv schema [options] [<input>]

--- a/src/cmd/scoresql.rs
+++ b/src/cmd/scoresql.rs
@@ -38,6 +38,7 @@ Examples:
   $ qsv scoresql data.csv script.sql
 
 For more examples, see https://github.com/dathere/qsv/blob/master/tests/test_scoresql.rs.
+See also https://github.com/dathere/qsv/wiki/SQL-and-Polars#scoresql
 
 Usage:
     qsv scoresql [options] <input>... <sql>

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -43,6 +43,7 @@ Examples:
   qsv search --preview-match 5 'warning' data.csv
 
 For examples, see https://github.com/dathere/qsv/blob/master/tests/test_search.rs.
+See also https://github.com/dathere/qsv/wiki/Selection-and-Inspection#search
 
 Usage:
     qsv search [options] <regex> [<input>]

--- a/src/cmd/searchset.rs
+++ b/src/cmd/searchset.rs
@@ -27,6 +27,7 @@ the first match.
 When the CSV is indexed, a faster parallel search is used.
 
 For examples, see https://github.com/dathere/qsv/blob/master/tests/test_searchset.rs.
+See also https://github.com/dathere/qsv/wiki/Selection-and-Inspection#searchset
 
 Usage:
     qsv searchset [options] (<regexset-file>) [<input>]

--- a/src/cmd/select.rs
+++ b/src/cmd/select.rs
@@ -64,6 +64,7 @@ Examples:
   qsv select '\"Date - Opening\",\"Date - Actual Closing\"'
 
 For more examples, see https://github.com/dathere/qsv/blob/master/tests/test_select.rs.
+See also https://github.com/dathere/qsv/wiki/Selection-and-Inspection#select
 
 Usage:
     qsv select [options] [--] <selection> [<input>]

--- a/src/cmd/slice.rs
+++ b/src/cmd/slice.rs
@@ -49,6 +49,7 @@ Examples:
   qsv slice --start 9 --len 10 --invert --json data.csv
 
 For more examples, see https://github.com/dathere/qsv/blob/master/tests/test_slice.rs.
+See also https://github.com/dathere/qsv/wiki/Selection-and-Inspection#slice
 
 Usage:
     qsv slice [options] [<input>]

--- a/src/cmd/snappy.rs
+++ b/src/cmd/snappy.rs
@@ -23,6 +23,7 @@ single-threaded compression.
 Also, this command is not specific to CSV data, it can compress/decompress ANY file.
 
 For examples, see https://github.com/dathere/qsv/blob/master/tests/test_snappy.rs.
+See also https://github.com/dathere/qsv/wiki/Conversion-and-IO#snappy
 
 Usage:
     qsv snappy compress [options] [<input>]

--- a/src/cmd/sniff.rs
+++ b/src/cmd/sniff.rs
@@ -43,6 +43,7 @@ Examples:
   qsv sniff --sample 0.20 data.ssv
 
 For examples, see https://github.com/dathere/qsv/blob/master/tests/test_sniff.rs.
+See also https://github.com/dathere/qsv/wiki/Selection-and-Inspection#sniff
 
 Usage:
     qsv sniff [options] [<input>]

--- a/src/cmd/sort.rs
+++ b/src/cmd/sort.rs
@@ -6,6 +6,7 @@ you need to sort a large file that may not fit into memory, use the
 extsort command instead.
 
 For examples, see https://github.com/dathere/qsv/blob/master/tests/test_sort.rs.
+See also https://github.com/dathere/qsv/wiki/Transform-and-Reshape#sort
 
 Usage:
     qsv sort [options] [<input>]

--- a/src/cmd/sortcheck.rs
+++ b/src/cmd/sortcheck.rs
@@ -39,6 +39,7 @@ Examples:
   qsv sortcheck --natural --json file.csv
 
 For examples, see https://github.com/dathere/qsv/blob/master/tests/test_sortcheck.rs.
+See also https://github.com/dathere/qsv/wiki/Transform-and-Reshape#sortcheck
 
 Usage:
     qsv sortcheck [options] [<input>]

--- a/src/cmd/split.rs
+++ b/src/cmd/split.rs
@@ -62,6 +62,7 @@ Examples:
   qsv split outdir --filter "powershell Compress-Archive -Path $FILE -Destination {}.zip" input.csv
 
 For more examples, see https://github.com/dathere/qsv/blob/master/tests/test_split.rs.
+See also https://github.com/dathere/qsv/wiki/Joins-and-Set-Ops#split
 
 Usage:
     qsv split [options] (--size <arg> | --chunks <arg> | --kb-size <arg>) <outdir> [<input>]

--- a/src/cmd/sqlp.rs
+++ b/src/cmd/sqlp.rs
@@ -154,6 +154,7 @@ Examples:
   $ qsv sqlp data.csv 'explain select * from data where col1 > 10 order by col2 desc limit 20'
 
 For more examples, see https://github.com/dathere/qsv/blob/master/tests/test_sqlp.rs.
+See also https://github.com/dathere/qsv/wiki/SQL-and-Polars#sqlp
 
 Usage:
     qsv sqlp [options] <input>... <sql>

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -125,6 +125,7 @@ Examples:
   qsv stats -E --cache-threshold -5000005 nyc311.csv
 
 For more examples, see https://github.com/dathere/qsv/tree/master/resources/test
+See also https://github.com/dathere/qsv/wiki/Aggregation-and-Statistics#stats
 
 If the polars feature is enabled, support additional tabular file formats and
 compression formats:

--- a/src/cmd/synthesize/mod.rs
+++ b/src/cmd/synthesize/mod.rs
@@ -73,6 +73,7 @@ Examples:
   $ qsv synthesize data.csv --dictionary dict.json -n 1000 > synthetic.csv
 
 For more examples, see https://github.com/dathere/qsv/blob/master/tests/test_synthesize.rs.
+See also https://github.com/dathere/qsv/wiki/AI-and-Documentation#synthesize
 
 Usage:
     qsv synthesize [options] <input>

--- a/src/cmd/table.rs
+++ b/src/cmd/table.rs
@@ -15,6 +15,8 @@ Note that formatting a table requires buffering all CSV data into memory.
 Therefore, you should use the 'sample' or 'slice' command to trim down large
 CSV data before formatting it with this command.
 
+See also https://github.com/dathere/qsv/wiki/Selection-and-Inspection#table
+
 Usage:
     qsv table [options] [<input>]
     qsv table --help

--- a/src/cmd/template.rs
+++ b/src/cmd/template.rs
@@ -75,6 +75,7 @@ coalesce(a, b, ...)                  First argument that is not undefined/none/e
 ```
 
 For more examples, see https://github.com/dathere/qsv/blob/master/tests/test_template.rs.
+See also https://github.com/dathere/qsv/wiki/Scripting-Luau-Python#template
 For a relatively complex MiniJinja template, see https://github.com/dathere/qsv/blob/master/scripts/template.tpl
 
 Usage:

--- a/src/cmd/to.rs
+++ b/src/cmd/to.rs
@@ -209,6 +209,7 @@ For all other conversions you can output the datapackage created by specifying `
   $ qsv to xlsx datapackage.xlsx --stats --print-package file1.csv file2.csv
 
 For more examples, see https://github.com/dathere/qsv/blob/master/tests/test_to.rs.
+See also https://github.com/dathere/qsv/wiki/Conversion-and-IO#to
 
 Usage:
     qsv to parquet [options] <destination> [<input>...]

--- a/src/cmd/tojsonl.rs
+++ b/src/cmd/tojsonl.rs
@@ -13,6 +13,7 @@ current (i.e. stats generated with --cardinality and --infer-dates options) and 
 skip recomputing stats.
 
 For examples, see https://github.com/dathere/qsv/blob/master/tests/test_tojsonl.rs.
+See also https://github.com/dathere/qsv/wiki/Conversion-and-IO#tojsonl
 
 Usage:
     qsv tojsonl [options] [<input>]

--- a/src/cmd/transpose.rs
+++ b/src/cmd/transpose.rs
@@ -28,6 +28,7 @@ Examples:
     $ qsv transpose --long /^name/ data.csv
 
 See https://github.com/dathere/qsv/blob/master/tests/test_transpose.rs for more examples.
+See also https://github.com/dathere/qsv/wiki/Transform-and-Reshape#transpose
 
 transpose options:
     -m, --multipass        Process the transpose by making multiple passes

--- a/src/cmd/validate.rs
+++ b/src/cmd/validate.rs
@@ -178,6 +178,7 @@ Examples:
 
 For more examples, see the tests included in this file (denoted by '#[test]') or see
 https://github.com/dathere/qsv/blob/master/tests/test_validate.rs.
+See also https://github.com/dathere/qsv/wiki/Validation-and-Schema#validate
 
 Usage:
     qsv validate schema [--no-format-validation] [<json-schema>]


### PR DESCRIPTION
## What

Adds a companion **Wiki link** to every command's `USAGE` prose, alongside the existing "For examples, see …/tests/test_<cmd>.rs" test-file link. Now that the Wiki is fully populated, each command's `--help` (and the generated `docs/help/*.md`) points to its narrative docs:

```
See also https://github.com/dathere/qsv/wiki/<Category>#<cmd>
```

## How

- The Wiki is **topic-based** (no per-command pages), so each link targets the command's `## ` heading anchor on its **category page** (e.g. `Aggregation-and-Statistics#stats`). Mapping derived from the `## \`cmd\`` headings across the 13 category pages, matching `Command-Reference.md`.
- Covers **all 72 commands** that have a Wiki entry:
  - placed immediately **after** the existing test-file line where present;
  - **standalone** before the `Usage:` section for the ~17 commands without one (e.g. `behead`, `edit`, `extsort`, `geoconvert`, `pragmastat`, `table`).
- Special cases handled:
  - `enum` / `py` (source file name ≠ command name);
  - `pro` → `Integrations#qsv-pro-bridge`;
  - 7 cross-listed commands routed to their **primary** category (e.g. `geoconvert` → Geospatial, `joinp` → Joins-and-Set-Ops, `sniff` → Selection-and-Inspection).
- `docs/help/*.md` regenerated via `qsv --generate-help-md` (renders as autolinked `See also <…>`). ToC unchanged (no new commands). MCP skill JSONs unaffected (the link lives in prose, not flag descriptions).

## Verification

- `cargo build --bin qsv -F all_features` clean.
- `qsv stats|behead|enum|pro --help` show the correct `See also` line.
- 72 `See also` wiki lines present in both `src/cmd/*.rs` and `docs/help/*.md`.
- Sampled anchors (`#stats`, `#behead`, `#enum`, `#qsv-pro-bridge`) resolve against the live Wiki pages.

## Diff

144 files: 72 `src/cmd/*.rs` + 72 `docs/help/*.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)