### PR TITLE
fix(describegpt): semanticmd review follow-ups for #3935 (stats/validation gating + tests)

### DIFF
--- a/docs/describegpt/nyc311-describegpt-semanticmd.md
+++ b/docs/describegpt/nyc311-describegpt-semanticmd.md
@@ -2,14 +2,14 @@
 semantic-md: datadict.yaml
 dataset:
   id: NYC_311_SR_2010-2020-sample-1M
-  title: NYC 311 SR 2010 2020 sample 1M
+  title: "NYC 311 SR 2010 2020 sample 1M"
   row_count: 1000000
   grain: "one row = one NYC 311 complaint record"
-  source: https://data.cityofnewyork.us/Social-Services/311-Service-Requests-from-2010-to-Present/erm2-nwe9
-  updated: 2020-12-23
-  license: NYC Open Data Terms of Use
+  source: "https://data.cityofnewyork.us/Social-Services/311-Service-Requests-from-2010-to-Present/erm2-nwe9"
+  updated: "2020-12-23"
+  license: "NYC Open Data Terms of Use"
   temporal_coverage: { column: "Created Date", start: "2010-01-01T00:00:00+00:00", end: "2020-12-23T01:25:51+00:00" }
-  spatial: { crs: "EPSG:4326", lat: "Latitude", lon: "Longitude" }
+  spatial: { crs: "EPSG:4326", lat: Latitude, lon: Longitude }
 concepts:
   - category.channel
   - category.status

--- a/resources/describegpt_md_defaults.toml
+++ b/resources/describegpt_md_defaults.toml
@@ -188,6 +188,8 @@ dataset:
 {% if entry.validation.max %}- Values <= {{ entry.validation.max }}
 {% endif -%}
 {% if entry.validation.min_length and entry.validation.max_length %}- Length {{ entry.validation.min_length }}–{{ entry.validation.max_length }}
+{% elif entry.validation.min_length %}- Length >= {{ entry.validation.min_length }}
+{% elif entry.validation.max_length %}- Length <= {{ entry.validation.max_length }}
 {% endif -%}
 {% endif -%}
 {% if entry.choices %}

--- a/src/cmd/describegpt.rs
+++ b/src/cmd/describegpt.rs
@@ -7058,6 +7058,126 @@ p_fewshot_examples = ""
     }
 
     #[test]
+    fn semanticmd_sparsity_only_stats_and_single_sided_length_render() {
+        use indexmap::IndexMap;
+
+        // Regression coverage for two review-driven edge cases:
+        //   1. a numeric column whose ONLY retained stat is `sparsity` must still render the
+        //      per-column ### Statistics block (has_stats gating), and
+        //   2. a text column with only one of min_length / max_length must render a single-sided
+        //      Length constraint (the template's elif branches), never an empty ### Validation
+        //      block.
+        let mut args = default_args_for_test();
+        args.flag_base_url = Some(DEFAULT_BASE_URL.to_string());
+        args.flag_model = Some(DEFAULT_MODEL.to_string());
+        args.arg_input = Some("data/edge.csv".to_string());
+        let model = "openai/gpt-oss-20b";
+        let base_url = "http://localhost:11434/v1";
+
+        let mut sparsity_only = IndexMap::new();
+        sparsity_only.insert("sparsity".to_string(), "0.42".to_string());
+        let mut min_len_only = IndexMap::new();
+        min_len_only.insert("min_length".to_string(), "3".to_string());
+        let mut max_len_only = IndexMap::new();
+        max_len_only.insert("max_length".to_string(), "50".to_string());
+
+        let entries = vec![
+            // Numeric column with only `sparsity` retained (no mean/median/etc.).
+            dictionary::DictionaryEntry {
+                name:         "score".to_string(),
+                r#type:       "Integer".to_string(),
+                label:        "Score".to_string(),
+                description:  "A numeric score.".to_string(),
+                content_type: String::new(),
+                min:          String::new(),
+                max:          String::new(),
+                cardinality:  500,
+                enumeration:  String::new(),
+                null_count:   0,
+                addl_cols:    sparsity_only,
+                examples:     String::new(),
+                freq_details: Vec::new(),
+                is_unique_id: false,
+                concept:      String::new(),
+                role:         String::new(),
+            },
+            // Text column with only `min_length` retained.
+            dictionary::DictionaryEntry {
+                name:         "code".to_string(),
+                r#type:       "String".to_string(),
+                label:        "Code".to_string(),
+                description:  "A short code.".to_string(),
+                content_type: String::new(),
+                min:          String::new(),
+                max:          String::new(),
+                cardinality:  20,
+                enumeration:  String::new(),
+                null_count:   0,
+                addl_cols:    min_len_only,
+                examples:     String::new(),
+                freq_details: Vec::new(),
+                is_unique_id: false,
+                concept:      String::new(),
+                role:         String::new(),
+            },
+            // Text column with only `max_length` retained.
+            dictionary::DictionaryEntry {
+                name:         "note".to_string(),
+                r#type:       "String".to_string(),
+                label:        "Note".to_string(),
+                description:  "A free-text note.".to_string(),
+                content_type: String::new(),
+                min:          String::new(),
+                max:          String::new(),
+                cardinality:  100,
+                enumeration:  String::new(),
+                null_count:   0,
+                addl_cols:    max_len_only,
+                examples:     String::new(),
+                freq_details: Vec::new(),
+                is_unique_id: false,
+                concept:      String::new(),
+                role:         String::new(),
+            },
+        ];
+
+        let shared = SharedRenderCtx::new(&args, model, base_url, PromptType::Dictionary);
+        let rendered =
+            render_semanticmd_body(&args, &entries, None, model, base_url, &shared).unwrap();
+
+        // 1. sparsity-only numeric column still emits the Statistics block, with the other (empty)
+        //    stat cells collapsed and the sparsity value in place.
+        assert!(
+            rendered.contains("## Column `score`"),
+            "score column section missing:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("### Statistics"),
+            "sparsity-only numeric column must still render ### Statistics:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("|  |  |  |  |  |  |  |  | 0.42 |"),
+            "sparsity-only statistics row not rendered as expected:\n{rendered}"
+        );
+
+        // 2a. min_length-only text column renders a single-sided lower bound.
+        assert!(
+            rendered.contains("### Validation\n\n- Length >= 3"),
+            "min_length-only column must render `- Length >= 3`:\n{rendered}"
+        );
+        // 2b. max_length-only text column renders a single-sided upper bound.
+        assert!(
+            rendered.contains("### Validation\n\n- Length <= 50"),
+            "max_length-only column must render `- Length <= 50`:\n{rendered}"
+        );
+        // Neither single-sided column should produce the both-bounds `Length a–b` form.
+        assert!(
+            !rendered.contains("- Length 3–"),
+            "single-sided length must not emit the combined range form:\n{rendered}"
+        );
+    }
+
+    #[test]
     fn semanticmd_pipe_in_column_name_is_escaped() {
         use indexmap::IndexMap;
 

--- a/src/cmd/describegpt/formatters.rs
+++ b/src/cmd/describegpt/formatters.rs
@@ -1583,4 +1583,60 @@ mod tests {
             "high-cardinality / constant columns must not be inferred as a primary key"
         );
     }
+
+    #[test]
+    fn semanticmd_has_stats_with_sparsity_only() {
+        use indexmap::IndexMap;
+
+        // A numeric column whose ONLY retained stat is `sparsity` (e.g. via a
+        // custom `--addl-cols-list`) must still render the ### Statistics block,
+        // since Sparsity is a column in that table.
+        let mut e = sample_entry("score", "");
+        e.r#type = "Integer".to_string();
+        let mut addl = IndexMap::new();
+        addl.insert("sparsity".to_string(), "0.42".to_string());
+        e.addl_cols = addl;
+
+        let entry = build_semanticmd_entry(&e, None);
+        assert!(entry.is_numeric);
+        assert!(
+            entry.has_stats,
+            "a numeric column whose only retained stat is sparsity must set has_stats"
+        );
+        assert_eq!(entry.stats.sparsity, "0.42");
+        assert!(entry.stats.mean.is_empty() && entry.stats.median.is_empty());
+
+        // Contrast: a numeric column with no retained stats has no Statistics block.
+        let mut bare = sample_entry("n", "");
+        bare.r#type = "Integer".to_string();
+        assert!(!build_semanticmd_entry(&bare, None).has_stats);
+    }
+
+    #[test]
+    fn semanticmd_validation_single_sided_length() {
+        use indexmap::IndexMap;
+
+        // Text column with ONLY min_length retained => has_validation true, the
+        // template renders `- Length >= …` (no empty ### Validation block).
+        let mut min_only = sample_entry("code", "");
+        let mut a = IndexMap::new();
+        a.insert("min_length".to_string(), "3".to_string());
+        min_only.addl_cols = a;
+        let min_e = build_semanticmd_entry(&min_only, None);
+        assert!(!min_e.is_numeric);
+        assert!(min_e.has_validation);
+        assert_eq!(min_e.validation.min_length, "3");
+        assert!(min_e.validation.max_length.is_empty());
+
+        // Text column with ONLY max_length retained => has_validation true, the
+        // template renders `- Length <= …`.
+        let mut max_only = sample_entry("note", "");
+        let mut b = IndexMap::new();
+        b.insert("max_length".to_string(), "50".to_string());
+        max_only.addl_cols = b;
+        let max_e = build_semanticmd_entry(&max_only, None);
+        assert!(max_e.has_validation);
+        assert_eq!(max_e.validation.max_length, "50");
+        assert!(max_e.validation.min_length.is_empty());
+    }
 }

--- a/src/cmd/describegpt/formatters.rs
+++ b/src/cmd/describegpt/formatters.rs
@@ -793,6 +793,7 @@ fn build_semanticmd_entry(e: &DictionaryEntry, primary_key: Option<&str>) -> Sem
             &stats.skewness,
             &stats.lower_fence,
             &stats.upper_fence,
+            &stats.sparsity,
         ]
         .iter()
         .any(|s| !s.is_empty());


### PR DESCRIPTION
Follow-up fixes for the semanticmd Data Dictionary work that was squash-merged in #3935. These two commits were made locally after the squash-merge and weren't part of that PR, so they're landing here.

## What changed

**Review fixes (Copilot review of #3935):**
- `has_stats` now considers `stats.sparsity`, so a column whose only retained stat is `sparsity` (e.g. via a custom `--addl-cols-list`) still renders the `### Statistics` block — consistent with the Sparsity column the table renders.
- The SemanticMd template renders the length constraint gracefully when only one of `min_length`/`max_length` is present (`- Length >= N` / `- Length <= N` via minijinja `elif`), avoiding an empty `### Validation` block.
- The committed reference doc frontmatter now matches actual `yaml_scalar` output: URL, spaced `title`/`license`, and the `YYYY-MM-DD` date are quoted; plain `lat`/`lon` are unquoted.

**Regression tests (roborev follow-up):**
- `formatters` unit tests: `build_semanticmd_entry` sets `has_stats` for a sparsity-only numeric column, and `has_validation` for a text column with only one of `min_length`/`max_length`.
- `describegpt` render test: a full semanticmd render asserting the `### Statistics` block appears for a sparsity-only numeric column and the `elif` length branches emit `- Length >= N` / `- Length <= N` (never an empty `### Validation` block).

## Verification
- `cargo +nightly fmt` clean
- `cargo test -F all_features describegpt` — 77 integration + semanticmd unit tests pass (3 new)
- `cargo clippy -F all_features --bin qsv` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)