### PR TITLE
docs(help): add Wiki "See also" link to profile command

### DIFF
--- a/docs/help/profile.md
+++ b/docs/help/profile.md
@@ -43,6 +43,7 @@ For an example CKAN scheming YAML spec, see:
 <https://github.com/dathere/datapusher-plus/blob/main/ckanext/datapusher_plus/dataset-druf.yaml>
 
 For more extensive examples, see <https://github.com/dathere/qsv/blob/master/tests/test_profile.rs>.
+See also <https://github.com/dathere/qsv/wiki/Metadata-Profiling>
 
 
 <a name="examples"></a>

--- a/src/cmd/profile.rs
+++ b/src/cmd/profile.rs
@@ -31,6 +31,7 @@ For an example CKAN scheming YAML spec, see:
   https://github.com/dathere/datapusher-plus/blob/main/ckanext/datapusher_plus/dataset-druf.yaml
 
 For more extensive examples, see https://github.com/dathere/qsv/blob/master/tests/test_profile.rs.
+See also https://github.com/dathere/qsv/wiki/Metadata-Profiling
 
 Examples:
 


### PR DESCRIPTION
Follow-up to #3928 (already merged), addressing roborev review #2645.

## What

The per-command Wiki "See also" pass in #3928 missed the public **`profile`** command, so `qsv profile --help` and `docs/help/profile.md` lacked the cross-link.

## Why it was missed

`profile`'s Wiki entry is a **whole dedicated page** (`Metadata-Profiling`, H1 `# Metadata Profiling (\`profile\`)`) rather than a `## <cmd>` anchor on a shared category page. The mapping in #3928 was derived from the `## \`cmd\`` headings, so the page-level command was skipped.

## Fix

Add the page-level link (matching `Command-Reference.md`'s `[profile](Metadata-Profiling)`):

```
See also https://github.com/dathere/qsv/wiki/Metadata-Profiling
```

placed after profile's existing test-file line in `src/cmd/profile.rs`; `docs/help/profile.md` regenerated via `qsv --generate-help-md`.

## Verification

- `cargo build --bin qsv -F all_features` clean.
- `qsv profile --help` shows the `See also` line.
- `docs/help/profile.md` renders the autolinked `See also <…/Metadata-Profiling>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)