### PR TITLE
fix(clippy): resolve clippy 1.96 fallout (approx_constant error + ~375 test warnings)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories    = ["command-line-utilities", "parser-implementations"]
 license       = "MIT OR Unlicense"
 autotests     = false
 edition       = "2024"
-rust-version  = "1.95"
+rust-version  = "1.96"
 resolver      = "3"
 autobins      = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,39 @@ required-features = ["datapusher_plus"]
 name = "tests"
 path = "tests/tests.rs"
 
+[lints.clippy]
+cast_possible_truncation = "allow"
+cast_possible_wrap       = "allow"
+cast_sign_loss           = "allow"
+# things are often more readable this way
+needless_raw_string_hashes = "allow"
+cast_lossless              = "allow"
+module_name_repetitions    = "allow"
+type_complexity            = "allow"
+zero_prefixed_literal      = "allow"
+# correctly used
+enum_glob_use   = "allow"
+result_unit_err = "allow"
+# not practical
+similar_names         = "allow"
+too_many_lines        = "allow"
+struct_excessive_bools = "allow"
+# preference
+doc_markdown       = "allow"
+unnecessary_wraps  = "allow"
+# false positive
+needless_doctest_main = "allow"
+# noisy
+missing_errors_doc   = "allow"
+use_self             = "allow"
+cognitive_complexity = "allow"
+option_if_let_else   = "allow"
+implicit_clone       = "allow"
+# pub(crate) documents crate-internal intent; equivalent to pub only because the module is private
+redundant_pub_crate = "allow"
+# warned
+missing_asserts_for_indexing = "warn"
+
 [profile.release]
 codegen-units = 1
 debug         = false

--- a/src/cmd/describegpt/dictionary.rs
+++ b/src/cmd/describegpt/dictionary.rs
@@ -909,9 +909,7 @@ pub(super) fn generate_code_based_dictionary(
         // (`identifier`) and the stats Date/DateTime type (`timestamp`). The LLM
         // fills/refines empty or non-authoritative values in
         // `combine_dictionary_entries`.
-        let (concept, role) = if !infer_content_type {
-            (String::new(), String::new())
-        } else {
+        let (concept, role) = if infer_content_type {
             let concept = concept_from_content_type(content_type_base(&content_type))
                 .map(ToString::to_string)
                 .unwrap_or_default();
@@ -924,6 +922,8 @@ pub(super) fn generate_code_based_dictionary(
                 }
             };
             (concept, role)
+        } else {
+            (String::new(), String::new())
         };
 
         dictionary_entries.push(DictionaryEntry {

--- a/src/cmd/excel.rs
+++ b/src/cmd/excel.rs
@@ -1286,7 +1286,7 @@ mod tests {
 
     #[test]
     fn float_to_i64_safe_non_integer() {
-        assert_eq!(float_to_i64_safe(3.14), None);
+        assert_eq!(float_to_i64_safe(3.5), None);
         assert_eq!(float_to_i64_safe(0.5), None);
         assert_eq!(float_to_i64_safe(-0.001), None);
     }

--- a/src/cmd/moarstats.rs
+++ b/src/cmd/moarstats.rs
@@ -6024,12 +6024,14 @@ mod tests {
     #[test]
     fn outlier_count_indices_are_in_range() {
         // Guard against a refactor changing these without updating COUNTS_LEN.
-        assert!(OUTLIER_EXTREME_LOWER < OUTLIER_COUNTS_LEN);
-        assert!(OUTLIER_MILD_LOWER < OUTLIER_COUNTS_LEN);
-        assert!(OUTLIER_NORMAL < OUTLIER_COUNTS_LEN);
-        assert!(OUTLIER_MILD_UPPER < OUTLIER_COUNTS_LEN);
-        assert!(OUTLIER_EXTREME_UPPER < OUTLIER_COUNTS_LEN);
-        assert!(OUTLIER_TOTAL < OUTLIER_COUNTS_LEN);
+        const {
+            assert!(OUTLIER_EXTREME_LOWER < OUTLIER_COUNTS_LEN);
+            assert!(OUTLIER_MILD_LOWER < OUTLIER_COUNTS_LEN);
+            assert!(OUTLIER_NORMAL < OUTLIER_COUNTS_LEN);
+            assert!(OUTLIER_MILD_UPPER < OUTLIER_COUNTS_LEN);
+            assert!(OUTLIER_EXTREME_UPPER < OUTLIER_COUNTS_LEN);
+            assert!(OUTLIER_TOTAL < OUTLIER_COUNTS_LEN);
+        }
     }
 
     // ---------------------------------------------------------------------

--- a/src/help_markdown_gen.rs
+++ b/src/help_markdown_gen.rs
@@ -2831,8 +2831,8 @@ Usage:
         assert_eq!(m.get("--dates-whitelist").copied(), Some("string"));
         assert_eq!(m.get("--delimiter").copied(), Some("string"));
         // Positional `arg_*` and subcommand `cmd_*` fields must be skipped.
-        assert!(m.get("--input").is_none());
-        assert!(m.get("--view").is_none());
+        assert!(!m.contains_key("--input"));
+        assert!(!m.contains_key("--view"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,39 +1,3 @@
-#![cfg_attr(
-    clippy,
-    allow(
-        clippy::cast_possible_truncation,
-        clippy::cast_possible_wrap,
-        clippy::cast_sign_loss,
-        // things are often more readable this way
-        clippy::needless_raw_string_hashes,
-        clippy::cast_lossless,
-        clippy::module_name_repetitions,
-        clippy::type_complexity,
-        clippy::zero_prefixed_literal,
-        // correctly used
-        clippy::enum_glob_use,
-        clippy::result_unit_err,
-        // not practical
-        clippy::similar_names,
-        clippy::too_many_lines,
-        clippy::struct_excessive_bools,
-        // preference
-        clippy::doc_markdown,
-        clippy::unnecessary_wraps,
-        // false positive
-        clippy::needless_doctest_main,
-        // noisy
-        clippy::missing_errors_doc,
-        clippy::use_self,
-        clippy::cognitive_complexity,
-        clippy::option_if_let_else,
-        clippy::implicit_clone,
-    ),
-    warn(
-        clippy::missing_asserts_for_indexing,
-    )
-)]
-
 use std::{env, io, time::Instant};
 
 extern crate qsv_docopt as docopt;

--- a/tests/test_cat.rs
+++ b/tests/test_cat.rs
@@ -617,7 +617,7 @@ fn cat_rowskey_grouping_customname() {
     let mut cmd = wrk.command("cat");
     cmd.arg("rowskey")
         .args(["--group", "fstem"])
-        .args(&["--group-name", "file group label"])
+        .args(["--group-name", "file group label"])
         .arg("in1.csv")
         .arg("in2.csv")
         .arg("in3.csv");

--- a/tests/test_color.rs
+++ b/tests/test_color.rs
@@ -355,5 +355,5 @@ data1,data2,d3";
     let got = wrk_stdout(INPUT, "50");
 
     // Headers should be truncated to fit
-    assert!(got.contains("…") || got.len() > 0);
+    assert!(got.contains("…") || !got.is_empty());
 }

--- a/tests/test_describegpt.rs
+++ b/tests/test_describegpt.rs
@@ -202,7 +202,7 @@ fn describegpt_valid_json() {
     let got = wrk.stdout::<String>(&mut cmd);
     match serde_json::from_str::<serde_json::Value>(&got) {
         Ok(_) => (),
-        Err(e) => assert!(false, "Error parsing JSON: {e}"),
+        Err(e) => panic!("Error parsing JSON: {e}"),
     }
 
     // Check that the command ran successfully
@@ -716,7 +716,7 @@ fn describegpt_output_to_file_json() {
     let output_content = std::fs::read_to_string(wrk.path("output.json")).unwrap();
     match serde_json::from_str::<serde_json::Value>(&output_content) {
         Ok(_) => (),
-        Err(e) => assert!(false, "Error parsing JSON from output file: {e}"),
+        Err(e) => panic!("Error parsing JSON from output file: {e}"),
     }
 }
 
@@ -972,7 +972,7 @@ fn describegpt_larger_dataset() {
     let got = wrk.stdout::<String>(&mut cmd);
     match serde_json::from_str::<serde_json::Value>(&got) {
         Ok(_) => (),
-        Err(e) => assert!(false, "Error parsing JSON: {e}"),
+        Err(e) => panic!("Error parsing JSON: {e}"),
     }
 
     // Check that the command ran successfully
@@ -1246,13 +1246,12 @@ fn test_base_url_flag_is_respected_issue_2976() {
     // The error should mention the Together AI URL, not OpenAI's URL
     // This confirms that the base URL flag is being respected
     if stderr.contains("together") || stderr.contains("HTTP") {
-        // The base URL is being used correctly
-        assert!(true, "Base URL flag is being respected");
+        // The base URL is being used correctly (respected)
     } else if stderr.contains("openai") {
         panic!("Base URL flag is not being respected - still using OpenAI URL");
     } else {
-        // Some other error occurred, which is fine for this test
-        assert!(true, "Base URL flag appears to be working");
+        // Some other error occurred, which is fine for this test (base URL flag appears to be
+        // working)
     }
 }
 

--- a/tests/test_describegpt.rs
+++ b/tests/test_describegpt.rs
@@ -40,32 +40,27 @@ fn is_local_llm_available() -> bool {
                         }
 
                         // Parse the JSON response to check for required models
-                        if let Ok(response_str) = String::from_utf8(output.stdout) {
-                            if let Ok(json_value) =
+                        if let Ok(response_str) = String::from_utf8(output.stdout)
+                            && let Ok(json_value) =
                                 serde_json::from_str::<serde_json::Value>(&response_str)
-                            {
-                                if let Some(data) = json_value.get("data") {
-                                    if let Some(models) = data.as_array() {
-                                        let mut has_deepseek = false;
-                                        let mut has_openai = false;
+                            && let Some(data) = json_value.get("data")
+                            && let Some(models) = data.as_array()
+                        {
+                            let mut has_deepseek = false;
+                            let mut has_openai = false;
 
-                                        for model in models {
-                                            if let Some(id) =
-                                                model.get("id").and_then(|v| v.as_str())
-                                            {
-                                                if id.contains("deepseek/deepseek-r1") {
-                                                    has_deepseek = true;
-                                                }
-                                                if id.contains("openai/gpt-oss") {
-                                                    has_openai = true;
-                                                }
-                                            }
-                                        }
-
-                                        return has_deepseek && has_openai;
+                            for model in models {
+                                if let Some(id) = model.get("id").and_then(|v| v.as_str()) {
+                                    if id.contains("deepseek/deepseek-r1") {
+                                        has_deepseek = true;
+                                    }
+                                    if id.contains("openai/gpt-oss") {
+                                        has_openai = true;
                                     }
                                 }
                             }
+
+                            return has_deepseek && has_openai;
                         }
                         false
                     },
@@ -798,7 +793,7 @@ fn describegpt_prompt_file() {
         polars_sql_guidance = "Use the following Polars SQL syntax to generate a SQL query: {polars_sql_guidance}"
         dd_fewshot_examples = "Use the following DuckDB few-shot examples: {dd_fewshot_examples}"
         p_fewshot_examples = "Use the following Polars SQL few-shot examples: {p_fewshot_examples}""#;
-    wrk.create_from_string("prompt.toml", &prompt_file_content);
+    wrk.create_from_string("prompt.toml", prompt_file_content);
 
     // Run the command with prompt file
     let mut cmd = wrk.command("describegpt");

--- a/tests/test_diff.rs
+++ b/tests/test_diff.rs
@@ -92,7 +92,7 @@ fn diff_diff_left_and_original_right_sort_diff_result_by_lines_by_default() {
     let mut cmd = wrk.command("diff");
     cmd.arg(test_file).arg(test_file2);
 
-    wrk.assert_success(&mut *&mut cmd);
+    wrk.assert_success(&mut cmd);
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
 

--- a/tests/test_enumerate.rs
+++ b/tests/test_enumerate.rs
@@ -41,7 +41,7 @@ fn enumerate_counter() {
         ],
     );
     let mut cmd = wrk.command("enum");
-    cmd.args(&["--start", "10"]).arg("data.csv");
+    cmd.args(["--start", "10"]).arg("data.csv");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
@@ -68,8 +68,8 @@ fn enumerate_counter_inc() {
         ],
     );
     let mut cmd = wrk.command("enum");
-    cmd.args(&["--start", "10"])
-        .args(&["--increment", "3"])
+    cmd.args(["--start", "10"])
+        .args(["--increment", "3"])
         .arg("data.csv");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
@@ -98,7 +98,7 @@ fn enumerate_hash() {
         ],
     );
     let mut cmd = wrk.command("enum");
-    cmd.args(&["--hash", "1-"]).arg("data.csv");
+    cmd.args(["--hash", "1-"]).arg("data.csv");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
@@ -128,7 +128,7 @@ fn enumerate_hash_intl() {
         ],
     );
     let mut cmd = wrk.command("enum");
-    cmd.args(&["--hash", "1-"]).arg("data.csv");
+    cmd.args(["--hash", "1-"]).arg("data.csv");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
@@ -158,7 +158,7 @@ fn enumerate_hash_replace_old_hash() {
         ],
     );
     let mut cmd = wrk.command("enum");
-    cmd.args(&["--hash", "!/hash/"]).arg("data.csv");
+    cmd.args(["--hash", "!/hash/"]).arg("data.csv");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
@@ -187,7 +187,7 @@ fn enumerate_hash_replace_old_hash2() {
         ],
     );
     let mut cmd = wrk.command("enum");
-    cmd.args(&["--hash", "1-"]).arg("data.csv");
+    cmd.args(["--hash", "1-"]).arg("data.csv");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
@@ -216,7 +216,7 @@ fn enumerate_hash_regex() {
         ],
     );
     let mut cmd = wrk.command("enum");
-    cmd.args(&["--hash", "/letter|number|random_text/"])
+    cmd.args(["--hash", "/letter|number|random_text/"])
         .arg("data.csv");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
@@ -246,7 +246,7 @@ fn enumerate_hash_subset() {
         ],
     );
     let mut cmd = wrk.command("enum");
-    cmd.args(&["--hash", "3,4"]).arg("data.csv");
+    cmd.args(["--hash", "3,4"]).arg("data.csv");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
@@ -275,7 +275,7 @@ fn enumerate_hash_reverse() {
         ],
     );
     let mut cmd = wrk.command("enum");
-    cmd.args(&["--hash", "_-1"]).arg("data.csv");
+    cmd.args(["--hash", "_-1"]).arg("data.csv");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
@@ -304,7 +304,7 @@ fn enumerate_hash_regex_not() {
         ],
     );
     let mut cmd = wrk.command("enum");
-    cmd.args(&["--hash", "!/hash/"]).arg("data.csv");
+    cmd.args(["--hash", "!/hash/"]).arg("data.csv");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![

--- a/tests/test_exclude.rs
+++ b/tests/test_exclude.rs
@@ -64,7 +64,7 @@ fn make_rows(headers: bool, rows: Vec<Vec<String>>) -> Vec<Vec<String>> {
     if headers {
         all_rows.push(svec!["city", "state"]);
     }
-    all_rows.extend(rows.into_iter());
+    all_rows.extend(rows);
     all_rows
 }
 
@@ -215,7 +215,7 @@ fn exclude_delimiter_tab() {
     );
 
     let mut cmd = wrk.command("exclude");
-    cmd.args(&["-d", "\\t"])
+    cmd.args(["-d", "\\t"])
         .arg("id")
         .arg("data.tsv")
         .arg("id")

--- a/tests/test_fetch.rs
+++ b/tests/test_fetch.rs
@@ -320,8 +320,8 @@ fn fetch_simple_diskcache() {
         .arg("data.csv")
         .arg("--store-error")
         .arg("--disk-cache")
-        .args(&["--disk-cache-dir", dc_dir])
-        .args(&["--rate-limit", "2"]);
+        .args(["--disk-cache-dir", dc_dir])
+        .args(["--rate-limit", "2"]);
 
     let got = wrk.stdout::<String>(&mut cmd);
 
@@ -343,8 +343,8 @@ fn fetch_simple_diskcache() {
         .arg("data.csv")
         .arg("--store-error")
         .arg("--disk-cache")
-        .args(&["--disk-cache-dir", dc_dir])
-        .args(&["--report", "short"]);
+        .args(["--disk-cache-dir", dc_dir])
+        .args(["--report", "short"]);
 
     let got = wrk.stdout::<String>(&mut cmd_2);
     assert_eq!(got, expected);
@@ -1160,8 +1160,8 @@ fn fetchpost_simple_diskcache() {
         .arg("--new-column")
         .arg("response")
         .arg("--disk-cache")
-        .args(&["--disk-cache-dir", dc_dir])
-        .args(&["--rate-limit", "2"])
+        .args(["--disk-cache-dir", dc_dir])
+        .args(["--rate-limit", "2"])
         .arg("data.csv");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
@@ -1771,12 +1771,11 @@ fn fetchpost_disk_cache() {
     );
 
     let mut cmd = wrk.command("fetchpost");
-    (&mut *cmd
-        .arg("URL")
+    cmd.arg("URL")
         .arg("col1")
         .arg("--disk-cache")
         .arg("--disk-cache-dir")
-        .arg(dc_dir))
+        .arg(dc_dir)
         .arg("--jaq")
         .arg(r#"."form""#)
         .arg("data.csv");

--- a/tests/test_fill.rs
+++ b/tests/test_fill.rs
@@ -76,7 +76,7 @@ fn fill_forward_groupby() {
     wrk.create("in.csv", example());
 
     let mut cmd = wrk.command("fill");
-    cmd.args(&vec!["-g", "2"]).arg("--").arg("1").arg("in.csv");
+    cmd.args(vec!["-g", "2"]).arg("--").arg("1").arg("in.csv");
 
     let got: Vec<CsvRecord> = wrk.read_stdout(&mut cmd);
     let expected = svec![
@@ -91,7 +91,7 @@ fn fill_first_groupby() {
     wrk.create("in.csv", example());
 
     let mut cmd = wrk.command("fill");
-    cmd.args(&vec!["-g", "2"])
+    cmd.args(vec!["-g", "2"])
         .arg("--first")
         .arg("--")
         .arg("1")

--- a/tests/test_frequency.rs
+++ b/tests/test_frequency.rs
@@ -1090,7 +1090,7 @@ fn frequency_json() {
     assert_eq!(field["field"], "h2");
     assert_eq!(field["cardinality"], 4);
     let freqs = field["frequencies"].as_array().unwrap();
-    let expected = vec![
+    let expected = [
         ("z", 3, 42.85714, 1.0),
         ("y", 2, 28.57143, 2.0),
         ("Y", 1, 14.28571, 3.0),
@@ -1124,7 +1124,7 @@ fn frequency_json_no_headers() {
     assert_eq!(field["cardinality"], 5);
     let freqs = field["frequencies"].as_array().unwrap();
     // NULL entries are now at the end by default (--null-sorted flag changes this behavior)
-    let expected = vec![
+    let expected = [
         ("a", 4, 50.0, 1.0),
         ("b", 1, 12.5, 2.0),
         ("h1", 1, 12.5, 2.0),
@@ -1157,7 +1157,7 @@ fn frequency_json_ignore_case() {
     assert_eq!(field["field"], "h2");
     assert_eq!(field["cardinality"], 3);
     let freqs = field["frequencies"].as_array().unwrap();
-    let expected = vec![("y", 3, 42.85714), ("z", 3, 42.85714), ("x", 1, 14.28571)];
+    let expected = [("y", 3, 42.85714), ("z", 3, 42.85714), ("x", 1, 14.28571)];
     for (i, (val, count, pct)) in expected.iter().enumerate() {
         assert_eq!(freqs[i]["value"], *val);
         assert_eq!(freqs[i]["count"], *count);
@@ -1186,14 +1186,14 @@ fn frequency_json_limit() {
     assert_eq!(h1["cardinality"], 4);
     assert_eq!(h2["cardinality"], 4);
     let freqs_h1 = h1["frequencies"].as_array().unwrap();
-    let expected_h1 = vec![("a", 4, 57.14286), ("Other (3)", 3, 42.85714)];
+    let expected_h1 = [("a", 4, 57.14286), ("Other (3)", 3, 42.85714)];
     for (i, (val, count, pct)) in expected_h1.iter().enumerate() {
         assert_eq!(freqs_h1[i]["value"], *val);
         assert_eq!(freqs_h1[i]["count"], *count);
         assert!((freqs_h1[i]["percentage"].as_f64().unwrap() - *pct).abs() < 1e-5);
     }
     let freqs_h2 = h2["frequencies"].as_array().unwrap();
-    let expected_h2 = vec![("z", 3, 42.85714), ("Other (3)", 4, 57.14286)];
+    let expected_h2 = [("z", 3, 42.85714), ("Other (3)", 4, 57.14286)];
     for (i, (val, count, pct)) in expected_h2.iter().enumerate() {
         assert_eq!(freqs_h2[i]["value"], *val);
         assert_eq!(freqs_h2[i]["count"], *count);
@@ -1262,7 +1262,7 @@ fn frequency_json_vis_whitespace() {
     assert_eq!(field["cardinality"], 3);
     let freqs = field["frequencies"].as_array().unwrap();
     // NULL is now at the end by default (--null-sorted flag changes this behavior)
-    let expected = vec![
+    let expected = [
         ("value", 4, 66.66667),
         ("no_whitespace", 1, 16.66667),
         ("(NULL)", 1, 16.66667),
@@ -1518,12 +1518,14 @@ fn frequency_toon_vis_whitespace() {
     let field = &fields[0];
     assert_eq!(field["field"], "header");
     assert_eq!(field["cardinality"], 3);
-    let freqs = field["frequencies"].as_array().expect(&format!(
-        "frequencies should be an array. Field keys: {:?}",
-        field.as_object().map(|o| o.keys().collect::<Vec<_>>())
-    ));
+    let freqs = field["frequencies"].as_array().unwrap_or_else(|| {
+        panic!(
+            "frequencies should be an array. Field keys: {:?}",
+            field.as_object().map(|o| o.keys().collect::<Vec<_>>())
+        )
+    });
     // NULL is now at the end by default (--null-sorted flag changes this behavior)
-    let expected = vec![
+    let expected = [
         ("value", 4, 66.66667),
         ("no_whitespace", 1, 16.66667),
         ("(NULL)", 1, 16.66667),
@@ -1994,13 +1996,13 @@ fn frequency_weight_excludes_weight_column() {
     // Should only have "value" column, not "weight" column
     let value_rows: Vec<_> = got
         .iter()
-        .filter(|r| r.len() > 0 && r[0] == "value")
+        .filter(|r| !r.is_empty() && r[0] == "value")
         .collect();
     assert_eq!(value_rows.len(), 2); // 2 value rows (a and b), header is filtered out
     // Should not have any "weight" column frequencies
     let weight_rows: Vec<_> = got
         .iter()
-        .filter(|r| r.len() > 0 && r[0] == "weight")
+        .filter(|r| !r.is_empty() && r[0] == "weight")
         .collect();
     assert_eq!(weight_rows.len(), 0);
 }
@@ -2514,9 +2516,8 @@ fn frequency_weight_parallel_merge() {
     assert_eq!(freq_rows.len(), 7, "Should have 7 unique values");
 
     // Verify weights are correctly aggregated by checking specific values
-    let find_freq = |value: &str| -> Option<&Vec<String>> {
-        freq_rows.iter().find(|r| r[1] == value).map(|r| *r)
-    };
+    let find_freq =
+        |value: &str| -> Option<&Vec<String>> { freq_rows.iter().find(|r| r[1] == value).copied() };
 
     // Check that "a" has aggregated weight of 450 (rounded)
     let a_freq = find_freq("a").expect("Should find 'a'");
@@ -2854,9 +2855,8 @@ fn frequency_weight_nan_values() {
         .filter(|r| r.len() > 1 && r[0] == "value" && r[1] != "value") // Skip header
         .collect();
 
-    let find_freq = |value: &str| -> Option<&Vec<String>> {
-        freq_rows.iter().find(|r| r[1] == value).map(|r| *r)
-    };
+    let find_freq =
+        |value: &str| -> Option<&Vec<String>> { freq_rows.iter().find(|r| r[1] == value).copied() };
 
     // The main goal is to verify that NaN weight values are handled gracefully without panicking.
     // The exact behavior depends on how fast_float2 parses "NaN":
@@ -2970,9 +2970,8 @@ fn frequency_weight_extremely_large_values() {
     // All values should appear (a, b, c, d)
     assert_eq!(freq_rows.len(), 4, "Should have 4 values");
 
-    let find_freq = |value: &str| -> Option<&Vec<String>> {
-        freq_rows.iter().find(|r| r[1] == value).map(|r| *r)
-    };
+    let find_freq =
+        |value: &str| -> Option<&Vec<String>> { freq_rows.iter().find(|r| r[1] == value).copied() };
 
     // Verify that extremely large values are clamped to u64::MAX
     let c_freq = find_freq("c").expect("Should find 'c'");
@@ -3040,9 +3039,8 @@ fn frequency_weight_mixed_invalid_values() {
         .filter(|r| r.len() > 1 && r[0] == "value" && r[1] != "value") // Skip header
         .collect();
 
-    let find_freq = |value: &str| -> Option<&Vec<String>> {
-        freq_rows.iter().find(|r| r[1] == value).map(|r| *r)
-    };
+    let find_freq =
+        |value: &str| -> Option<&Vec<String>> { freq_rows.iter().find(|r| r[1] == value).copied() };
 
     // The main goal is to verify that invalid weight values are handled gracefully
     // without panicking. The exact behavior may vary based on how fast_float2 parses values.
@@ -3054,7 +3052,7 @@ fn frequency_weight_mixed_invalid_values() {
 
     // At minimum, we should have some frequency values (at least "huge" should appear)
     assert!(
-        freq_rows.len() > 0,
+        !freq_rows.is_empty(),
         "Should have at least some frequency values"
     );
 
@@ -3167,9 +3165,8 @@ fn frequency_weight_no_other_zero() {
     );
 
     // Verify all expected values are present
-    let find_freq = |value: &str| -> Option<&Vec<String>> {
-        freq_rows.iter().find(|r| r[1] == value).map(|r| *r)
-    };
+    let find_freq =
+        |value: &str| -> Option<&Vec<String>> { freq_rows.iter().find(|r| r[1] == value).copied() };
 
     assert!(find_freq("a").is_some(), "Should find 'a'");
     assert!(find_freq("b").is_some(), "Should find 'b'");
@@ -3575,7 +3572,7 @@ fn frequency_weight_json_no_stats() {
     // (Empty arrays are removed from JSON output, so stats key should not exist)
     let stats = field.get("stats");
     assert!(
-        stats.is_none() || stats.unwrap().as_array().map_or(true, |a| a.is_empty()),
+        stats.is_none() || stats.unwrap().as_array().is_none_or(|a| a.is_empty()),
         "Stats should be omitted or empty when using --weight --json"
     );
 
@@ -3933,15 +3930,12 @@ fn frequency_null_sorted_other_sorted() {
     // But since Other has rank 0 and --other-sorted is set, it sorts with others
     let values: Vec<&str> = got.iter().skip(1).map(|r| r[1].as_str()).collect();
     // All values should be present in some order determined by count
-    assert!(values.iter().any(|v| *v == "a"), "Expected 'a' in output");
+    assert!(values.contains(&"a"), "Expected 'a' in output");
     assert!(
         values.iter().any(|v| v.starts_with("Other")),
         "Expected 'Other' in output"
     );
-    assert!(
-        values.iter().any(|v| *v == "(NULL)"),
-        "Expected '(NULL)' in output"
-    );
+    assert!(values.contains(&"(NULL)"), "Expected '(NULL)' in output");
 }
 
 #[test]
@@ -5881,7 +5875,7 @@ fn frequency_jsonl_cache_null_roundtrip() {
     let has_empty_value = fields.iter().any(|entry| {
         entry["frequencies"]
             .as_array()
-            .map_or(false, |freqs| freqs.iter().any(|f| f["value"] == ""))
+            .is_some_and(|freqs| freqs.iter().any(|f| f["value"] == ""))
     });
     assert!(
         has_empty_value,

--- a/tests/test_geoconvert.rs
+++ b/tests/test_geoconvert.rs
@@ -57,7 +57,7 @@ fn geoconvert_geojson_to_csv() {
     wrk.assert_success(&mut cmd);
 
     let mut cmd = wrk.command("select");
-    cmd.args(&["name,Shape_Length,Shape_Area"])
+    cmd.args(["name,Shape_Length,Shape_Area"])
         .arg(&txcities_csv_first5);
 
     let got: String = wrk.stdout(&mut cmd);

--- a/tests/test_index.rs
+++ b/tests/test_index.rs
@@ -61,7 +61,7 @@ fn index_outdated_stats() {
     // even if the index is stale, stats should succeed
     // as the index is automatically updated
     let mut cmd = wrk.command("stats");
-    cmd.args(&["in.csv"]);
+    cmd.args(["in.csv"]);
 
     wrk.assert_success(&mut cmd);
 }

--- a/tests/test_join.rs
+++ b/tests/test_join.rs
@@ -120,7 +120,7 @@ fn make_rows(headers: bool, left_only: bool, rows: Vec<Vec<String>>) -> Vec<Vec<
             all_rows.push(svec!["city", "state", "city", "place"]);
         }
     }
-    all_rows.extend(rows.into_iter());
+    all_rows.extend(rows);
     all_rows
 }
 
@@ -137,7 +137,7 @@ fn make_rows_with_zeros(
             all_rows.push(svec!["id", "value", "id", "info"]);
         }
     }
-    all_rows.extend(rows.into_iter());
+    all_rows.extend(rows);
     all_rows
 }
 
@@ -716,7 +716,7 @@ fn join_inner_zeros_casei() {
     wrk.create("cities2.csv", cities2);
 
     let mut cmd = wrk.command("join");
-    cmd.args(&["id", "cities1.csv", "id", "cities2.csv"])
+    cmd.args(["id", "cities1.csv", "id", "cities2.csv"])
         .arg("--ignore-leading-zeros")
         .arg("--ignore-case");
 

--- a/tests/test_joinp.rs
+++ b/tests/test_joinp.rs
@@ -175,7 +175,7 @@ fn make_rows(left_only: bool, rows: Vec<Vec<String>>) -> Vec<Vec<String>> {
     } else {
         all_rows.push(svec!["city", "state", "place"]);
     }
-    all_rows.extend(rows.into_iter());
+    all_rows.extend(rows);
     all_rows
 }
 
@@ -1275,7 +1275,7 @@ fn joinp_ignore_case() {
     );
 
     let mut cmd = wrk.command("joinp");
-    cmd.args(&["city", "cities_mixed.csv", "city", "places_mixed.csv"])
+    cmd.args(["city", "cities_mixed.csv", "city", "places_mixed.csv"])
         .arg("--ignore-case");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
@@ -1318,7 +1318,7 @@ fn joinp_ignore_case_maintain_order_right() {
     );
 
     let mut cmd = wrk.command("joinp");
-    cmd.args(&["city", "cities_mixed.csv", "city", "places_mixed.csv"])
+    cmd.args(["city", "cities_mixed.csv", "city", "places_mixed.csv"])
         .arg("--ignore-case")
         .args(["--maintain-order", "right"]);
 
@@ -1364,7 +1364,7 @@ fn joinp_ignore_case_maintain_order_left() {
     );
 
     let mut cmd = wrk.command("joinp");
-    cmd.args(&["city", "cities_mixed.csv", "city", "places_mixed.csv"])
+    cmd.args(["city", "cities_mixed.csv", "city", "places_mixed.csv"])
         .arg("--ignore-case")
         .args(["--maintain-order", "left"]);
 
@@ -1410,7 +1410,7 @@ fn joinp_ignore_case_maintain_order_left_right() {
     );
 
     let mut cmd = wrk.command("joinp");
-    cmd.args(&["city", "cities_mixed.csv", "city", "places_mixed.csv"])
+    cmd.args(["city", "cities_mixed.csv", "city", "places_mixed.csv"])
         .arg("--ignore-case")
         .args(["--maintain-order", "left_right"]);
 
@@ -1456,7 +1456,7 @@ fn joinp_ignore_case_maintain_order_right_left() {
     );
 
     let mut cmd = wrk.command("joinp");
-    cmd.args(&["city", "cities_mixed.csv", "city", "places_mixed.csv"])
+    cmd.args(["city", "cities_mixed.csv", "city", "places_mixed.csv"])
         .arg("--ignore-case")
         .args(["--maintain-order", "right_left"]);
 
@@ -1502,14 +1502,14 @@ fn joinp_filter_pattern_matching() {
 
     // Test 1: Right starts-with left
     let mut cmd = wrk.command("joinp");
-    cmd.args(&["code", "prefixes.csv", "id", "values.csv"])
+    cmd.args(["code", "prefixes.csv", "id", "values.csv"])
         .arg("--cross")
         .args([
             "--sql-filter",
             "select * from join_result where STARTS_WITH(id, code)",
         ]);
 
-    wrk.assert_success(&mut *&mut cmd);
+    wrk.assert_success(&mut cmd);
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
@@ -1523,14 +1523,14 @@ fn joinp_filter_pattern_matching() {
 
     // Test 2: Right contains left
     let mut cmd = wrk.command("joinp");
-    cmd.args(&["code", "prefixes.csv", "id", "values.csv"])
+    cmd.args(["code", "prefixes.csv", "id", "values.csv"])
         .arg("--cross")
         .args([
             "--sql-filter",
             "select * from join_result where STRPOS(id, code) > 0",
         ]);
 
-    wrk.assert_success(&mut *&mut cmd);
+    wrk.assert_success(&mut cmd);
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
@@ -1547,14 +1547,14 @@ fn joinp_filter_pattern_matching() {
 
     // Test 3: Right ends-with left
     let mut cmd = wrk.command("joinp");
-    cmd.args(&["code", "prefixes.csv", "id", "values.csv"])
+    cmd.args(["code", "prefixes.csv", "id", "values.csv"])
         .arg("--cross")
         .args([
             "--sql-filter",
             "select * from join_result where ENDS_WITH(id, code)",
         ]);
 
-    wrk.assert_success(&mut *&mut cmd);
+    wrk.assert_success(&mut cmd);
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
@@ -1588,14 +1588,14 @@ fn joinp_filter_pattern_matching() {
 
     // Test 4: Left starts-with right
     let mut cmd = wrk.command("joinp");
-    cmd.args(&["code", "full_codes.csv", "pattern", "patterns.csv"])
+    cmd.args(["code", "full_codes.csv", "pattern", "patterns.csv"])
         .arg("--cross")
         .args([
             "--sql-filter",
             "select * from join_result where STARTS_WITH(code, pattern)",
         ]);
 
-    wrk.assert_success(&mut *&mut cmd);
+    wrk.assert_success(&mut cmd);
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
@@ -1608,14 +1608,14 @@ fn joinp_filter_pattern_matching() {
 
     // Test 5: Left contains right
     let mut cmd = wrk.command("joinp");
-    cmd.args(&["code", "full_codes.csv", "pattern", "patterns.csv"])
+    cmd.args(["code", "full_codes.csv", "pattern", "patterns.csv"])
         .arg("--cross")
         .args([
             "--sql-filter",
             "select * from join_result where STRPOS(code, pattern) > 0",
         ]);
 
-    wrk.assert_success(&mut *&mut cmd);
+    wrk.assert_success(&mut cmd);
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
@@ -1629,14 +1629,14 @@ fn joinp_filter_pattern_matching() {
 
     // Test 6: Left ends-with right
     let mut cmd = wrk.command("joinp");
-    cmd.args(&["code", "full_codes.csv", "pattern", "patterns.csv"])
+    cmd.args(["code", "full_codes.csv", "pattern", "patterns.csv"])
         .arg("--cross")
         .args([
             "--sql-filter",
             "select * from join_result where ENDS_WITH(code, pattern)",
         ]);
 
-    wrk.assert_success(&mut *&mut cmd);
+    wrk.assert_success(&mut cmd);
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
@@ -1675,7 +1675,7 @@ fn test_joinp_cache_schema() {
 
     // Test 1: No schema caching (default)
     let mut cmd = wrk.command("joinp");
-    cmd.args(&["has_text", "left.csv", "has_text", "right.csv"]);
+    cmd.args(["has_text", "left.csv", "has_text", "right.csv"]);
     wrk.assert_success(&mut cmd);
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
@@ -1693,7 +1693,7 @@ fn test_joinp_cache_schema() {
 
     // Test 2: Cache inferred schema
     let mut cmd = wrk.command("joinp");
-    cmd.args(&["has_text", "left.csv", "has_text", "right.csv"])
+    cmd.args(["has_text", "left.csv", "has_text", "right.csv"])
         .arg("--cache-schema")
         .arg("1");
 
@@ -1707,7 +1707,7 @@ fn test_joinp_cache_schema() {
 
     // Test 3: Use string schema for all columns
     let mut cmd = wrk.command("joinp");
-    cmd.args(&["has_text", "left.csv", "has_text", "right.csv"])
+    cmd.args(["has_text", "left.csv", "has_text", "right.csv"])
         .arg("--cache-schema")
         .arg("-1");
     wrk.assert_success(&mut cmd);
@@ -1717,7 +1717,7 @@ fn test_joinp_cache_schema() {
 
     // Test 4: Use and cache string schema
     let mut cmd = wrk.command("joinp");
-    cmd.args(&["has_text", "left.csv", "has_text", "right.csv"])
+    cmd.args(["has_text", "left.csv", "has_text", "right.csv"])
         .arg("--cache-schema")
         .arg("-2");
     wrk.assert_success(&mut cmd);
@@ -1727,7 +1727,7 @@ fn test_joinp_cache_schema() {
 
     // Test 5: Invalid cache-schema value
     let mut cmd = wrk.command("joinp");
-    cmd.args(&["has_text", "left.csv", "has_text", "right.csv"])
+    cmd.args(["has_text", "left.csv", "has_text", "right.csv"])
         .arg("--cache-schema")
         .arg("2");
     wrk.assert_err(&mut cmd);
@@ -1833,7 +1833,7 @@ fn joinp_ignore_leading_zero() {
     );
 
     let mut cmd = wrk.command("joinp");
-    cmd.args(&["id", "left.csv", "id", "right.csv"]).arg("-z");
+    cmd.args(["id", "left.csv", "id", "right.csv"]).arg("-z");
 
     wrk.assert_success(&mut cmd);
 
@@ -1875,7 +1875,7 @@ fn joinp_ignore_leading_zero_string_schema() {
     );
 
     let mut cmd = wrk.command("joinp");
-    cmd.args(&["id", "left.csv", "id", "right.csv"])
+    cmd.args(["id", "left.csv", "id", "right.csv"])
         .arg("-z")
         .args(["--cache-schema", "-2"]); // force schema to all String types
 
@@ -1919,7 +1919,7 @@ fn joinp_ignore_leading_zero_with_non_numeric() {
     );
 
     let mut cmd = wrk.command("joinp");
-    cmd.args(&["code", "left.csv", "code", "right.csv"])
+    cmd.args(["code", "left.csv", "code", "right.csv"])
         .arg("--ignore-leading-zeros");
 
     wrk.assert_success(&mut cmd);
@@ -1959,7 +1959,7 @@ fn joinp_ignore_leading_zero_multiple_columns() {
     );
 
     let mut cmd = wrk.command("joinp");
-    cmd.args(&["id,code", "left.csv", "id,code", "right.csv"])
+    cmd.args(["id,code", "left.csv", "id,code", "right.csv"])
         .arg("--ignore-leading-zeros")
         .args(["--cache-schema", "-2"]); // force schema to all String types
 
@@ -2000,7 +2000,7 @@ fn joinp_ignore_case_and_leading_zeros() {
     );
 
     let mut cmd = wrk.command("joinp");
-    cmd.args(&["id,code", "left.csv", "id,code", "right.csv"])
+    cmd.args(["id,code", "left.csv", "id,code", "right.csv"])
         .arg("--ignore-leading-zeros")
         .arg("--ignore-case")
         .args(["--cache-schema", "-2"]); // force schema to all String types
@@ -2041,7 +2041,7 @@ fn joinp_ignore_case_and_leading_zeros_coalesce() {
     );
 
     let mut cmd = wrk.command("joinp");
-    cmd.args(&["id,code", "left.csv", "id,code", "right.csv"])
+    cmd.args(["id,code", "left.csv", "id,code", "right.csv"])
         .arg("--ignore-leading-zeros")
         .arg("--ignore-case")
         .arg("--coalesce")
@@ -2083,7 +2083,7 @@ fn joinp_non_equi_greater_than() {
     let mut cmd = wrk.command("joinp");
     cmd.arg("--non-equi")
         .arg("budget_right > price_left")
-        .args(&["prices.csv", "budgets.csv"])
+        .args(["prices.csv", "budgets.csv"])
         .args(["--float-precision", "2"]);
 
     wrk.assert_success(&mut cmd);
@@ -2124,7 +2124,7 @@ fn joinp_non_equi_less_than() {
     let mut cmd = wrk.command("joinp");
     cmd.arg("--non-equi")
         .arg("date_left < deadline_right")
-        .args(&["events.csv", "deadlines.csv"]);
+        .args(["events.csv", "deadlines.csv"]);
 
     wrk.assert_success(&mut cmd);
 
@@ -2163,7 +2163,7 @@ fn joinp_non_equi_less_than_date_arithmetic() {
     let mut cmd = wrk.command("joinp");
     cmd.arg("--non-equi")
         .arg("date_left  + interval '4 months' < deadline_right")
-        .args(&["events.csv", "deadlines.csv"])
+        .args(["events.csv", "deadlines.csv"])
         .arg("--try-parsedates");
 
     wrk.assert_success(&mut cmd);
@@ -2203,7 +2203,7 @@ fn joinp_non_equi_not_equal() {
     let mut cmd = wrk.command("joinp");
     cmd.arg("--non-equi")
         .arg("team_left != team_right")
-        .args(&["teams.csv", "matches.csv"]);
+        .args(["teams.csv", "matches.csv"]);
 
     wrk.assert_success(&mut cmd);
 
@@ -2227,7 +2227,7 @@ fn joinp_non_equi_invalid_operator() {
     let mut cmd = wrk.command("joinp");
     cmd.arg("--non-equi")
         .arg("col1 INVALID col2")
-        .args(&["cities.csv", "places.csv"]);
+        .args(["cities.csv", "places.csv"]);
 
     wrk.assert_err(&mut cmd);
 }
@@ -2239,7 +2239,7 @@ fn joinp_non_equi_invalid_format() {
     let mut cmd = wrk.command("joinp");
     cmd.arg("--non-equi")
         .arg("invalid expression format")
-        .args(&["cities.csv", "places.csv"]);
+        .args(["cities.csv", "places.csv"]);
 
     wrk.assert_err(&mut cmd);
 }
@@ -2272,8 +2272,8 @@ fn joinp_non_equi_compound() {
             "salary_left >= min_salary_right AND salary_left <= max_salary_right AND \
              experience_left >= min_exp_right",
         )
-        .args(&["employees.csv", "jobs.csv"])
-        .args(&[
+        .args(["employees.csv", "jobs.csv"])
+        .args([
             "--sql-filter",
             "select * from join_result order by name_left, salary_left, experience_left, \
              position_right",
@@ -2331,7 +2331,7 @@ fn joinp_ignore_leading_zeros_issue_2424() {
     );
 
     let mut cmd = wrk.command("joinp");
-    cmd.args(&[
+    cmd.args([
         "-i",
         "-z",
         "--left-semi",
@@ -2382,7 +2382,7 @@ fn joinp_unicode_normalization() {
 
     // Test NFC normalization
     let mut cmd = wrk.command("joinp");
-    cmd.args(&["name", "left.csv", "name", "right.csv"])
+    cmd.args(["name", "left.csv", "name", "right.csv"])
         .args(["--norm-unicode", "nfc"]);
 
     wrk.assert_success(&mut cmd);
@@ -2421,7 +2421,7 @@ fn joinp_unicode_normalization_with_other_options() {
     );
 
     let mut cmd = wrk.command("joinp");
-    cmd.args(&["id,name", "left.csv", "id,name", "right.csv"])
+    cmd.args(["id,name", "left.csv", "id,name", "right.csv"])
         .args(["--norm-unicode", "nfkc"])
         .arg("--ignore-leading-zeros")
         .arg("--ignore-case")
@@ -2467,7 +2467,7 @@ fn joinp_unicode_normalization_ligatures() {
 
     // Test NFKC normalization (should decompose ligatures)
     let mut cmd = wrk.command("joinp");
-    cmd.args(&["name", "left.csv", "name", "right.csv"])
+    cmd.args(["name", "left.csv", "name", "right.csv"])
         .args(["--norm-unicode", "nfkc"])
         .args(["--maintain-order", "left"]);
 
@@ -2486,7 +2486,7 @@ fn joinp_unicode_normalization_ligatures() {
 
     // Test NFKD normalization (should also decompose ligatures)
     let mut cmd = wrk.command("joinp");
-    cmd.args(&["name", "left.csv", "name", "right.csv"])
+    cmd.args(["name", "left.csv", "name", "right.csv"])
         .args(["--norm-unicode", "nfkd"]);
 
     wrk.assert_success(&mut cmd);
@@ -2496,7 +2496,7 @@ fn joinp_unicode_normalization_ligatures() {
 
     // Test NFC normalization (should NOT decompose ligatures)
     let mut cmd = wrk.command("joinp");
-    cmd.args(&["name", "left.csv", "name", "right.csv"])
+    cmd.args(["name", "left.csv", "name", "right.csv"])
         .args(["--norm-unicode", "nfc"])
         .args(["--maintain-order", "left"]);
 

--- a/tests/test_luau.rs
+++ b/tests/test_luau.rs
@@ -3037,7 +3037,7 @@ BEGIN {
         boolean_true = true,
         boolean_false = false,
         number_integer = 42,
-        number_float = 3.14,
+        number_float = 1.23,
         empty_string = "",
         empty_table = {},
         nested_empty = {empty = {}}
@@ -3060,7 +3060,7 @@ return "ok"
     assert_eq!(json["boolean_true"], json!(true));
     assert_eq!(json["boolean_false"], json!(false));
     assert_eq!(json["number_integer"], json!(42));
-    assert_eq!(json["number_float"], json!(3.14));
+    assert_eq!(json["number_float"], json!(1.23));
     assert_eq!(json["empty_string"], json!(""));
     assert_eq!(json["empty_table"], json!({}));
     assert_eq!(json["nested_empty"]["empty"], json!({}));

--- a/tests/test_moarstats.rs
+++ b/tests/test_moarstats.rs
@@ -293,18 +293,18 @@ fn moarstats_custom_rounding() {
     if let Some(pearson_idx) = get_column_index(&headers, "pearson_skewness") {
         for result in rdr.records() {
             let record = result.unwrap();
-            if let Some(val_str) = get_field_value(&record, pearson_idx) {
-                if !val_str.is_empty() {
-                    // Check decimal places (allowing for scientific notation edge cases)
-                    if let Some(dot_pos) = val_str.find('.') {
-                        let after_dot = &val_str[dot_pos + 1..];
-                        // Should have at most 2 decimal places (or be in scientific notation)
-                        assert!(
-                            after_dot.len() <= 2 || val_str.contains('e') || val_str.contains('E'),
-                            "Value '{}' should be rounded to 2 decimal places",
-                            val_str
-                        );
-                    }
+            if let Some(val_str) = get_field_value(&record, pearson_idx)
+                && !val_str.is_empty()
+            {
+                // Check decimal places (allowing for scientific notation edge cases)
+                if let Some(dot_pos) = val_str.find('.') {
+                    let after_dot = &val_str[dot_pos + 1..];
+                    // Should have at most 2 decimal places (or be in scientific notation)
+                    assert!(
+                        after_dot.len() <= 2 || val_str.contains('e') || val_str.contains('E'),
+                        "Value '{}' should be rounded to 2 decimal places",
+                        val_str
+                    );
                 }
             }
         }
@@ -430,20 +430,18 @@ fn moarstats_verify_computed_values() {
             && mode_idx.is_some()
             && mean_idx.is_some()
             && stddev_idx.is_some()
-        {
-            if let (Some(mode_idx), Some(mean_idx), Some(stddev_idx), Some(mode_zscore_idx)) =
+            && let (Some(mode_idx), Some(mean_idx), Some(stddev_idx), Some(mode_zscore_idx)) =
                 (mode_idx, mean_idx, stddev_idx, mode_zscore_idx)
-            {
-                let mode_val = get_field_value(&record, mode_idx);
-                let mean_val = get_field_value(&record, mean_idx);
-                let stddev_val = get_field_value(&record, stddev_idx);
-                let mode_zscore_val = get_field_value(&record, mode_zscore_idx);
+        {
+            let mode_val = get_field_value(&record, mode_idx);
+            let mean_val = get_field_value(&record, mean_idx);
+            let stddev_val = get_field_value(&record, stddev_idx);
+            let mode_zscore_val = get_field_value(&record, mode_zscore_idx);
 
-                // Mode might be a string, so we check if it can be parsed
-                if mode_val.is_some() && mean_val.is_some() && stddev_val.is_some() {
-                    // mode_zscore might be empty if mode is not numeric, which is fine
-                    assert!(mode_zscore_val.is_some(), "mode_zscore column should exist");
-                }
+            // Mode might be a string, so we check if it can be parsed
+            if mode_val.is_some() && mean_val.is_some() && stddev_val.is_some() {
+                // mode_zscore might be empty if mode is not numeric, which is fine
+                assert!(mode_zscore_val.is_some(), "mode_zscore column should exist");
             }
         }
     }
@@ -738,48 +736,48 @@ fn moarstats_outlier_statistics_values() {
             // Verify outlier counts
             if let Some(outliers_total_idx) = get_column_index(&headers, "outliers_total") {
                 let outliers_total_val = get_field_value(&record, outliers_total_idx);
-                if let Some(val_str) = outliers_total_val {
-                    if !val_str.is_empty() {
-                        let count: u64 = val_str.parse().unwrap();
-                        assert!(count > 0, "Should have some outliers");
-                    }
+                if let Some(val_str) = outliers_total_val
+                    && !val_str.is_empty()
+                {
+                    let count: u64 = val_str.parse().unwrap();
+                    assert!(count > 0, "Should have some outliers");
                 }
             }
 
             // Verify outlier mean exists when outliers are present
             if let Some(outliers_mean_idx) = get_column_index(&headers, "outliers_mean") {
                 let outliers_mean_val = get_field_value(&record, outliers_mean_idx);
-                if let Some(val_str) = outliers_mean_val {
-                    if !val_str.is_empty() {
-                        let mean: f64 = val_str.parse().unwrap();
-                        // Outlier mean should be higher than normal values (10-50)
-                        assert!(
-                            mean > 50.0,
-                            "Outlier mean should be higher than normal values"
-                        );
-                    }
+                if let Some(val_str) = outliers_mean_val
+                    && !val_str.is_empty()
+                {
+                    let mean: f64 = val_str.parse().unwrap();
+                    // Outlier mean should be higher than normal values (10-50)
+                    assert!(
+                        mean > 50.0,
+                        "Outlier mean should be higher than normal values"
+                    );
                 }
             }
 
             // Verify outliers_range
             if let Some(outliers_range_idx) = get_column_index(&headers, "outliers_range") {
                 let outliers_range_val = get_field_value(&record, outliers_range_idx);
-                if let Some(val_str) = outliers_range_val {
-                    if !val_str.is_empty() {
-                        let range: f64 = val_str.parse().unwrap();
-                        assert!(range > 0.0, "Outlier range should be positive");
-                    }
+                if let Some(val_str) = outliers_range_val
+                    && !val_str.is_empty()
+                {
+                    let range: f64 = val_str.parse().unwrap();
+                    assert!(range > 0.0, "Outlier range should be positive");
                 }
             }
 
             // Verify outliers_total_cnt (updated column name)
             if let Some(outliers_total_idx) = get_column_index(&headers, "outliers_total_cnt") {
                 let outliers_total_val = get_field_value(&record, outliers_total_idx);
-                if let Some(val_str) = outliers_total_val {
-                    if !val_str.is_empty() {
-                        let count: u64 = val_str.parse().unwrap();
-                        assert!(count > 0, "Should have some outliers");
-                    }
+                if let Some(val_str) = outliers_total_val
+                    && !val_str.is_empty()
+                {
+                    let count: u64 = val_str.parse().unwrap();
+                    assert!(count > 0, "Should have some outliers");
                 }
             }
 
@@ -839,12 +837,12 @@ fn moarstats_no_outliers() {
             // If no outliers, outliers_total_cnt should be 0
             if let Some(outliers_total_idx) = get_column_index(&headers, "outliers_total_cnt") {
                 let outliers_total_val = get_field_value(&record, outliers_total_idx);
-                if let Some(val_str) = outliers_total_val {
-                    if !val_str.is_empty() {
-                        let _count: u64 = val_str.parse().unwrap();
-                        // With tightly clustered values, might have 0 outliers
-                        // Count is u64, so it's always non-negative
-                    }
+                if let Some(val_str) = outliers_total_val
+                    && !val_str.is_empty()
+                {
+                    let _count: u64 = val_str.parse().unwrap();
+                    // With tightly clustered values, might have 0 outliers
+                    // Count is u64, so it's always non-negative
                 }
             }
 
@@ -887,12 +885,12 @@ fn moarstats_multiple_numeric_fields() {
         let record = result.unwrap();
         let field_type = get_field_value(&record, type_idx).unwrap();
 
-        if field_type == "Float" || field_type == "Integer" {
-            if let Some(pearson_idx) = pearson_idx {
-                let pearson_val = get_field_value(&record, pearson_idx);
-                if pearson_val.is_some() && !pearson_val.as_ref().unwrap().is_empty() {
-                    numeric_fields_with_stats += 1;
-                }
+        if (field_type == "Float" || field_type == "Integer")
+            && let Some(pearson_idx) = pearson_idx
+        {
+            let pearson_val = get_field_value(&record, pearson_idx);
+            if pearson_val.is_some() && !pearson_val.as_ref().unwrap().is_empty() {
+                numeric_fields_with_stats += 1;
             }
         }
     }
@@ -985,7 +983,7 @@ fn moarstats_winsorized_trimmed_means_q1_q3() {
 
                 // Trimmed mean should generally be between Q1 and Q3 (approximately 3-7)
                 assert!(
-                    trimmed >= 2.0 && trimmed <= 8.0,
+                    (2.0..=8.0).contains(&trimmed),
                     "Trimmed mean should be within reasonable range"
                 );
             }
@@ -1215,15 +1213,15 @@ fn moarstats_date_datetime_fields() {
             // Check winsorized mean is formatted as date string
             if let Some(winsorized_idx) = get_column_index(&headers, "winsorized_mean_25pct") {
                 let winsorized_val = get_field_value(&record, winsorized_idx);
-                if let Some(val_str) = winsorized_val {
-                    if !val_str.is_empty() {
-                        // Should be RFC3339 format (contains 'T' or is YYYY-MM-DD)
-                        assert!(
-                            val_str.contains('-') && val_str.len() >= 10,
-                            "Date winsorized mean should be formatted as date string, got: {}",
-                            val_str
-                        );
-                    }
+                if let Some(val_str) = winsorized_val
+                    && !val_str.is_empty()
+                {
+                    // Should be RFC3339 format (contains 'T' or is YYYY-MM-DD)
+                    assert!(
+                        val_str.contains('-') && val_str.len() >= 10,
+                        "Date winsorized mean should be formatted as date string, got: {}",
+                        val_str
+                    );
                 }
             }
 
@@ -1469,12 +1467,12 @@ fn moarstats_relative_standard_error() {
         {
             if let Some(rse_idx) = get_column_index(&headers, "relative_standard_error") {
                 let rse_val = get_field_value(&record, rse_idx);
-                if let Some(val_str) = rse_val {
-                    if !val_str.is_empty() {
-                        found_rse_value = true;
-                        let rse: f64 = val_str.parse().unwrap();
-                        assert!(rse >= 0.0, "Relative standard error should be non-negative");
-                    }
+                if let Some(val_str) = rse_val
+                    && !val_str.is_empty()
+                {
+                    found_rse_value = true;
+                    let rse: f64 = val_str.parse().unwrap();
+                    assert!(rse >= 0.0, "Relative standard error should be non-negative");
                 }
             }
             break;
@@ -1533,24 +1531,24 @@ fn moarstats_zscore_min_max() {
         if (field_type == "Float" || field_type == "Integer") && field_name == "latitude" {
             if let Some(min_zscore_idx) = get_column_index(&headers, "min_zscore") {
                 let min_zscore_val = get_field_value(&record, min_zscore_idx);
-                if let Some(val_str) = min_zscore_val {
-                    if !val_str.is_empty() {
-                        let zscore: f64 = val_str.parse().unwrap();
-                        // Min zscore should typically be negative (min is usually below mean)
-                        // But we just check it's a valid number
-                        assert!(zscore.is_finite(), "min_zscore should be a finite number");
-                    }
+                if let Some(val_str) = min_zscore_val
+                    && !val_str.is_empty()
+                {
+                    let zscore: f64 = val_str.parse().unwrap();
+                    // Min zscore should typically be negative (min is usually below mean)
+                    // But we just check it's a valid number
+                    assert!(zscore.is_finite(), "min_zscore should be a finite number");
                 }
             }
 
             if let Some(max_zscore_idx) = get_column_index(&headers, "max_zscore") {
                 let max_zscore_val = get_field_value(&record, max_zscore_idx);
-                if let Some(val_str) = max_zscore_val {
-                    if !val_str.is_empty() {
-                        let zscore: f64 = val_str.parse().unwrap();
-                        // Max zscore should typically be positive (max is usually above mean)
-                        assert!(zscore.is_finite(), "max_zscore should be a finite number");
-                    }
+                if let Some(val_str) = max_zscore_val
+                    && !val_str.is_empty()
+                {
+                    let zscore: f64 = val_str.parse().unwrap();
+                    // Max zscore should typically be positive (max is usually above mean)
+                    assert!(zscore.is_finite(), "max_zscore should be a finite number");
                 }
             }
 
@@ -1608,15 +1606,15 @@ fn moarstats_median_mean_ratio() {
         if field_name == "test" {
             if let Some(ratio_idx) = get_column_index(&headers, "median_mean_ratio") {
                 let ratio_val = get_field_value(&record, ratio_idx);
-                if let Some(val_str) = ratio_val {
-                    if !val_str.is_empty() {
-                        let ratio: f64 = val_str.parse().unwrap();
-                        // With an outlier, median should be less than mean, so ratio < 1
-                        assert!(
-                            ratio > 0.0 && ratio.is_finite(),
-                            "median_mean_ratio should be positive and finite"
-                        );
-                    }
+                if let Some(val_str) = ratio_val
+                    && !val_str.is_empty()
+                {
+                    let ratio: f64 = val_str.parse().unwrap();
+                    // With an outlier, median should be less than mean, so ratio < 1
+                    assert!(
+                        ratio > 0.0 && ratio.is_finite(),
+                        "median_mean_ratio should be positive and finite"
+                    );
                 }
             }
             break;
@@ -1921,17 +1919,16 @@ fn moarstats_kurtosis_gini_constant_values() {
             // With constant values, Gini should be 0 (perfect equality)
             if let Some(gini_idx) = get_column_index(&headers, "gini_coefficient") {
                 let gini_val = get_field_value(&record, gini_idx);
-                if let Some(val_str) = gini_val {
-                    if !val_str.is_empty() {
-                        let gini: f64 = val_str.parse().unwrap();
-                        // Gini should be 0 for constant values (perfect equality)
-                        assert!(
-                            gini.abs() < 0.001,
-                            "gini_coefficient should be approximately 0 for constant values, got: \
-                             {}",
-                            gini
-                        );
-                    }
+                if let Some(val_str) = gini_val
+                    && !val_str.is_empty()
+                {
+                    let gini: f64 = val_str.parse().unwrap();
+                    // Gini should be 0 for constant values (perfect equality)
+                    assert!(
+                        gini.abs() < 0.001,
+                        "gini_coefficient should be approximately 0 for constant values, got: {}",
+                        gini
+                    );
                 }
             }
 
@@ -1990,33 +1987,33 @@ fn moarstats_kurtosis_gini_unequal_distribution() {
             // With unequal distribution, Gini should be > 0
             if let Some(gini_idx) = get_column_index(&headers, "gini_coefficient") {
                 let gini_val = get_field_value(&record, gini_idx);
-                if let Some(val_str) = gini_val {
-                    if !val_str.is_empty() {
-                        let gini: f64 = val_str.parse().unwrap();
-                        // With one large value, Gini should be significantly > 0
-                        assert!(
-                            gini > 0.1,
-                            "gini_coefficient should be > 0.1 for unequal distribution, got: {}",
-                            gini
-                        );
-                        assert!(
-                            gini <= 1.0,
-                            "gini_coefficient should be <= 1.0, got: {}",
-                            gini
-                        );
-                    }
+                if let Some(val_str) = gini_val
+                    && !val_str.is_empty()
+                {
+                    let gini: f64 = val_str.parse().unwrap();
+                    // With one large value, Gini should be significantly > 0
+                    assert!(
+                        gini > 0.1,
+                        "gini_coefficient should be > 0.1 for unequal distribution, got: {}",
+                        gini
+                    );
+                    assert!(
+                        gini <= 1.0,
+                        "gini_coefficient should be <= 1.0, got: {}",
+                        gini
+                    );
                 }
             }
 
             // Kurtosis should be computed
             if let Some(kurtosis_idx) = get_column_index(&headers, "kurtosis") {
                 let kurtosis_val = get_field_value(&record, kurtosis_idx);
-                if let Some(val_str) = kurtosis_val {
-                    if !val_str.is_empty() {
-                        let kurtosis: f64 = val_str.parse().unwrap();
-                        // With an outlier, kurtosis might be positive (heavy tails)
-                        assert!(kurtosis.is_finite(), "kurtosis should be finite");
-                    }
+                if let Some(val_str) = kurtosis_val
+                    && !val_str.is_empty()
+                {
+                    let kurtosis: f64 = val_str.parse().unwrap();
+                    // With an outlier, kurtosis might be positive (heavy tails)
+                    assert!(kurtosis.is_finite(), "kurtosis should be finite");
                 }
             }
 
@@ -2248,28 +2245,28 @@ fn moarstats_with_advanced_flag() {
             // Check kurtosis
             if let Some(kurtosis_idx) = get_column_index(&headers, "kurtosis") {
                 let kurtosis_val = get_field_value(&record, kurtosis_idx);
-                if let Some(val_str) = kurtosis_val {
-                    if !val_str.is_empty() {
-                        found_kurtosis_value = true;
-                        let kurtosis: f64 = val_str.parse().unwrap();
-                        assert!(kurtosis.is_finite(), "kurtosis should be a finite number");
-                    }
+                if let Some(val_str) = kurtosis_val
+                    && !val_str.is_empty()
+                {
+                    found_kurtosis_value = true;
+                    let kurtosis: f64 = val_str.parse().unwrap();
+                    assert!(kurtosis.is_finite(), "kurtosis should be a finite number");
                 }
             }
 
             // Check Gini coefficient
             if let Some(gini_idx) = get_column_index(&headers, "gini_coefficient") {
                 let gini_val = get_field_value(&record, gini_idx);
-                if let Some(val_str) = gini_val {
-                    if !val_str.is_empty() {
-                        found_gini_value = true;
-                        let gini: f64 = val_str.parse().unwrap();
-                        assert!(
-                            gini >= 0.0 && gini <= 1.0,
-                            "gini_coefficient should be between 0 and 1, got: {}",
-                            gini
-                        );
-                    }
+                if let Some(val_str) = gini_val
+                    && !val_str.is_empty()
+                {
+                    found_gini_value = true;
+                    let gini: f64 = val_str.parse().unwrap();
+                    assert!(
+                        (0.0..=1.0).contains(&gini),
+                        "gini_coefficient should be between 0 and 1, got: {}",
+                        gini
+                    );
                 }
             }
 
@@ -2407,52 +2404,52 @@ fn moarstats_outlier_variance_stddev() {
             // Verify outliers_stddev and outliers_variance
             if let Some(stddev_idx) = get_column_index(&headers, "outliers_stddev") {
                 let stddev_val = get_field_value(&record, stddev_idx);
-                if let Some(val_str) = stddev_val {
-                    if !val_str.is_empty() {
-                        let stddev: f64 = val_str.parse().unwrap();
-                        assert!(stddev >= 0.0, "outliers_stddev should be non-negative");
-                        assert!(stddev.is_finite(), "outliers_stddev should be finite");
-                    }
+                if let Some(val_str) = stddev_val
+                    && !val_str.is_empty()
+                {
+                    let stddev: f64 = val_str.parse().unwrap();
+                    assert!(stddev >= 0.0, "outliers_stddev should be non-negative");
+                    assert!(stddev.is_finite(), "outliers_stddev should be finite");
                 }
             }
 
             if let Some(variance_idx) = get_column_index(&headers, "outliers_variance") {
                 let variance_val = get_field_value(&record, variance_idx);
-                if let Some(val_str) = variance_val {
-                    if !val_str.is_empty() {
-                        let variance: f64 = val_str.parse().unwrap();
-                        assert!(variance >= 0.0, "outliers_variance should be non-negative");
-                        assert!(variance.is_finite(), "outliers_variance should be finite");
-                    }
+                if let Some(val_str) = variance_val
+                    && !val_str.is_empty()
+                {
+                    let variance: f64 = val_str.parse().unwrap();
+                    assert!(variance >= 0.0, "outliers_variance should be non-negative");
+                    assert!(variance.is_finite(), "outliers_variance should be finite");
                 }
             }
 
             // Verify non_outliers_stddev and non_outliers_variance
             if let Some(stddev_idx) = get_column_index(&headers, "non_outliers_stddev") {
                 let stddev_val = get_field_value(&record, stddev_idx);
-                if let Some(val_str) = stddev_val {
-                    if !val_str.is_empty() {
-                        let stddev: f64 = val_str.parse().unwrap();
-                        assert!(stddev >= 0.0, "non_outliers_stddev should be non-negative");
-                        assert!(stddev.is_finite(), "non_outliers_stddev should be finite");
-                    }
+                if let Some(val_str) = stddev_val
+                    && !val_str.is_empty()
+                {
+                    let stddev: f64 = val_str.parse().unwrap();
+                    assert!(stddev >= 0.0, "non_outliers_stddev should be non-negative");
+                    assert!(stddev.is_finite(), "non_outliers_stddev should be finite");
                 }
             }
 
             if let Some(variance_idx) = get_column_index(&headers, "non_outliers_variance") {
                 let variance_val = get_field_value(&record, variance_idx);
-                if let Some(val_str) = variance_val {
-                    if !val_str.is_empty() {
-                        let variance: f64 = val_str.parse().unwrap();
-                        assert!(
-                            variance >= 0.0,
-                            "non_outliers_variance should be non-negative"
-                        );
-                        assert!(
-                            variance.is_finite(),
-                            "non_outliers_variance should be finite"
-                        );
-                    }
+                if let Some(val_str) = variance_val
+                    && !val_str.is_empty()
+                {
+                    let variance: f64 = val_str.parse().unwrap();
+                    assert!(
+                        variance >= 0.0,
+                        "non_outliers_variance should be non-negative"
+                    );
+                    assert!(
+                        variance.is_finite(),
+                        "non_outliers_variance should be finite"
+                    );
                 }
             }
 
@@ -2510,23 +2507,23 @@ fn moarstats_outlier_coefficient_of_variation() {
         if field_name == "test" {
             if let Some(cv_idx) = get_column_index(&headers, "outliers_cv") {
                 let cv_val = get_field_value(&record, cv_idx);
-                if let Some(val_str) = cv_val {
-                    if !val_str.is_empty() {
-                        let cv: f64 = val_str.parse().unwrap();
-                        assert!(cv >= 0.0, "outliers_cv should be non-negative");
-                        assert!(cv.is_finite(), "outliers_cv should be finite");
-                    }
+                if let Some(val_str) = cv_val
+                    && !val_str.is_empty()
+                {
+                    let cv: f64 = val_str.parse().unwrap();
+                    assert!(cv >= 0.0, "outliers_cv should be non-negative");
+                    assert!(cv.is_finite(), "outliers_cv should be finite");
                 }
             }
 
             if let Some(cv_idx) = get_column_index(&headers, "non_outliers_cv") {
                 let cv_val = get_field_value(&record, cv_idx);
-                if let Some(val_str) = cv_val {
-                    if !val_str.is_empty() {
-                        let cv: f64 = val_str.parse().unwrap();
-                        assert!(cv >= 0.0, "non_outliers_cv should be non-negative");
-                        assert!(cv.is_finite(), "non_outliers_cv should be finite");
-                    }
+                if let Some(val_str) = cv_val
+                    && !val_str.is_empty()
+                {
+                    let cv: f64 = val_str.parse().unwrap();
+                    assert!(cv >= 0.0, "non_outliers_cv should be non-negative");
+                    assert!(cv.is_finite(), "non_outliers_cv should be finite");
                 }
             }
 
@@ -2580,15 +2577,15 @@ fn moarstats_outlier_percentage() {
         if field_name == "test" {
             if let Some(pct_idx) = get_column_index(&headers, "outliers_percentage") {
                 let pct_val = get_field_value(&record, pct_idx);
-                if let Some(val_str) = pct_val {
-                    if !val_str.is_empty() {
-                        let pct: f64 = val_str.parse().unwrap();
-                        assert!(
-                            pct >= 0.0 && pct <= 100.0,
-                            "outliers_percentage should be between 0 and 100"
-                        );
-                        assert!(pct.is_finite(), "outliers_percentage should be finite");
-                    }
+                if let Some(val_str) = pct_val
+                    && !val_str.is_empty()
+                {
+                    let pct: f64 = val_str.parse().unwrap();
+                    assert!(
+                        (0.0..=100.0).contains(&pct),
+                        "outliers_percentage should be between 0 and 100"
+                    );
+                    assert!(pct.is_finite(), "outliers_percentage should be finite");
                 }
             }
 
@@ -2646,21 +2643,21 @@ fn moarstats_outlier_impact() {
         if field_name == "test" {
             if let Some(impact_idx) = get_column_index(&headers, "outlier_impact") {
                 let impact_val = get_field_value(&record, impact_idx);
-                if let Some(val_str) = impact_val {
-                    if !val_str.is_empty() {
-                        let impact: f64 = val_str.parse().unwrap();
-                        assert!(impact.is_finite(), "outlier_impact should be finite");
-                    }
+                if let Some(val_str) = impact_val
+                    && !val_str.is_empty()
+                {
+                    let impact: f64 = val_str.parse().unwrap();
+                    assert!(impact.is_finite(), "outlier_impact should be finite");
                 }
             }
 
             if let Some(ratio_idx) = get_column_index(&headers, "outlier_impact_ratio") {
                 let ratio_val = get_field_value(&record, ratio_idx);
-                if let Some(val_str) = ratio_val {
-                    if !val_str.is_empty() {
-                        let ratio: f64 = val_str.parse().unwrap();
-                        assert!(ratio.is_finite(), "outlier_impact_ratio should be finite");
-                    }
+                if let Some(val_str) = ratio_val
+                    && !val_str.is_empty()
+                {
+                    let ratio: f64 = val_str.parse().unwrap();
+                    assert!(ratio.is_finite(), "outlier_impact_ratio should be finite");
                 }
             }
 
@@ -2715,18 +2712,18 @@ fn moarstats_outlier_spread_ratio() {
         if field_name == "test" {
             if let Some(ratio_idx) = get_column_index(&headers, "outliers_normal_stddev_ratio") {
                 let ratio_val = get_field_value(&record, ratio_idx);
-                if let Some(val_str) = ratio_val {
-                    if !val_str.is_empty() {
-                        let ratio: f64 = val_str.parse().unwrap();
-                        assert!(
-                            ratio >= 0.0,
-                            "outliers_normal_stddev_ratio should be non-negative"
-                        );
-                        assert!(
-                            ratio.is_finite(),
-                            "outliers_normal_stddev_ratio should be finite"
-                        );
-                    }
+                if let Some(val_str) = ratio_val
+                    && !val_str.is_empty()
+                {
+                    let ratio: f64 = val_str.parse().unwrap();
+                    assert!(
+                        ratio >= 0.0,
+                        "outliers_normal_stddev_ratio should be non-negative"
+                    );
+                    assert!(
+                        ratio.is_finite(),
+                        "outliers_normal_stddev_ratio should be finite"
+                    );
                 }
             }
 
@@ -2783,27 +2780,27 @@ fn moarstats_outlier_fence_zscores() {
         if field_name == "test" {
             if let Some(zscore_idx) = get_column_index(&headers, "lower_outer_fence_zscore") {
                 let zscore_val = get_field_value(&record, zscore_idx);
-                if let Some(val_str) = zscore_val {
-                    if !val_str.is_empty() {
-                        let zscore: f64 = val_str.parse().unwrap();
-                        assert!(
-                            zscore.is_finite(),
-                            "lower_outer_fence_zscore should be finite"
-                        );
-                    }
+                if let Some(val_str) = zscore_val
+                    && !val_str.is_empty()
+                {
+                    let zscore: f64 = val_str.parse().unwrap();
+                    assert!(
+                        zscore.is_finite(),
+                        "lower_outer_fence_zscore should be finite"
+                    );
                 }
             }
 
             if let Some(zscore_idx) = get_column_index(&headers, "upper_outer_fence_zscore") {
                 let zscore_val = get_field_value(&record, zscore_idx);
-                if let Some(val_str) = zscore_val {
-                    if !val_str.is_empty() {
-                        let zscore: f64 = val_str.parse().unwrap();
-                        assert!(
-                            zscore.is_finite(),
-                            "upper_outer_fence_zscore should be finite"
-                        );
-                    }
+                if let Some(val_str) = zscore_val
+                    && !val_str.is_empty()
+                {
+                    let zscore: f64 = val_str.parse().unwrap();
+                    assert!(
+                        zscore.is_finite(),
+                        "upper_outer_fence_zscore should be finite"
+                    );
                 }
             }
 
@@ -2873,64 +2870,64 @@ fn moarstats_trimmed_winsorized_variance_stddev() {
             // Verify trimmed stddev/variance
             if let Some(stddev_idx) = get_column_index(&headers, "trimmed_stddev_25pct") {
                 let stddev_val = get_field_value(&record, stddev_idx);
-                if let Some(val_str) = stddev_val {
-                    if !val_str.is_empty() {
-                        let stddev: f64 = val_str.parse().unwrap();
-                        assert!(stddev >= 0.0, "trimmed_stddev_25pct should be non-negative");
-                        assert!(stddev.is_finite(), "trimmed_stddev_25pct should be finite");
-                    }
+                if let Some(val_str) = stddev_val
+                    && !val_str.is_empty()
+                {
+                    let stddev: f64 = val_str.parse().unwrap();
+                    assert!(stddev >= 0.0, "trimmed_stddev_25pct should be non-negative");
+                    assert!(stddev.is_finite(), "trimmed_stddev_25pct should be finite");
                 }
             }
 
             if let Some(variance_idx) = get_column_index(&headers, "trimmed_variance_25pct") {
                 let variance_val = get_field_value(&record, variance_idx);
-                if let Some(val_str) = variance_val {
-                    if !val_str.is_empty() {
-                        let variance: f64 = val_str.parse().unwrap();
-                        assert!(
-                            variance >= 0.0,
-                            "trimmed_variance_25pct should be non-negative"
-                        );
-                        assert!(
-                            variance.is_finite(),
-                            "trimmed_variance_25pct should be finite"
-                        );
-                    }
+                if let Some(val_str) = variance_val
+                    && !val_str.is_empty()
+                {
+                    let variance: f64 = val_str.parse().unwrap();
+                    assert!(
+                        variance >= 0.0,
+                        "trimmed_variance_25pct should be non-negative"
+                    );
+                    assert!(
+                        variance.is_finite(),
+                        "trimmed_variance_25pct should be finite"
+                    );
                 }
             }
 
             // Verify winsorized stddev/variance
             if let Some(stddev_idx) = get_column_index(&headers, "winsorized_stddev_25pct") {
                 let stddev_val = get_field_value(&record, stddev_idx);
-                if let Some(val_str) = stddev_val {
-                    if !val_str.is_empty() {
-                        let stddev: f64 = val_str.parse().unwrap();
-                        assert!(
-                            stddev >= 0.0,
-                            "winsorized_stddev_25pct should be non-negative"
-                        );
-                        assert!(
-                            stddev.is_finite(),
-                            "winsorized_stddev_25pct should be finite"
-                        );
-                    }
+                if let Some(val_str) = stddev_val
+                    && !val_str.is_empty()
+                {
+                    let stddev: f64 = val_str.parse().unwrap();
+                    assert!(
+                        stddev >= 0.0,
+                        "winsorized_stddev_25pct should be non-negative"
+                    );
+                    assert!(
+                        stddev.is_finite(),
+                        "winsorized_stddev_25pct should be finite"
+                    );
                 }
             }
 
             if let Some(variance_idx) = get_column_index(&headers, "winsorized_variance_25pct") {
                 let variance_val = get_field_value(&record, variance_idx);
-                if let Some(val_str) = variance_val {
-                    if !val_str.is_empty() {
-                        let variance: f64 = val_str.parse().unwrap();
-                        assert!(
-                            variance >= 0.0,
-                            "winsorized_variance_25pct should be non-negative"
-                        );
-                        assert!(
-                            variance.is_finite(),
-                            "winsorized_variance_25pct should be finite"
-                        );
-                    }
+                if let Some(val_str) = variance_val
+                    && !val_str.is_empty()
+                {
+                    let variance: f64 = val_str.parse().unwrap();
+                    assert!(
+                        variance >= 0.0,
+                        "winsorized_variance_25pct should be non-negative"
+                    );
+                    assert!(
+                        variance.is_finite(),
+                        "winsorized_variance_25pct should be finite"
+                    );
                 }
             }
 
@@ -2987,23 +2984,23 @@ fn moarstats_trimmed_winsorized_cv() {
         if field_name == "test" {
             if let Some(cv_idx) = get_column_index(&headers, "trimmed_cv_25pct") {
                 let cv_val = get_field_value(&record, cv_idx);
-                if let Some(val_str) = cv_val {
-                    if !val_str.is_empty() {
-                        let cv: f64 = val_str.parse().unwrap();
-                        assert!(cv >= 0.0, "trimmed_cv_25pct should be non-negative");
-                        assert!(cv.is_finite(), "trimmed_cv_25pct should be finite");
-                    }
+                if let Some(val_str) = cv_val
+                    && !val_str.is_empty()
+                {
+                    let cv: f64 = val_str.parse().unwrap();
+                    assert!(cv >= 0.0, "trimmed_cv_25pct should be non-negative");
+                    assert!(cv.is_finite(), "trimmed_cv_25pct should be finite");
                 }
             }
 
             if let Some(cv_idx) = get_column_index(&headers, "winsorized_cv_25pct") {
                 let cv_val = get_field_value(&record, cv_idx);
-                if let Some(val_str) = cv_val {
-                    if !val_str.is_empty() {
-                        let cv: f64 = val_str.parse().unwrap();
-                        assert!(cv >= 0.0, "winsorized_cv_25pct should be non-negative");
-                        assert!(cv.is_finite(), "winsorized_cv_25pct should be finite");
-                    }
+                if let Some(val_str) = cv_val
+                    && !val_str.is_empty()
+                {
+                    let cv: f64 = val_str.parse().unwrap();
+                    assert!(cv >= 0.0, "winsorized_cv_25pct should be non-negative");
+                    assert!(cv.is_finite(), "winsorized_cv_25pct should be finite");
                 }
             }
 
@@ -3070,12 +3067,12 @@ fn moarstats_trimmed_winsorized_stddev_ratio() {
             for (idx, header) in headers.iter().enumerate() {
                 if header.contains("trimmed") && header.contains("stddev_ratio") {
                     let ratio_val = get_field_value(&record, idx);
-                    if let Some(val_str) = ratio_val {
-                        if !val_str.is_empty() {
-                            let ratio: f64 = val_str.parse().unwrap();
-                            assert!(ratio >= 0.0, "trimmed stddev_ratio should be non-negative");
-                            assert!(ratio.is_finite(), "trimmed stddev_ratio should be finite");
-                        }
+                    if let Some(val_str) = ratio_val
+                        && !val_str.is_empty()
+                    {
+                        let ratio: f64 = val_str.parse().unwrap();
+                        assert!(ratio >= 0.0, "trimmed stddev_ratio should be non-negative");
+                        assert!(ratio.is_finite(), "trimmed stddev_ratio should be finite");
                     }
                 }
             }
@@ -3084,18 +3081,18 @@ fn moarstats_trimmed_winsorized_stddev_ratio() {
             for (idx, header) in headers.iter().enumerate() {
                 if header.contains("winsorized") && header.contains("stddev_ratio") {
                     let ratio_val = get_field_value(&record, idx);
-                    if let Some(val_str) = ratio_val {
-                        if !val_str.is_empty() {
-                            let ratio: f64 = val_str.parse().unwrap();
-                            assert!(
-                                ratio >= 0.0,
-                                "winsorized stddev_ratio should be non-negative"
-                            );
-                            assert!(
-                                ratio.is_finite(),
-                                "winsorized stddev_ratio should be finite"
-                            );
-                        }
+                    if let Some(val_str) = ratio_val
+                        && !val_str.is_empty()
+                    {
+                        let ratio: f64 = val_str.parse().unwrap();
+                        assert!(
+                            ratio >= 0.0,
+                            "winsorized stddev_ratio should be non-negative"
+                        );
+                        assert!(
+                            ratio.is_finite(),
+                            "winsorized stddev_ratio should be finite"
+                        );
                     }
                 }
             }
@@ -3157,26 +3154,26 @@ fn moarstats_trimmed_winsorized_range() {
         if field_name == "test" {
             if let Some(range_idx) = get_column_index(&headers, "trimmed_range_25pct") {
                 let range_val = get_field_value(&record, range_idx);
-                if let Some(val_str) = range_val {
-                    if !val_str.is_empty() {
-                        let range: f64 = val_str.parse().unwrap();
-                        assert!(range >= 0.0, "trimmed_range_25pct should be non-negative");
-                        assert!(range.is_finite(), "trimmed_range_25pct should be finite");
-                    }
+                if let Some(val_str) = range_val
+                    && !val_str.is_empty()
+                {
+                    let range: f64 = val_str.parse().unwrap();
+                    assert!(range >= 0.0, "trimmed_range_25pct should be non-negative");
+                    assert!(range.is_finite(), "trimmed_range_25pct should be finite");
                 }
             }
 
             if let Some(range_idx) = get_column_index(&headers, "winsorized_range_25pct") {
                 let range_val = get_field_value(&record, range_idx);
-                if let Some(val_str) = range_val {
-                    if !val_str.is_empty() {
-                        let range: f64 = val_str.parse().unwrap();
-                        assert!(
-                            range >= 0.0,
-                            "winsorized_range_25pct should be non-negative"
-                        );
-                        assert!(range.is_finite(), "winsorized_range_25pct should be finite");
-                    }
+                if let Some(val_str) = range_val
+                    && !val_str.is_empty()
+                {
+                    let range: f64 = val_str.parse().unwrap();
+                    assert!(
+                        range >= 0.0,
+                        "winsorized_range_25pct should be non-negative"
+                    );
+                    assert!(range.is_finite(), "winsorized_range_25pct should be finite");
                 }
             }
 
@@ -3225,22 +3222,22 @@ fn moarstats_shannon_entropy_basic() {
         // Shannon entropy works for all field types
         if let Some(entropy_idx) = get_column_index(&headers, "shannon_entropy") {
             let entropy_val = get_field_value(&record, entropy_idx);
-            if let Some(val_str) = entropy_val {
-                if !val_str.is_empty() {
-                    found_entropy_value = true;
-                    let entropy: f64 = val_str.parse().unwrap();
-                    // Entropy should be non-negative
-                    assert!(
-                        entropy >= 0.0,
-                        "shannon_entropy should be non-negative, got: {}",
-                        entropy
-                    );
-                    assert!(
-                        entropy.is_finite(),
-                        "shannon_entropy should be finite, got: {}",
-                        entropy
-                    );
-                }
+            if let Some(val_str) = entropy_val
+                && !val_str.is_empty()
+            {
+                found_entropy_value = true;
+                let entropy: f64 = val_str.parse().unwrap();
+                // Entropy should be non-negative
+                assert!(
+                    entropy >= 0.0,
+                    "shannon_entropy should be non-negative, got: {}",
+                    entropy
+                );
+                assert!(
+                    entropy.is_finite(),
+                    "shannon_entropy should be finite, got: {}",
+                    entropy
+                );
             }
         }
 
@@ -3299,17 +3296,16 @@ fn moarstats_shannon_entropy_constant_values() {
             // With constant values, entropy should be 0 (all values identical)
             if let Some(entropy_idx) = get_column_index(&headers, "shannon_entropy") {
                 let entropy_val = get_field_value(&record, entropy_idx);
-                if let Some(val_str) = entropy_val {
-                    if !val_str.is_empty() {
-                        let entropy: f64 = val_str.parse().unwrap();
-                        // Entropy should be approximately 0 for constant values
-                        assert!(
-                            entropy.abs() < 0.001,
-                            "shannon_entropy should be approximately 0 for constant values, got: \
-                             {}",
-                            entropy
-                        );
-                    }
+                if let Some(val_str) = entropy_val
+                    && !val_str.is_empty()
+                {
+                    let entropy: f64 = val_str.parse().unwrap();
+                    // Entropy should be approximately 0 for constant values
+                    assert!(
+                        entropy.abs() < 0.001,
+                        "shannon_entropy should be approximately 0 for constant values, got: {}",
+                        entropy
+                    );
                 }
             }
 
@@ -3364,25 +3360,25 @@ fn moarstats_shannon_entropy_all_unique() {
         if field_name == "test" {
             if let Some(entropy_idx) = get_column_index(&headers, "shannon_entropy") {
                 let entropy_val = get_field_value(&record, entropy_idx);
-                if let Some(val_str) = entropy_val {
-                    if !val_str.is_empty() {
-                        let entropy: f64 = val_str.parse().unwrap();
-                        let max_entropy = 8.0_f64.log2(); // log2(8) = 3.0
-                        // Entropy should be close to maximum (all unique values)
-                        assert!(
-                            entropy >= max_entropy * 0.99,
-                            "shannon_entropy should be close to maximum for all unique values, \
-                             expected ~{}, got: {}",
-                            max_entropy,
-                            entropy
-                        );
-                        assert!(
-                            entropy <= max_entropy,
-                            "shannon_entropy cannot exceed log2(n), expected <= {}, got: {}",
-                            max_entropy,
-                            entropy
-                        );
-                    }
+                if let Some(val_str) = entropy_val
+                    && !val_str.is_empty()
+                {
+                    let entropy: f64 = val_str.parse().unwrap();
+                    let max_entropy = 8.0_f64.log2(); // log2(8) = 3.0
+                    // Entropy should be close to maximum (all unique values)
+                    assert!(
+                        entropy >= max_entropy * 0.99,
+                        "shannon_entropy should be close to maximum for all unique values, \
+                         expected ~{}, got: {}",
+                        max_entropy,
+                        entropy
+                    );
+                    assert!(
+                        entropy <= max_entropy,
+                        "shannon_entropy cannot exceed log2(n), expected <= {}, got: {}",
+                        max_entropy,
+                        entropy
+                    );
                 }
             }
 
@@ -3436,18 +3432,18 @@ fn moarstats_shannon_entropy_string_fields() {
             // String fields should have entropy computed
             if let Some(entropy_idx) = get_column_index(&headers, "shannon_entropy") {
                 let entropy_val = get_field_value(&record, entropy_idx);
-                if let Some(val_str) = entropy_val {
-                    if !val_str.is_empty() {
-                        let entropy: f64 = val_str.parse().unwrap();
-                        // With 3 unique values out of 5 total, entropy should be between 0 and
-                        // log2(3)
-                        assert!(
-                            entropy >= 0.0 && entropy <= 3.0_f64.log2(),
-                            "shannon_entropy for string fields should be in valid range, got: {}",
-                            entropy
-                        );
-                        assert!(entropy.is_finite(), "shannon_entropy should be finite");
-                    }
+                if let Some(val_str) = entropy_val
+                    && !val_str.is_empty()
+                {
+                    let entropy: f64 = val_str.parse().unwrap();
+                    // With 3 unique values out of 5 total, entropy should be between 0 and
+                    // log2(3)
+                    assert!(
+                        entropy >= 0.0 && entropy <= 3.0_f64.log2(),
+                        "shannon_entropy for string fields should be in valid range, got: {}",
+                        entropy
+                    );
+                    assert!(entropy.is_finite(), "shannon_entropy should be finite");
                 }
             }
 
@@ -3500,27 +3496,27 @@ fn moarstats_shannon_entropy_mixed_distribution() {
         if field_name == "test" {
             if let Some(entropy_idx) = get_column_index(&headers, "shannon_entropy") {
                 let entropy_val = get_field_value(&record, entropy_idx);
-                if let Some(val_str) = entropy_val {
-                    if !val_str.is_empty() {
-                        let entropy: f64 = val_str.parse().unwrap();
-                        // With 3 unique values (A appears 3 times, B appears 2 times, C appears 1
-                        // time) Entropy should be between 0 and log2(3) ≈
-                        // 1.585 But since distribution is not uniform, it
-                        // should be less than maximum
-                        let max_entropy = 3.0_f64.log2();
-                        assert!(
-                            entropy >= 0.0 && entropy <= max_entropy,
-                            "shannon_entropy should be in valid range [0, log2(3)], got: {}",
-                            entropy
-                        );
-                        // With non-uniform distribution, entropy should be less than maximum
-                        assert!(
-                            entropy < max_entropy,
-                            "shannon_entropy should be less than maximum for non-uniform \
-                             distribution, got: {}",
-                            entropy
-                        );
-                    }
+                if let Some(val_str) = entropy_val
+                    && !val_str.is_empty()
+                {
+                    let entropy: f64 = val_str.parse().unwrap();
+                    // With 3 unique values (A appears 3 times, B appears 2 times, C appears 1
+                    // time) Entropy should be between 0 and log2(3) ≈
+                    // 1.585 But since distribution is not uniform, it
+                    // should be less than maximum
+                    let max_entropy = 3.0_f64.log2();
+                    assert!(
+                        entropy >= 0.0 && entropy <= max_entropy,
+                        "shannon_entropy should be in valid range [0, log2(3)], got: {}",
+                        entropy
+                    );
+                    // With non-uniform distribution, entropy should be less than maximum
+                    assert!(
+                        entropy < max_entropy,
+                        "shannon_entropy should be less than maximum for non-uniform \
+                         distribution, got: {}",
+                        entropy
+                    );
                 }
             }
 
@@ -3618,16 +3614,16 @@ fn moarstats_shannon_entropy_insufficient_data() {
             // With only one value, entropy should be 0 (all values identical)
             if let Some(entropy_idx) = get_column_index(&headers, "shannon_entropy") {
                 let entropy_val = get_field_value(&record, entropy_idx);
-                if let Some(val_str) = entropy_val {
-                    if !val_str.is_empty() {
-                        let entropy: f64 = val_str.parse().unwrap();
-                        // Single value means entropy = 0
-                        assert!(
-                            entropy.abs() < 0.001,
-                            "shannon_entropy should be 0 for single value, got: {}",
-                            entropy
-                        );
-                    }
+                if let Some(val_str) = entropy_val
+                    && !val_str.is_empty()
+                {
+                    let entropy: f64 = val_str.parse().unwrap();
+                    // Single value means entropy = 0
+                    assert!(
+                        entropy.abs() < 0.001,
+                        "shannon_entropy should be 0 for single value, got: {}",
+                        entropy
+                    );
                 }
             }
 
@@ -3684,18 +3680,18 @@ fn moarstats_shannon_entropy_boolean_fields() {
             // Boolean fields should have entropy computed
             if let Some(entropy_idx) = get_column_index(&headers, "shannon_entropy") {
                 let entropy_val = get_field_value(&record, entropy_idx);
-                if let Some(val_str) = entropy_val {
-                    if !val_str.is_empty() {
-                        let entropy: f64 = val_str.parse().unwrap();
-                        // With 2 unique values (true/false), max entropy is log2(2) = 1.0
-                        // With 3 true and 2 false, entropy should be less than 1.0
-                        assert!(
-                            entropy >= 0.0 && entropy <= 1.0,
-                            "shannon_entropy for boolean fields should be in [0, 1], got: {}",
-                            entropy
-                        );
-                        assert!(entropy.is_finite(), "shannon_entropy should be finite");
-                    }
+                if let Some(val_str) = entropy_val
+                    && !val_str.is_empty()
+                {
+                    let entropy: f64 = val_str.parse().unwrap();
+                    // With 2 unique values (true/false), max entropy is log2(2) = 1.0
+                    // With 3 true and 2 false, entropy should be less than 1.0
+                    assert!(
+                        (0.0..=1.0).contains(&entropy),
+                        "shannon_entropy for boolean fields should be in [0, 1], got: {}",
+                        entropy
+                    );
+                    assert!(entropy.is_finite(), "shannon_entropy should be finite");
                 }
             }
 
@@ -3794,16 +3790,16 @@ fn moarstats_bivariate_basic() {
 
             // Verify Pearson correlation (should be 1.0 for perfect positive correlation)
             let pearson_val = get_field_value(&record, pearson_idx);
-            if let Some(val_str) = pearson_val {
-                if !val_str.is_empty() {
-                    let pearson: f64 = val_str.parse().unwrap();
-                    assert!(
-                        pearson >= 0.99 && pearson <= 1.0,
-                        "Pearson correlation should be close to 1.0 for perfect positive \
-                         correlation, got: {}",
-                        pearson
-                    );
-                }
+            if let Some(val_str) = pearson_val
+                && !val_str.is_empty()
+            {
+                let pearson: f64 = val_str.parse().unwrap();
+                assert!(
+                    (0.99..=1.0).contains(&pearson),
+                    "Pearson correlation should be close to 1.0 for perfect positive correlation, \
+                     got: {}",
+                    pearson
+                );
             }
 
             break;
@@ -3857,16 +3853,16 @@ fn moarstats_bivariate_negative_correlation() {
 
         if (field1 == "x" && field2 == "y") || (field1 == "y" && field2 == "x") {
             let pearson_val = get_field_value(&record, pearson_idx);
-            if let Some(val_str) = pearson_val {
-                if !val_str.is_empty() {
-                    let pearson: f64 = val_str.parse().unwrap();
-                    assert!(
-                        pearson <= -0.99 && pearson >= -1.0,
-                        "Pearson correlation should be close to -1.0 for perfect negative \
-                         correlation, got: {}",
-                        pearson
-                    );
-                }
+            if let Some(val_str) = pearson_val
+                && !val_str.is_empty()
+            {
+                let pearson: f64 = val_str.parse().unwrap();
+                assert!(
+                    (-1.0..=-0.99).contains(&pearson),
+                    "Pearson correlation should be close to -1.0 for perfect negative \
+                     correlation, got: {}",
+                    pearson
+                );
             }
             break;
         }
@@ -3930,16 +3926,16 @@ fn moarstats_bivariate_string_fields() {
 
             // Verify mutual information exists and is non-negative
             let mi_val = get_field_value(&record, mi_idx);
-            if let Some(val_str) = mi_val {
-                if !val_str.is_empty() {
-                    let mi: f64 = val_str.parse().unwrap();
-                    assert!(
-                        mi >= 0.0,
-                        "Mutual information should be non-negative, got: {}",
-                        mi
-                    );
-                    assert!(mi.is_finite(), "Mutual information should be finite");
-                }
+            if let Some(val_str) = mi_val
+                && !val_str.is_empty()
+            {
+                let mi: f64 = val_str.parse().unwrap();
+                assert!(
+                    mi >= 0.0,
+                    "Mutual information should be non-negative, got: {}",
+                    mi
+                );
+                assert!(mi.is_finite(), "Mutual information should be finite");
             }
 
             break;
@@ -4023,33 +4019,33 @@ fn moarstats_bivariate_normalized_mutual_information() {
                 "Normalized mutual information should be computed"
             );
 
-            if let Some(val_str) = nmi_val {
-                if !val_str.is_empty() {
-                    let nmi: f64 = val_str.parse().unwrap();
-                    // NMI should be between 0 and 1 (normalized)
-                    assert!(
-                        nmi >= 0.0 && nmi <= 1.0,
-                        "Normalized mutual information should be in [0, 1], got: {}",
-                        nmi
-                    );
-                    assert!(
-                        nmi.is_finite(),
-                        "Normalized mutual information should be finite, got: {}",
-                        nmi
-                    );
-                    assert!(
-                        !nmi.is_nan(),
-                        "Normalized mutual information should not be NaN"
-                    );
+            if let Some(val_str) = nmi_val
+                && !val_str.is_empty()
+            {
+                let nmi: f64 = val_str.parse().unwrap();
+                // NMI should be between 0 and 1 (normalized)
+                assert!(
+                    (0.0..=1.0).contains(&nmi),
+                    "Normalized mutual information should be in [0, 1], got: {}",
+                    nmi
+                );
+                assert!(
+                    nmi.is_finite(),
+                    "Normalized mutual information should be finite, got: {}",
+                    nmi
+                );
+                assert!(
+                    !nmi.is_nan(),
+                    "Normalized mutual information should not be NaN"
+                );
 
-                    // Verify NMI is non-negative
-                    //(should always be true given the range check above)
-                    assert!(
-                        nmi >= 0.0,
-                        "Normalized mutual information should be non-negative, got: {}",
-                        nmi
-                    );
-                }
+                // Verify NMI is non-negative
+                //(should always be true given the range check above)
+                assert!(
+                    nmi >= 0.0,
+                    "Normalized mutual information should be non-negative, got: {}",
+                    nmi
+                );
             }
 
             break;
@@ -4218,7 +4214,7 @@ fn moarstats_bivariate_all_statistics() {
             if let Some(val_str) = pearson_val {
                 let pearson: f64 = val_str.parse().unwrap();
                 assert!(
-                    pearson >= -1.0 && pearson <= 1.0,
+                    (-1.0..=1.0).contains(&pearson),
                     "Pearson correlation should be in [-1, 1], got: {}",
                     pearson
                 );
@@ -4227,7 +4223,7 @@ fn moarstats_bivariate_all_statistics() {
             if let Some(val_str) = spearman_val {
                 let spearman: f64 = val_str.parse().unwrap();
                 assert!(
-                    spearman >= -1.0 && spearman <= 1.0,
+                    (-1.0..=1.0).contains(&spearman),
                     "Spearman correlation should be in [-1, 1], got: {}",
                     spearman
                 );
@@ -4236,7 +4232,7 @@ fn moarstats_bivariate_all_statistics() {
             if let Some(val_str) = kendall_val {
                 let kendall: f64 = val_str.parse().unwrap();
                 assert!(
-                    kendall >= -1.0 && kendall <= 1.0,
+                    (-1.0..=1.0).contains(&kendall),
                     "Kendall tau should be in [-1, 1], got: {}",
                     kendall
                 );
@@ -5338,7 +5334,7 @@ fn moarstats_xsd_gdate_scan_quick_mode() {
 
         if field.starts_with("g") {
             assert!(
-                xsd_type.as_deref().map_or(false, |t| t.ends_with("??")),
+                xsd_type.as_deref().is_some_and(|t| t.ends_with("??")),
                 "Quick mode should use double ?? suffix (less confident), got: {:?}",
                 xsd_type
             );
@@ -5510,9 +5506,7 @@ fn moarstats_xsd_gdate_scan_default_quick() {
             // Default should be quick mode with ?? suffix
             // So we just check that it's detected as gYear with some suffix
             assert!(
-                xsd_type
-                    .as_deref()
-                    .map_or(false, |t| t.starts_with("gYear")),
+                xsd_type.as_deref().is_some_and(|t| t.starts_with("gYear")),
                 "Year should be detected as gYear variant, got: {:?}",
                 xsd_type
             );
@@ -5559,9 +5553,7 @@ fn moarstats_xsd_gdate_scan_fallback_quick() {
             // Should fallback to quick mode (?? suffix) when percentiles unavailable
             // But if the field is Integer and min/max are in range, it should still detect gYear??
             assert!(
-                xsd_type
-                    .as_deref()
-                    .map_or(false, |t| t.starts_with("gYear")),
+                xsd_type.as_deref().is_some_and(|t| t.starts_with("gYear")),
                 "Year should be detected even when percentiles missing, got: {:?}",
                 xsd_type
             );

--- a/tests/test_moarstats.rs
+++ b/tests/test_moarstats.rs
@@ -198,6 +198,9 @@ fn moarstats_auto_generate_stats() {
 
     // Run moarstats with stats options - should auto-generate stats
     let mut cmd = wrk.command("moarstats");
+    // `--stats-options` takes a single space-separated string that qsv splits
+    // internally, so the space here is intentional (not two CLI args).
+    #[allow(clippy::suspicious_command_arg_space)]
     cmd.arg(&test_file)
         .arg("--stats-options")
         .arg("--everything --infer-dates");

--- a/tests/test_partition.rs
+++ b/tests/test_partition.rs
@@ -31,7 +31,7 @@ fn partition() {
     wrk.create("in.csv", data(true));
 
     let mut cmd = wrk.command("partition");
-    cmd.arg("state").arg(&wrk.path(".")).arg("in.csv");
+    cmd.arg("state").arg(wrk.path(".")).arg("in.csv");
     wrk.run(&mut cmd);
 
     part_eq!(
@@ -70,7 +70,7 @@ fn partition_drop() {
     let mut cmd = wrk.command("partition");
     cmd.arg("--drop")
         .arg("state")
-        .arg(&wrk.path("."))
+        .arg(wrk.path("."))
         .arg("in.csv");
     wrk.run(&mut cmd);
 
@@ -110,7 +110,7 @@ fn partition_without_headers() {
     let mut cmd = wrk.command("partition");
     cmd.arg("--no-headers")
         .arg("1")
-        .arg(&wrk.path("."))
+        .arg(wrk.path("."))
         .arg("in.csv");
     wrk.run(&mut cmd);
 
@@ -148,7 +148,7 @@ fn partition_drop_without_headers() {
     cmd.arg("--drop")
         .arg("--no-headers")
         .arg("1")
-        .arg(&wrk.path("."))
+        .arg(wrk.path("."))
         .arg("in.csv");
     wrk.run(&mut cmd);
 
@@ -183,7 +183,7 @@ fn partition_into_new_directory() {
     wrk.create("in.csv", data(true));
 
     let mut cmd = wrk.command("partition");
-    cmd.arg("state").arg(&wrk.path("out")).arg("in.csv");
+    cmd.arg("state").arg(wrk.path("out")).arg("in.csv");
     wrk.run(&mut cmd);
 
     assert!(wrk.path("out/NY.csv").exists());
@@ -197,7 +197,7 @@ fn partition_custom_filename() {
     let mut cmd = wrk.command("partition");
     cmd.args(["--filename", "state-{}-partition.csv"])
         .arg("state")
-        .arg(&wrk.path("."))
+        .arg(wrk.path("."))
         .arg("in.csv");
     wrk.run(&mut cmd);
 
@@ -212,7 +212,7 @@ fn partition_custom_filename_with_directory() {
     let mut cmd = wrk.command("partition");
     cmd.args(["--filename", "{}/cities.csv"])
         .arg("state")
-        .arg(&wrk.path("."))
+        .arg(wrk.path("."))
         .arg("in.csv");
     wrk.run(&mut cmd);
 
@@ -228,14 +228,14 @@ fn partition_invalid_filename() {
     let mut cmd = wrk.command("partition");
     cmd.args(["--filename", "foo.csv"])
         .arg("state")
-        .arg(&wrk.path("."))
+        .arg(wrk.path("."))
         .arg("in.csv");
     wrk.assert_err(&mut cmd);
 
     let mut cmd = wrk.command("partition");
     cmd.args(["--filename", "{}{}.csv"])
         .arg("state")
-        .arg(&wrk.path("."))
+        .arg(wrk.path("."))
         .arg("in.csv");
     wrk.assert_err(&mut cmd);
 }
@@ -260,7 +260,7 @@ fn partition_with_tricky_key_values() {
     wrk.create("in.csv", tricky_data());
 
     let mut cmd = wrk.command("partition");
-    cmd.arg("key").arg(&wrk.path(".")).arg("in.csv");
+    cmd.arg("key").arg(wrk.path(".")).arg("in.csv");
     wrk.run(&mut cmd);
 
     part_eq!(
@@ -361,7 +361,7 @@ fn partition_with_limit() {
     let mut cmd = wrk.command("partition");
     cmd.args(["--limit", "7"])
         .arg("state")
-        .arg(&wrk.path("."))
+        .arg(wrk.path("."))
         .arg("in.csv");
     wrk.run(&mut cmd);
 
@@ -519,7 +519,7 @@ fn partition_with_prefix_length() {
     let mut cmd = wrk.command("partition");
     cmd.args(["--prefix-length", "1"])
         .arg("state")
-        .arg(&wrk.path("."))
+        .arg(wrk.path("."))
         .arg("in.csv");
     wrk.run(&mut cmd);
 
@@ -559,7 +559,7 @@ fn partition_case_insensitive_collision() {
     );
 
     let mut cmd = wrk.command("partition");
-    cmd.arg("state").arg(&wrk.path(".")).arg("in.csv");
+    cmd.arg("state").arg(wrk.path(".")).arg("in.csv");
     wrk.run(&mut cmd);
 
     // On case-insensitive file systems, "CO" and "Co" would collide
@@ -610,7 +610,7 @@ fn partition_stdin_pipeline() {
 
     // Run the partition command with stdin input and --limit to trigger process_in_batches
     let mut cmd = wrk.command("partition");
-    cmd.args(["--limit", "3"]).arg("state").arg(&wrk.path("."));
+    cmd.args(["--limit", "3"]).arg("state").arg(wrk.path("."));
 
     // Set up stdin for the command (no input file argument = implicit stdin)
     let stdin_data = wrk.read_to_string("stdin_data.csv").unwrap();

--- a/tests/test_pivotp.rs
+++ b/tests/test_pivotp.rs
@@ -78,7 +78,7 @@ fn setup_maintain_order(name: &str) -> Workdir {
 
 // Test basic pivot with single index
 pivotp_test!(pivotp_basic, |wrk: Workdir, mut cmd: process::Command| {
-    cmd.args(&[
+    cmd.args([
         "product",
         "--index",
         "date",
@@ -104,7 +104,7 @@ pivotp_test!(pivotp_basic, |wrk: Workdir, mut cmd: process::Command| {
 pivotp_test!(
     pivotp_multi_index,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&[
+        cmd.args([
             "product",
             "--index",
             "date,region",
@@ -131,7 +131,7 @@ pivotp_test!(
 
 // Test pivot with sum aggregation
 pivotp_test!(pivotp_sum_agg, |wrk: Workdir, mut cmd: process::Command| {
-    cmd.args(&[
+    cmd.args([
         "product",
         "--index",
         "region",
@@ -157,7 +157,7 @@ pivotp_test!(pivotp_sum_agg, |wrk: Workdir, mut cmd: process::Command| {
 pivotp_test!(
     pivotp_mean_agg,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&[
+        cmd.args([
             "product",
             "--index",
             "region",
@@ -182,7 +182,7 @@ pivotp_test!(
 
 // Test pivot with min aggregation
 pivotp_test!(pivotp_min_agg, |wrk: Workdir, mut cmd: process::Command| {
-    cmd.args(&[
+    cmd.args([
         "product",
         "--index",
         "region",
@@ -206,7 +206,7 @@ pivotp_test!(pivotp_min_agg, |wrk: Workdir, mut cmd: process::Command| {
 
 // Test pivot with max aggregation
 pivotp_test!(pivotp_max_agg, |wrk: Workdir, mut cmd: process::Command| {
-    cmd.args(&[
+    cmd.args([
         "product",
         "--index",
         "region",
@@ -232,7 +232,7 @@ pivotp_test!(pivotp_max_agg, |wrk: Workdir, mut cmd: process::Command| {
 pivotp_test!(
     pivotp_median_agg,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&[
+        cmd.args([
             "product",
             "--index",
             "region",
@@ -262,7 +262,7 @@ pivotp_test!(
 pivotp_test!(
     pivotp_quantile_p95_agg,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&[
+        cmd.args([
             "product",
             "--index",
             "region",
@@ -290,7 +290,7 @@ pivotp_test!(
 pivotp_test!(
     pivotp_q_alias_p50_equals_median,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&[
+        cmd.args([
             "product",
             "--index",
             "region",
@@ -319,7 +319,7 @@ pivotp_test!(
     pivotp_quantile_invalid_p_rejected,
     |wrk: Workdir, mut cmd: process::Command| {
         // Out-of-range high
-        cmd.args(&[
+        cmd.args([
             "product",
             "--index",
             "region",
@@ -338,7 +338,7 @@ pivotp_test!(
 
         // Out-of-range low (negative)
         let mut cmd_2 = wrk.command("pivotp");
-        cmd_2.args(&[
+        cmd_2.args([
             "product",
             "--index",
             "region",
@@ -357,7 +357,7 @@ pivotp_test!(
 
         // Non-numeric suffix
         let mut cmd3 = wrk.command("pivotp");
-        cmd3.args(&[
+        cmd3.args([
             "product",
             "--index",
             "region",
@@ -382,7 +382,7 @@ pivotp_test!(
 pivotp_test!(
     pivotp_quantile_groupby_mode,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&[
+        cmd.args([
             "--index",
             "region",
             "--values",
@@ -406,7 +406,7 @@ pivotp_test!(
 
 // Test pivot with len aggregation
 pivotp_test!(pivotp_len_agg, |wrk: Workdir, mut cmd: process::Command| {
-    cmd.args(&[
+    cmd.args([
         "product",
         "--index",
         "region",
@@ -432,7 +432,7 @@ pivotp_test!(pivotp_len_agg, |wrk: Workdir, mut cmd: process::Command| {
 pivotp_test!(
     pivotp_last_agg,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&[
+        cmd.args([
             "product",
             "--index",
             "region",
@@ -459,7 +459,7 @@ pivotp_test!(
 pivotp_test!(
     pivotp_item_agg,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&[
+        cmd.args([
             "product",
             "--index",
             "region",
@@ -482,7 +482,7 @@ pivotp_test!(
 pivotp_test!(
     pivotp_sort_columns,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&[
+        cmd.args([
             "product",
             "--index",
             "date",
@@ -510,7 +510,7 @@ pivotp_test!(
 pivotp_maintain_order_test!(
     pivotp_maintain_order,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&[
+        cmd.args([
             "product",
             "--index",
             "date",
@@ -538,7 +538,7 @@ pivotp_maintain_order_test!(
 pivotp_maintain_order_test!(
     pivotp_maintain_order_and_sort_columns,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&[
+        cmd.args([
             "product",
             "--index",
             "date",
@@ -567,7 +567,7 @@ pivotp_maintain_order_test!(
 pivotp_test!(
     pivotp_col_separator,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&[
+        cmd.args([
             "product",
             "--index",
             "date",
@@ -604,7 +604,7 @@ pivotp_test!(
         ];
         wrk.create("sales_semicolon.csv", sales);
 
-        cmd.args(&[
+        cmd.args([
             "product",
             "--index",
             "date",
@@ -627,7 +627,7 @@ pivotp_test!(
 pivotp_test!(
     pivotp_no_index,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&["product", "--values", "sales", "--agg", "sum", "sales.csv"]);
+        cmd.args(["product", "--values", "sales", "--agg", "sum", "sales.csv"]);
 
         wrk.assert_success(&mut cmd);
 
@@ -647,7 +647,7 @@ pivotp_test!(
 pivotp_test!(
     pivotp_multi_on_cols,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&[
+        cmd.args([
             "product,region", // Multiple on-cols
             "--index",
             "date",
@@ -692,7 +692,7 @@ pivotp_test!(
         ];
         wrk.create("sales_multi.csv", sales_multi);
 
-        cmd.args(&[
+        cmd.args([
             "product",
             "--index",
             "date",
@@ -729,7 +729,7 @@ pivotp_test!(
         ];
         wrk.create("sales_multi.csv", sales_multi);
 
-        cmd.args(&[
+        cmd.args([
             "product",
             "--index",
             "date",
@@ -764,7 +764,7 @@ pivotp_test!(
 pivotp_test!(
     pivotp_try_parsedates,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&[
+        cmd.args([
             "product",
             "--index",
             "date",
@@ -800,7 +800,7 @@ pivotp_test!(
         ];
         wrk.create_with_delim("sales_decimal.csv", sales_decimal, b';');
 
-        cmd.args(&[
+        cmd.args([
             "product",
             "--index",
             "date",
@@ -826,7 +826,7 @@ pivotp_test!(
 pivotp_test!(
     pivotp_validate,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&[
+        cmd.args([
             "product",
             "--index",
             "date",
@@ -1317,7 +1317,7 @@ fn pivotp_smart_multimodal() {
 fn pivotp_smart_date_sparse() {
     let wrk = Workdir::new("pivotp_smart_date_sparse");
     // Date column with >50% NULL values
-    let csv_content = vec![
+    let csv_content = [
         "category,group,date_val",
         "A,X,2024-01-01",
         "A,Y,",
@@ -1369,7 +1369,7 @@ fn pivotp_smart_date_sparse() {
 fn pivotp_smart_date_ascending() {
     let wrk = Workdir::new("pivotp_smart_date_ascending");
     // Ascending date values — Last gives the most recent entry
-    let csv_content = vec![
+    let csv_content = [
         "category,group,date_val",
         "A,X,2024-01-01",
         "A,Y,2024-01-15",
@@ -1419,7 +1419,7 @@ fn pivotp_smart_date_ascending() {
 pivotp_test!(
     pivotp_infer_len,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&[
+        cmd.args([
             "product",
             "--index",
             "date",
@@ -1446,7 +1446,7 @@ pivotp_test!(
 pivotp_test!(
     pivotp_grand_total,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&[
+        cmd.args([
             "product",
             "--index",
             "region",
@@ -1475,7 +1475,7 @@ pivotp_test!(
 pivotp_test!(
     pivotp_subtotal,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&[
+        cmd.args([
             "product",
             "--index",
             "date,region",
@@ -1507,7 +1507,7 @@ pivotp_test!(
 pivotp_test!(
     pivotp_grand_total_and_subtotal,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&[
+        cmd.args([
             "product",
             "--index",
             "date,region",
@@ -1541,7 +1541,7 @@ pivotp_test!(
 pivotp_test!(
     pivotp_subtotal_single_index_error,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&[
+        cmd.args([
             "product",
             "--index",
             "region",
@@ -1561,7 +1561,7 @@ pivotp_test!(
 pivotp_test!(
     pivotp_grand_total_custom_label,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&[
+        cmd.args([
             "product",
             "--index",
             "region",
@@ -1587,7 +1587,7 @@ pivotp_test!(
 pivotp_test!(
     pivotp_grand_total_with_mean_agg,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&[
+        cmd.args([
             "product",
             "--index",
             "region",
@@ -1627,7 +1627,7 @@ pivotp_test!(
 pivotp_test!(
     pivotp_grand_total_sort_columns,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&[
+        cmd.args([
             "product",
             "--index",
             "region",
@@ -1659,7 +1659,7 @@ pivotp_test!(
 pivotp_test!(
     pivotp_grand_total_non_numeric_value,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&[
+        cmd.args([
             "product",
             "--index",
             "region",
@@ -1695,7 +1695,7 @@ pivotp_test!(
 pivotp_test!(
     pivotp_subtotal_non_numeric_value,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&[
+        cmd.args([
             "sales",
             "--index",
             "product,region",
@@ -1770,7 +1770,7 @@ fn setup_groupby(name: &str) -> Workdir {
 pivotp_groupby_test!(
     pivotp_groupby_basic_count,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&["--index", "GROUP", "--agg", "len", "test.csv"]);
+        cmd.args(["--index", "GROUP", "--agg", "len", "test.csv"]);
 
         wrk.assert_success(&mut cmd);
 
@@ -1791,7 +1791,7 @@ pivotp_groupby_test!(
 pivotp_groupby_test!(
     pivotp_groupby_no_values_default_agg,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&["--index", "GROUP", "test.csv"]);
+        cmd.args(["--index", "GROUP", "test.csv"]);
 
         wrk.assert_success(&mut cmd);
 
@@ -1806,7 +1806,7 @@ pivotp_groupby_test!(
 pivotp_groupby_test!(
     pivotp_groupby_grand_total,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&[
+        cmd.args([
             "--index",
             "GROUP",
             "--agg",
@@ -1835,7 +1835,7 @@ pivotp_groupby_test!(
 pivotp_groupby_test!(
     pivotp_groupby_with_values,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&[
+        cmd.args([
             "--index", "GROUP", "--values", "NAME", "--agg", "len", "test.csv",
         ]);
 
@@ -1858,7 +1858,7 @@ pivotp_groupby_test!(
 pivotp_test!(
     pivotp_groupby_sum,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&[
+        cmd.args([
             "--index",
             "region",
             "--values",
@@ -1884,7 +1884,7 @@ pivotp_test!(
 pivotp_test!(
     pivotp_groupby_multi_index,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&[
+        cmd.args([
             "--index",
             "date,region",
             "--values",
@@ -1921,7 +1921,7 @@ pivotp_test!(
         ];
         wrk.create("multi.csv", data);
 
-        cmd.args(&[
+        cmd.args([
             "--index",
             "region",
             "--values",
@@ -1947,7 +1947,7 @@ pivotp_test!(
 pivotp_groupby_test!(
     pivotp_groupby_maintain_order,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&[
+        cmd.args([
             "--index",
             "GROUP",
             "--agg",
@@ -1971,7 +1971,7 @@ pivotp_groupby_test!(
 pivotp_groupby_test!(
     pivotp_groupby_custom_total_label,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&[
+        cmd.args([
             "--index",
             "GROUP",
             "--agg",
@@ -1995,7 +1995,7 @@ pivotp_groupby_test!(
 pivotp_groupby_test!(
     pivotp_groupby_no_index_error,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&["--agg", "len", "test.csv"]);
+        cmd.args(["--agg", "len", "test.csv"]);
 
         wrk.assert_err(&mut cmd);
         let stderr = wrk.output_stderr(&mut cmd);
@@ -2010,7 +2010,7 @@ pivotp_groupby_test!(
 pivotp_groupby_test!(
     pivotp_groupby_subtotal_error,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&["--index", "GROUP", "--agg", "len", "--subtotal", "test.csv"]);
+        cmd.args(["--index", "GROUP", "--agg", "len", "--subtotal", "test.csv"]);
 
         wrk.assert_err(&mut cmd);
         let stderr = wrk.output_stderr(&mut cmd);
@@ -2025,7 +2025,7 @@ pivotp_groupby_test!(
 pivotp_groupby_test!(
     pivotp_groupby_validate_error,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&["--index", "GROUP", "--agg", "len", "--validate", "test.csv"]);
+        cmd.args(["--index", "GROUP", "--agg", "len", "--validate", "test.csv"]);
 
         wrk.assert_err(&mut cmd);
         let stderr = wrk.output_stderr(&mut cmd);
@@ -2040,7 +2040,7 @@ pivotp_groupby_test!(
 pivotp_groupby_test!(
     pivotp_groupby_sort_columns_error,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&[
+        cmd.args([
             "--index",
             "GROUP",
             "--agg",
@@ -2062,7 +2062,7 @@ pivotp_groupby_test!(
 pivotp_groupby_test!(
     pivotp_groupby_agg_none_error,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&["--index", "GROUP", "--agg", "none", "test.csv"]);
+        cmd.args(["--index", "GROUP", "--agg", "none", "test.csv"]);
 
         wrk.assert_err(&mut cmd);
         let stderr = wrk.output_stderr(&mut cmd);
@@ -2077,7 +2077,7 @@ pivotp_groupby_test!(
 pivotp_groupby_test!(
     pivotp_groupby_agg_item_error,
     |wrk: Workdir, mut cmd: process::Command| {
-        cmd.args(&["--index", "GROUP", "--agg", "item", "test.csv"]);
+        cmd.args(["--index", "GROUP", "--agg", "item", "test.csv"]);
 
         wrk.assert_err(&mut cmd);
         let stderr = wrk.output_stderr(&mut cmd);

--- a/tests/test_pragmastat.rs
+++ b/tests/test_pragmastat.rs
@@ -286,11 +286,10 @@ fn pragmastat_non_numeric_columns() {
     // case_status is text ("Open"/"Closed") => n=0, all estimators empty
     assert_eq!(got[1][0], "case_status");
     assert_eq!(got[1][1], "0");
-    for i in 2..8 {
+    for (header, cell) in got[0][2..8].iter().zip(&got[1][2..8]) {
         assert!(
-            got[1][i].is_empty(),
-            "column {} should be empty for non-numeric data",
-            got[0][i]
+            cell.is_empty(),
+            "column {header} should be empty for non-numeric data"
         );
     }
 }

--- a/tests/test_pseudo.rs
+++ b/tests/test_pseudo.rs
@@ -178,7 +178,7 @@ fn pseudo_overflow() {
             svec!["Bob", "teal"],
         ],
     );
-    let close_to_max = std::u64::MAX - 10;
+    let close_to_max = u64::MAX - 10;
     let mut cmd = wrk.command("pseudo");
     cmd.arg("name")
         .args(["--formatstr", "ID-{}"])

--- a/tests/test_schema.rs
+++ b/tests/test_schema.rs
@@ -280,7 +280,7 @@ fn generate_schema_with_const_and_enum_constraints() {
 9,r9,const,charlie
 ";
 
-    wrk.create_from_string("enum_const_test.csv", &csv);
+    wrk.create_from_string("enum_const_test.csv", csv);
 
     // run schema command with value constraints option
     let mut cmd = wrk.command("schema");
@@ -395,7 +395,7 @@ fn generate_schema_tsv_delimiter_detection_issue_2997() {
 2025-01-01\tSTART\tN/A\t3023.46\t-\t-\tBalance from 2024\tN/A
 2025-01-28\tDEBIT\tTRADE\t-3023\tDeployer 0xb1\tVelodrome\tSell for USDC\thttps://optimistic.etherscan.io/tx/0x79e857395945f03a57454efcccdc5ca00430f5886018d71a9a137808a60fe7fc";
 
-    wrk.create_from_string("test_data.tsv", &tsv_data);
+    wrk.create_from_string("test_data.tsv", tsv_data);
 
     // run schema command (without explicit delimiter - should auto-detect)
     let mut cmd = wrk.command("schema");
@@ -481,7 +481,7 @@ user2@test.org
 admin@company.co.uk
 support@domain.net";
 
-    wrk.create_from_string("emails.csv", &csv);
+    wrk.create_from_string("emails.csv", csv);
 
     let mut cmd = wrk.command("schema");
     cmd.arg("emails.csv");
@@ -514,7 +514,7 @@ test.org
 subdomain.example.com
 host-name.co.uk";
 
-    wrk.create_from_string("hostnames.csv", &csv);
+    wrk.create_from_string("hostnames.csv", csv);
 
     let mut cmd = wrk.command("schema");
     cmd.arg("hostnames.csv");
@@ -547,7 +547,7 @@ fn generate_schema_with_strict_formats_ipv4() {
 172.16.0.1
 8.8.8.8";
 
-    wrk.create_from_string("ipv4s.csv", &csv);
+    wrk.create_from_string("ipv4s.csv", csv);
 
     let mut cmd = wrk.command("schema");
     cmd.arg("ipv4s.csv");
@@ -580,7 +580,7 @@ fn generate_schema_with_strict_formats_ipv6() {
 ::1
 2001:db8::1";
 
-    wrk.create_from_string("ipv6s.csv", &csv);
+    wrk.create_from_string("ipv6s.csv", csv);
 
     let mut cmd = wrk.command("schema");
     cmd.arg("ipv6s.csv");
@@ -614,7 +614,7 @@ user2@test.org
 not-an-email
 admin@company.co.uk";
 
-    wrk.create_from_string("mixed.csv", &csv);
+    wrk.create_from_string("mixed.csv", csv);
 
     let mut cmd = wrk.command("schema");
     cmd.arg("mixed.csv");
@@ -648,7 +648,7 @@ fn generate_schema_with_strict_formats_ipv4_precedence_over_hostname() {
 10.0.0.1
 172.16.0.1";
 
-    wrk.create_from_string("ipv4_precedence.csv", &csv);
+    wrk.create_from_string("ipv4_precedence.csv", csv);
 
     let mut cmd = wrk.command("schema");
     cmd.arg("ipv4_precedence.csv");

--- a/tests/test_slice.rs
+++ b/tests/test_slice.rs
@@ -130,19 +130,19 @@ fn test_slice(
 ) {
     let (wrk, mut cmd) = setup(name, headers, use_index);
     if let Some(start) = start {
-        cmd.arg("--start").arg(&start.to_string());
+        cmd.arg("--start").arg(start.to_string());
     }
     if let Some(end) = end {
         if as_len {
             let start = start.unwrap_or(0);
             if start < 0 {
-                cmd.arg("--len").arg(&end.to_string());
+                cmd.arg("--len").arg(end.to_string());
             } else {
                 cmd.arg("--len")
-                    .arg(&(end - start.unsigned_abs()).to_string());
+                    .arg((end - start.unsigned_abs()).to_string());
             }
         } else {
-            cmd.arg("--end").arg(&end.to_string());
+            cmd.arg("--end").arg(end.to_string());
         }
     }
     if !headers {
@@ -151,7 +151,7 @@ fn test_slice(
     if json_output {
         let output_file = wrk.path("output.json").to_string_lossy().to_string();
 
-        cmd.arg("--json").args(&["--output", &output_file]);
+        cmd.arg("--json").args(["--output", &output_file]);
 
         wrk.assert_success(&mut cmd);
 
@@ -187,7 +187,7 @@ fn test_slice(
 
 fn test_index(name: &str, idx: isize, expected: &str, headers: bool, use_index: bool) {
     let (wrk, mut cmd) = setup(name, headers, use_index);
-    cmd.arg("--index").arg(&idx.to_string());
+    cmd.arg("--index").arg(idx.to_string());
     if !headers {
         cmd.arg("--no-headers");
     }
@@ -321,19 +321,19 @@ fn test_slice_invert(
 ) {
     let (wrk, mut cmd) = setup(name, headers, use_index);
     if let Some(start) = start {
-        cmd.arg("--start").arg(&start.to_string());
+        cmd.arg("--start").arg(start.to_string());
     }
     if let Some(end) = end {
         if as_len {
             let start = start.unwrap_or(0);
             if start < 0 {
-                cmd.arg("--len").arg(&end.to_string());
+                cmd.arg("--len").arg(end.to_string());
             } else {
                 cmd.arg("--len")
-                    .arg(&(end - start.unsigned_abs()).to_string());
+                    .arg((end - start.unsigned_abs()).to_string());
             }
         } else {
-            cmd.arg("--end").arg(&end.to_string());
+            cmd.arg("--end").arg(end.to_string());
         }
     }
     if !headers {
@@ -344,7 +344,7 @@ fn test_slice_invert(
     if json_output {
         let output_file = wrk.path("output.json").to_string_lossy().to_string();
 
-        cmd.arg("--json").args(&["--output", &output_file]);
+        cmd.arg("--json").args(["--output", &output_file]);
 
         wrk.assert_success(&mut cmd);
 

--- a/tests/test_split.rs
+++ b/tests/test_split.rs
@@ -34,7 +34,7 @@ fn split_zero() {
     wrk.create("in.csv", data(true));
 
     let mut cmd = wrk.command("split");
-    cmd.args(["--size", "0"]).arg(&wrk.path(".")).arg("in.csv");
+    cmd.args(["--size", "0"]).arg(wrk.path(".")).arg("in.csv");
     wrk.assert_err(&mut cmd);
 }
 
@@ -44,7 +44,7 @@ fn split() {
     wrk.create("in.csv", data(true));
 
     let mut cmd = wrk.command("split");
-    cmd.args(["--size", "2"]).arg(&wrk.path(".")).arg("in.csv");
+    cmd.args(["--size", "2"]).arg(wrk.path(".")).arg("in.csv");
     wrk.run(&mut cmd);
 
     split_eq!(
@@ -83,9 +83,7 @@ fn split_chunks() {
     wrk.create("in.csv", data(true));
 
     let mut cmd = wrk.command("split");
-    cmd.args(["--chunks", "3"])
-        .arg(&wrk.path("."))
-        .arg("in.csv");
+    cmd.args(["--chunks", "3"]).arg(wrk.path(".")).arg("in.csv");
     wrk.run(&mut cmd);
 
     split_eq!(
@@ -125,7 +123,7 @@ fn split_a_lot() {
 
     let mut cmd = wrk.command("split");
     cmd.args(["--size", "1000"])
-        .arg(&wrk.path("."))
+        .arg(wrk.path("."))
         .arg("in.csv");
     wrk.run(&mut cmd);
 
@@ -152,7 +150,7 @@ fn split_a_lot_indexed() {
 
     let mut cmd = wrk.command("split");
     cmd.args(["--size", "1000"])
-        .arg(&wrk.path("."))
+        .arg(wrk.path("."))
         .arg("in.csv");
     wrk.run(&mut cmd);
 
@@ -181,7 +179,7 @@ fn split_padding() {
     cmd.args(["--size", "2"])
         .arg("--pad")
         .arg("4")
-        .arg(&wrk.path("."))
+        .arg(wrk.path("."))
         .arg("in.csv");
     wrk.run(&mut cmd);
 
@@ -224,7 +222,7 @@ fn split_chunks_padding() {
     cmd.args(["--chunks", "3"])
         .arg("--pad")
         .arg("4")
-        .arg(&wrk.path("."))
+        .arg(wrk.path("."))
         .arg("in.csv");
     wrk.run(&mut cmd);
 
@@ -264,7 +262,7 @@ fn split_idx() {
     wrk.create_indexed("in.csv", data(true));
 
     let mut cmd = wrk.command("split");
-    cmd.args(["--size", "2"]).arg(&wrk.path(".")).arg("in.csv");
+    cmd.args(["--size", "2"]).arg(wrk.path(".")).arg("in.csv");
     wrk.run(&mut cmd);
 
     split_eq!(
@@ -303,9 +301,7 @@ fn split_chunks_idx() {
     wrk.create_indexed("in.csv", data(true));
 
     let mut cmd = wrk.command("split");
-    cmd.args(["--chunks", "3"])
-        .arg(&wrk.path("."))
-        .arg("in.csv");
+    cmd.args(["--chunks", "3"]).arg(wrk.path(".")).arg("in.csv");
     wrk.run(&mut cmd);
 
     split_eq!(
@@ -345,7 +341,7 @@ fn split_no_headers() {
 
     let mut cmd = wrk.command("split");
     cmd.args(["--no-headers", "--size", "2"])
-        .arg(&wrk.path("."))
+        .arg(wrk.path("."))
         .arg("in.csv");
     wrk.run(&mut cmd);
 
@@ -382,7 +378,7 @@ fn split_chunks_no_headers() {
 
     let mut cmd = wrk.command("split");
     cmd.args(["--no-headers", "--chunks", "3"])
-        .arg(&wrk.path("."))
+        .arg(wrk.path("."))
         .arg("in.csv");
     wrk.run(&mut cmd);
 
@@ -419,7 +415,7 @@ fn split_no_headers_idx() {
 
     let mut cmd = wrk.command("split");
     cmd.args(["--no-headers", "--size", "2"])
-        .arg(&wrk.path("."))
+        .arg(wrk.path("."))
         .arg("in.csv");
     wrk.run(&mut cmd);
 
@@ -456,7 +452,7 @@ fn split_chunks_no_headers_idx() {
 
     let mut cmd = wrk.command("split");
     cmd.args(["--no-headers", "--chunks", "3"])
-        .arg(&wrk.path("."))
+        .arg(wrk.path("."))
         .arg("in.csv");
     wrk.run(&mut cmd);
 
@@ -492,7 +488,7 @@ fn split_one() {
     wrk.create("in.csv", data(true));
 
     let mut cmd = wrk.command("split");
-    cmd.args(["--size", "1"]).arg(&wrk.path(".")).arg("in.csv");
+    cmd.args(["--size", "1"]).arg(wrk.path(".")).arg("in.csv");
     wrk.run(&mut cmd);
 
     split_eq!(
@@ -551,7 +547,7 @@ fn split_one_idx() {
     wrk.create_indexed("in.csv", data(true));
 
     let mut cmd = wrk.command("split");
-    cmd.args(["--size", "1"]).arg(&wrk.path(".")).arg("in.csv");
+    cmd.args(["--size", "1"]).arg(wrk.path(".")).arg("in.csv");
     wrk.run(&mut cmd);
 
     split_eq!(
@@ -610,7 +606,7 @@ fn split_uneven() {
     wrk.create("in.csv", data(true));
 
     let mut cmd = wrk.command("split");
-    cmd.args(["--size", "4"]).arg(&wrk.path(".")).arg("in.csv");
+    cmd.args(["--size", "4"]).arg(wrk.path(".")).arg("in.csv");
     wrk.run(&mut cmd);
 
     split_eq!(
@@ -642,7 +638,7 @@ fn split_chunks_a_lot() {
 
     let mut cmd = wrk.command("split");
     cmd.args(["--chunks", "10"])
-        .arg(&wrk.path("."))
+        .arg(wrk.path("."))
         .arg("in.csv");
     wrk.run(&mut cmd);
 
@@ -703,7 +699,7 @@ fn split_uneven_idx() {
     wrk.create_indexed("in.csv", data(true));
 
     let mut cmd = wrk.command("split");
-    cmd.args(["--size", "4"]).arg(&wrk.path(".")).arg("in.csv");
+    cmd.args(["--size", "4"]).arg(wrk.path(".")).arg("in.csv");
     wrk.run(&mut cmd);
 
     split_eq!(
@@ -736,7 +732,7 @@ fn split_custom_filename() {
     let mut cmd = wrk.command("split");
     cmd.args(["--size", "2"])
         .args(["--filename", "prefix-{}.csv"])
-        .arg(&wrk.path("."))
+        .arg(wrk.path("."))
         .arg("in.csv");
     wrk.run(&mut cmd);
 
@@ -755,7 +751,7 @@ fn split_custom_filename_padded() {
         .arg("--pad")
         .arg("3")
         .args(["--filename", "prefix-{}.csv"])
-        .arg(&wrk.path("."))
+        .arg(wrk.path("."))
         .arg("in.csv");
     wrk.run(&mut cmd);
 
@@ -786,7 +782,7 @@ fn split_kbsize_boston_5k() {
 
     let mut cmd = wrk.command("split");
     cmd.args(["--kb-size", "5"])
-        .arg(&wrk.path("."))
+        .arg(wrk.path("."))
         .arg(test_file);
     wrk.run(&mut cmd);
 
@@ -812,7 +808,7 @@ fn split_kbsize_boston_5k_padded() {
 
     let mut cmd = wrk.command("split");
     cmd.args(["--kb-size", "5"])
-        .arg(&wrk.path("."))
+        .arg(wrk.path("."))
         .args(["--filename", "testme-{}.csv"])
         .args(["--pad", "3"])
         .arg(test_file);
@@ -838,7 +834,7 @@ fn split_kbsize_boston_5k_no_headers() {
 
     let mut cmd = wrk.command("split");
     cmd.args(["--kb-size", "5"])
-        .arg(&wrk.path("."))
+        .arg(wrk.path("."))
         .arg("--no-headers")
         .arg(test_file);
     wrk.run(&mut cmd);
@@ -865,13 +861,13 @@ fn split_filter_basic() {
         cmd.args(["--size", "2"])
             .arg("--filter")
             .arg("copy /Y %FILE% {}.bak")
-            .arg(&wrk.path("."))
+            .arg(wrk.path("."))
             .arg("in.csv");
     } else {
         cmd.args(["--size", "2"])
             .arg("--filter")
             .arg("cp $FILE {}.bak")
-            .arg(&wrk.path("."))
+            .arg(wrk.path("."))
             .arg("in.csv");
     }
     wrk.run(&mut cmd);
@@ -930,7 +926,7 @@ fn split_filter_with_padding() {
             .arg("3")
             .arg("--filter")
             .arg("copy /Y %FILE% chunk_{}.bak")
-            .arg(&wrk.path("."))
+            .arg(wrk.path("."))
             .arg("in.csv");
     } else {
         cmd.args(["--size", "2"])
@@ -938,7 +934,7 @@ fn split_filter_with_padding() {
             .arg("3")
             .arg("--filter")
             .arg("cp $FILE chunk_{}.bak")
-            .arg(&wrk.path("."))
+            .arg(wrk.path("."))
             .arg("in.csv");
     }
     wrk.run(&mut cmd);
@@ -995,14 +991,14 @@ fn split_filter_with_custom_filename() {
             .args(["--filename", "prefix-{}.csv"])
             .arg("--filter")
             .arg("copy /Y %FILE% prefix-{}.bak")
-            .arg(&wrk.path("."))
+            .arg(wrk.path("."))
             .arg("in.csv");
     } else {
         cmd.args(["--size", "2"])
             .args(["--filename", "prefix-{}.csv"])
             .arg("--filter")
             .arg("cp $FILE prefix-{}.bak")
-            .arg(&wrk.path("."))
+            .arg(wrk.path("."))
             .arg("in.csv");
     }
     wrk.run(&mut cmd);
@@ -1057,13 +1053,13 @@ fn split_filter_with_chunks() {
         cmd.args(["--chunks", "3"])
             .arg("--filter")
             .arg("copy /Y %FILE% chunk_{}.bak")
-            .arg(&wrk.path("."))
+            .arg(wrk.path("."))
             .arg("in.csv");
     } else {
         cmd.args(["--chunks", "3"])
             .arg("--filter")
             .arg("cp $FILE chunk_{}.bak")
-            .arg(&wrk.path("."))
+            .arg(wrk.path("."))
             .arg("in.csv");
     }
     wrk.run(&mut cmd);
@@ -1119,13 +1115,13 @@ fn split_filter_with_kb_size() {
         cmd.args(["--kb-size", "5"])
             .arg("--filter")
             .arg("copy /Y %FILE% {}.bak")
-            .arg(&wrk.path("."))
+            .arg(wrk.path("."))
             .arg(test_file);
     } else {
         cmd.args(["--kb-size", "5"])
             .arg("--filter")
             .arg("cp $FILE {}.bak")
-            .arg(&wrk.path("."))
+            .arg(wrk.path("."))
             .arg(test_file);
     }
     wrk.run(&mut cmd);
@@ -1154,13 +1150,13 @@ fn split_filter_with_no_headers() {
         cmd.args(["--no-headers", "--size", "2"])
             .arg("--filter")
             .arg("copy /Y %FILE% {}.bak")
-            .arg(&wrk.path("."))
+            .arg(wrk.path("."))
             .arg("in.csv");
     } else {
         cmd.args(["--no-headers", "--size", "2"])
             .arg("--filter")
             .arg("cp $FILE {}.bak")
-            .arg(&wrk.path("."))
+            .arg(wrk.path("."))
             .arg("in.csv");
     }
     wrk.run(&mut cmd);
@@ -1214,14 +1210,14 @@ fn split_filter_with_cleanup() {
             .arg("--filter")
             .arg("copy /Y %FILE% {}.bak")
             .arg("--filter-cleanup")
-            .arg(&wrk.path("."))
+            .arg(wrk.path("."))
             .arg("in.csv");
     } else {
         cmd.args(["--size", "2"])
             .arg("--filter")
             .arg("cp $FILE {}.bak")
             .arg("--filter-cleanup")
-            .arg(&wrk.path("."))
+            .arg(wrk.path("."))
             .arg("in.csv");
     }
     wrk.run(&mut cmd);
@@ -1279,13 +1275,13 @@ fn split_filter_without_cleanup() {
         cmd.args(["--size", "2"])
             .arg("--filter")
             .arg("copy /Y %FILE% {}.bak")
-            .arg(&wrk.path("."))
+            .arg(wrk.path("."))
             .arg("in.csv");
     } else {
         cmd.args(["--size", "2"])
             .arg("--filter")
             .arg("cp $FILE {}.bak")
-            .arg(&wrk.path("."))
+            .arg(wrk.path("."))
             .arg("in.csv");
     }
     wrk.run(&mut cmd);
@@ -1343,14 +1339,14 @@ fn split_filter_with_cleanup_failed_command() {
             .arg("--filter")
             .arg("nonexistent_command %FILE% \"{}.bak\"")
             .arg("--filter-cleanup")
-            .arg(&wrk.path("."))
+            .arg(wrk.path("."))
             .arg("in.csv");
     } else {
         cmd.args(["--size", "2"])
             .arg("--filter")
             .arg("nonexistent_command $FILE {}.bak")
             .arg("--filter-cleanup")
-            .arg(&wrk.path("."))
+            .arg(wrk.path("."))
             .arg("in.csv");
     }
     wrk.run(&mut cmd);
@@ -1381,14 +1377,14 @@ fn split_filter_with_ignore_errors() {
             .arg("--filter")
             .arg("nonexistent_command %FILE% \"{}.bak\"")
             .arg("--filter-ignore-errors")
-            .arg(&wrk.path("."))
+            .arg(wrk.path("."))
             .arg("in.csv");
     } else {
         cmd.args(["--size", "2"])
             .arg("--filter")
             .arg("nonexistent_command $FILE {}.bak")
             .arg("--filter-ignore-errors")
-            .arg(&wrk.path("."))
+            .arg(wrk.path("."))
             .arg("in.csv");
     }
     // The command should run successfully despite the filter command failing
@@ -1416,13 +1412,13 @@ fn split_filter_without_ignore_errors() {
         cmd.args(["--size", "2"])
             .arg("--filter")
             .arg("nonexistent_command %FILE% \"{}.bak\"")
-            .arg(&wrk.path("."))
+            .arg(wrk.path("."))
             .arg("in.csv");
     } else {
         cmd.args(["--size", "2"])
             .arg("--filter")
             .arg("nonexistent_command $FILE {}.bak")
-            .arg(&wrk.path("."))
+            .arg(wrk.path("."))
             .arg("in.csv");
     }
     // The command should fail when the filter command fails
@@ -1573,7 +1569,7 @@ fn split_stdin_100_rows() {
     // Run the split command with stdin input
     let mut cmd = wrk.command("split");
     cmd.args(["--size", "20"])
-        .arg(&wrk.path("."))
+        .arg(wrk.path("."))
         .arg("--quiet")
         .arg("-"); // Use "-" to indicate stdin
 
@@ -1679,16 +1675,14 @@ fn split_chunks_zero_rejected() {
     wrk.create("in.csv", data(true));
 
     let mut cmd = wrk.command("split");
-    cmd.args(["--chunks", "0"])
-        .arg(&wrk.path("."))
-        .arg("in.csv");
+    cmd.args(["--chunks", "0"]).arg(wrk.path(".")).arg("in.csv");
     wrk.assert_err(&mut cmd);
 
     // also exercise the indexed path
     wrk.create_indexed("in_idx.csv", data(true));
     let mut cmd = wrk.command("split");
     cmd.args(["--chunks", "0"])
-        .arg(&wrk.path("."))
+        .arg(wrk.path("."))
         .arg("in_idx.csv");
     wrk.assert_err(&mut cmd);
 }
@@ -1700,7 +1694,7 @@ fn split_kb_size_zero_rejected() {
 
     let mut cmd = wrk.command("split");
     cmd.args(["--kb-size", "0"])
-        .arg(&wrk.path("."))
+        .arg(wrk.path("."))
         .arg("in.csv");
     wrk.assert_err(&mut cmd);
 }
@@ -1714,7 +1708,7 @@ fn split_filter_cleanup_without_filter_rejected() {
     let mut cmd = wrk.command("split");
     cmd.args(["--size", "2"])
         .arg("--filter-cleanup")
-        .arg(&wrk.path("."))
+        .arg(wrk.path("."))
         .arg("in.csv");
     wrk.assert_err(&mut cmd);
 
@@ -1722,7 +1716,7 @@ fn split_filter_cleanup_without_filter_rejected() {
     cmd_2
         .args(["--size", "2"])
         .arg("--filter-ignore-errors")
-        .arg(&wrk.path("."))
+        .arg(wrk.path("."))
         .arg("in.csv");
     wrk.assert_err(&mut cmd_2);
 }
@@ -1741,7 +1735,7 @@ fn split_kb_size_header_too_large_rejected() {
     // 1KB budget vs. ~3KB+ header should produce a clean error.
     let mut cmd = wrk.command("split");
     cmd.args(["--kb-size", "1"])
-        .arg(&wrk.path("."))
+        .arg(wrk.path("."))
         .arg("in.csv");
     wrk.assert_err(&mut cmd);
 }
@@ -1767,7 +1761,7 @@ fn split_kb_size_variable_rows_under_budget() {
 
     let mut cmd = wrk.command("split");
     cmd.args(["--kb-size", "2"])
-        .arg(&wrk.path("."))
+        .arg(wrk.path("."))
         .arg("in.csv");
     wrk.run(&mut cmd);
 
@@ -1810,13 +1804,13 @@ fn split_empty_input_sequential() {
         cmd.args(["--size", "10"])
             .arg("--filter")
             .arg("copy /Y %FILE% {}.bak")
-            .arg(&wrk.path("."))
+            .arg(wrk.path("."))
             .arg("in.csv");
     } else {
         cmd.args(["--size", "10"])
             .arg("--filter")
             .arg("cp $FILE {}.bak")
-            .arg(&wrk.path("."))
+            .arg(wrk.path("."))
             .arg("in.csv");
     }
     wrk.assert_success(&mut cmd);
@@ -1829,7 +1823,7 @@ fn split_empty_input_kb_size() {
 
     let mut cmd = wrk.command("split");
     cmd.args(["--kb-size", "5"])
-        .arg(&wrk.path("."))
+        .arg(wrk.path("."))
         .arg("in.csv");
     wrk.assert_success(&mut cmd);
     // Empty input must produce zero chunks (no phantom header-only file).
@@ -1848,7 +1842,7 @@ fn split_filter_multiword_command() {
     cmd.args(["--size", "2"])
         .arg("--filter")
         .arg("sh -c 'cp \"$FILE\" \"$FILE.bak\"'")
-        .arg(&wrk.path("."))
+        .arg(wrk.path("."))
         .arg("in.csv");
     wrk.assert_success(&mut cmd);
     assert!(wrk.path("0.csv.bak").exists());

--- a/tests/test_sqlp.rs
+++ b/tests/test_sqlp.rs
@@ -49,7 +49,7 @@ fn make_rows(left_only: bool, rows: Vec<Vec<String>>) -> Vec<Vec<String>> {
     } else {
         all_rows.push(svec!["city", "state", "city:places", "place"]);
     }
-    all_rows.extend(rows.into_iter());
+    all_rows.extend(rows);
     all_rows
 }
 

--- a/tests/test_stats.rs
+++ b/tests/test_stats.rs
@@ -780,8 +780,8 @@ fn stats_rounding() {
     let test_file = wrk.load_test_file("boston311-100.csv");
 
     let mut cmd = wrk.command("stats");
-    cmd.args(&["--everything"])
-        .args(&["--round", "8"])
+    cmd.args(["--everything"])
+        .args(["--round", "8"])
         .arg(test_file);
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
@@ -827,7 +827,7 @@ fn stats_no_date_inference() {
     let test_file = wrk.load_test_file("boston311-100.csv");
 
     let mut cmd = wrk.command("stats");
-    cmd.args(&["--everything"]).arg(test_file);
+    cmd.args(["--everything"]).arg(test_file);
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
 
@@ -878,7 +878,7 @@ fn stats_with_date_inference_default_whitelist() {
     let test_file = wrk.load_test_file("boston311-100.csv");
 
     let mut cmd = wrk.command("stats");
-    cmd.args(&["--everything"])
+    cmd.args(["--everything"])
         .arg(test_file)
         .arg("--infer-dates");
 
@@ -1092,7 +1092,7 @@ fn stats_typesonly_cache_threshold_zero() {
     cmd.args(["--typesonly"])
         .arg("--infer-dates")
         .args(["--dates-whitelist", "all"])
-        .args(&["--cache-threshold", "0"])
+        .args(["--cache-threshold", "0"])
         .arg(test_file);
 
     let got: String = wrk.stdout(&mut cmd);
@@ -1135,7 +1135,7 @@ fn stats_cache() {
     cmd.arg("--infer-dates")
         .args(["--dates-whitelist", "all"])
         // set cache threshold to 1 to force cache creation
-        .args(&["--cache-threshold", "1"])
+        .args(["--cache-threshold", "1"])
         .arg(test_file);
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
@@ -1208,7 +1208,7 @@ fn stats_cache_negative_threshold_unmet() {
         .args(["--dates-whitelist", "all"])
         // set cache threshold to -51200 to set autoindex_size to 50 kb
         // and to force cache creation
-        .args(&["--cache-threshold", "-51200"])
+        .args(["--cache-threshold", "-51200"])
         .arg(test_file.clone());
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
@@ -1281,7 +1281,7 @@ fn stats_antimodes_len_500() {
 
     let mut cmd = wrk.command("stats");
     cmd.env("QSV_ANTIMODES_LEN", "500")
-        .args(&["--everything"])
+        .args(["--everything"])
         .arg(test_file);
 
     let got: String = wrk.stdout(&mut cmd);
@@ -1669,7 +1669,7 @@ fn stats_output_tab_delimited() {
     let out_file = wrk.path("output.tab").to_string_lossy().to_string();
 
     let mut cmd = wrk.command("stats");
-    cmd.arg("data.csv").args(&["--output", &out_file]);
+    cmd.arg("data.csv").args(["--output", &out_file]);
 
     wrk.assert_success(&mut cmd);
 
@@ -1701,8 +1701,8 @@ fn stats_cache_always_csv_when_output_is_tsv() {
 
     let mut cmd = wrk.command("stats");
     cmd.arg("data.csv")
-        .args(&["--output", &out_file])
-        .args(&["--cache-threshold", "1"]);
+        .args(["--output", &out_file])
+        .args(["--cache-threshold", "1"]);
 
     wrk.assert_success(&mut cmd);
 
@@ -1761,8 +1761,8 @@ fn stats_cache_always_csv_when_output_is_ssv() {
 
     let mut cmd = wrk.command("stats");
     cmd.arg("data.csv")
-        .args(&["--output", &out_file])
-        .args(&["--cache-threshold", "1"]);
+        .args(["--output", &out_file])
+        .args(["--cache-threshold", "1"]);
 
     wrk.assert_success(&mut cmd);
 
@@ -1811,8 +1811,8 @@ fn stats_cache_always_csv_when_output_is_snappy() {
 
     let mut cmd = wrk.command("stats");
     cmd.arg("data.csv")
-        .args(&["--output", &out_file])
-        .args(&["--cache-threshold", "1"]);
+        .args(["--output", &out_file])
+        .args(["--cache-threshold", "1"]);
 
     wrk.assert_success(&mut cmd);
 
@@ -1885,8 +1885,8 @@ fn stats_cache_always_csv_when_output_is_tsv_sz() {
 
     let mut cmd = wrk.command("stats");
     cmd.arg("data.csv")
-        .args(&["--output", &out_file])
-        .args(&["--cache-threshold", "1"]);
+        .args(["--output", &out_file])
+        .args(["--cache-threshold", "1"]);
 
     wrk.assert_success(&mut cmd);
 
@@ -1944,7 +1944,7 @@ fn stats_output_ssv_delimited() {
     let out_file = wrk.path("output.ssv").to_string_lossy().to_string();
 
     let mut cmd = wrk.command("stats");
-    cmd.arg("data.csv").args(&["--output", &out_file]);
+    cmd.arg("data.csv").args(["--output", &out_file]);
 
     wrk.assert_success(&mut cmd);
 
@@ -1976,7 +1976,7 @@ fn stats_output_csvsz_delimited() {
     let out_file = wrk.path("output.csv.sz").to_string_lossy().to_string();
 
     let mut cmd = wrk.command("stats");
-    cmd.arg("data.csv").args(&["--output", &out_file]);
+    cmd.arg("data.csv").args(["--output", &out_file]);
 
     wrk.assert_success(&mut cmd);
 
@@ -2102,7 +2102,7 @@ fn stats_percentiles() {
         .arg("10,25,50,75,90");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
-    assert!(got.len() > 0);
+    assert!(!got.is_empty());
 
     let expected = vec![
         svec![
@@ -2206,7 +2206,7 @@ fn stats_percentiles_floats() {
         .arg("10.5,25.25,50.75,75.6,90.1");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
-    assert!(got.len() > 0);
+    assert!(!got.is_empty());
 
     let expected = vec![
         svec![
@@ -2302,7 +2302,7 @@ fn stats_percentiles_with_dates() {
         .arg("--infer-dates");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
-    assert!(got.len() > 0);
+    assert!(!got.is_empty());
 
     let expected = vec![
         svec![
@@ -2396,7 +2396,7 @@ fn stats_percentiles_with_nulls() {
         .arg("25,50,75");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
-    assert!(got.len() > 0);
+    assert!(!got.is_empty());
 
     let expected = vec![
         svec![
@@ -2490,7 +2490,7 @@ fn stats_percentiles_mixed_types() {
         .arg("25,50,75");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
-    assert!(got.len() > 0);
+    assert!(!got.is_empty());
 
     let expected = vec![
         svec![
@@ -2557,7 +2557,7 @@ fn stats_percentiles_edge_cases() {
         .arg("10,25,50,75,90");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
-    assert!(got.len() > 0);
+    assert!(!got.is_empty());
 
     let expected = vec![
         svec![
@@ -2656,7 +2656,7 @@ fn stats_percentiles_custom_list() {
         .arg("1,5,33.3,66.6,95,99");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
-    assert!(got.len() > 0);
+    assert!(!got.is_empty());
 
     let expected = vec![
         svec![
@@ -2740,7 +2740,7 @@ fn stats_percentiles_single_value() {
         .arg("25,50,75");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
-    assert!(got.len() > 0);
+    assert!(!got.is_empty());
 
     let expected = vec![
         svec![
@@ -2839,7 +2839,7 @@ fn stats_percentiles_deciles_lowercase() {
         .arg("deciles");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
-    assert!(got.len() > 0);
+    assert!(!got.is_empty());
 
     // Find the percentiles column value
     let headers = &got[0];
@@ -2891,7 +2891,7 @@ fn stats_percentiles_deciles_uppercase() {
         .arg("DECILES");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
-    assert!(got.len() > 0);
+    assert!(!got.is_empty());
 
     let headers = &got[0];
     let percentiles_idx = headers
@@ -2935,7 +2935,7 @@ fn stats_percentiles_deciles_mixed_case() {
         .arg("DeCiLeS");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
-    assert!(got.len() > 0);
+    assert!(!got.is_empty());
 
     let headers = &got[0];
     let percentiles_idx = headers
@@ -2979,7 +2979,7 @@ fn stats_percentiles_quintiles_lowercase() {
         .arg("quintiles");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
-    assert!(got.len() > 0);
+    assert!(!got.is_empty());
 
     let headers = &got[0];
     let percentiles_idx = headers
@@ -3029,7 +3029,7 @@ fn stats_percentiles_quintiles_uppercase() {
         .arg("QUINTILES");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
-    assert!(got.len() > 0);
+    assert!(!got.is_empty());
 
     let headers = &got[0];
     let percentiles_idx = headers
@@ -3073,7 +3073,7 @@ fn stats_percentiles_quintiles_mixed_case() {
         .arg("QuInTiLeS");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
-    assert!(got.len() > 0);
+    assert!(!got.is_empty());
 
     let headers = &got[0];
     let percentiles_idx = headers
@@ -3127,7 +3127,7 @@ fn stats_percentiles_deciles_with_more_values() {
         .arg("deciles");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
-    assert!(got.len() > 0);
+    assert!(!got.is_empty());
 
     let headers = &got[0];
     let percentiles_idx = headers
@@ -3193,7 +3193,7 @@ fn stats_percentiles_quintiles_with_more_values() {
         .arg("quintiles");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
-    assert!(got.len() > 0);
+    assert!(!got.is_empty());
 
     let headers = &got[0];
     let percentiles_idx = headers
@@ -3244,7 +3244,7 @@ fn stats_percentiles_regular_list_still_works() {
         .arg("25,50,75");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
-    assert!(got.len() > 0);
+    assert!(!got.is_empty());
 
     let headers = &got[0];
     let percentiles_idx = headers
@@ -3645,7 +3645,7 @@ fn stats_cache_invalidates_on_select_change() {
         "expected 2 rows for select c,d, got {fields:?}"
     );
     assert!(
-        fields.iter().any(|f| *f == "c") && fields.iter().any(|f| *f == "d"),
+        fields.contains(&"c") && fields.contains(&"d"),
         "expected stats for columns c,d but got {fields:?}"
     );
 }
@@ -4134,7 +4134,7 @@ fn stats_string_max_length() {
 
     // Find the row for col1
     for row in &got {
-        if row.len() > 0 && row[0] == "col1" {
+        if !row.is_empty() && row[0] == "col1" {
             // The min and max values are in columns 4 and 5 (0-indexed)
             if row.len() > 5 {
                 min_value = row[4].clone();
@@ -4160,7 +4160,7 @@ fn stats_string_max_length() {
 
     // Find the row for col1
     for row in &got {
-        if row.len() > 0 && row[0] == "col1" {
+        if !row.is_empty() && row[0] == "col1" {
             // The min and max values are in columns 4 and 5 (0-indexed)
             if row.len() > 5 {
                 min_value = row[4].clone();
@@ -4186,7 +4186,7 @@ fn stats_string_max_length() {
 
     // Find the row for col1
     for row in &got {
-        if row.len() > 0 && row[0] == "col1" {
+        if !row.is_empty() && row[0] == "col1" {
             // The min and max values are in columns 4 and 5 (0-indexed)
             if row.len() > 5 {
                 min_value = row[4].clone();
@@ -4323,7 +4323,7 @@ fn stats_auto_index_creation_on_oom() {
     let index_path = format!("{}.idx", test_file.display());
     let index_file = Path::new(&index_path);
     if index_file.exists() {
-        std::fs::remove_file(&index_file).unwrap();
+        std::fs::remove_file(index_file).unwrap();
     }
     assert!(!index_file.exists(), "Index should not exist initially");
 
@@ -5932,7 +5932,7 @@ fn stats_weighted_infinity_weights() {
     if !mean_str.is_empty() {
         let mean_val: f64 = mean_str.parse().unwrap();
         assert!(
-            mean_val >= 1.0 && mean_val <= 2.0,
+            (1.0..=2.0).contains(&mean_val),
             "Mean should be between 1.0 and 2.0 with very large weights, got {}",
             mean_val
         );
@@ -6438,7 +6438,7 @@ fn stats_quantile_method_approx_disables_mad() {
         .split(',')
         .collect();
     assert!(
-        !headers.iter().any(|h| *h == "mad"),
+        !headers.contains(&"mad"),
         "mad column should be omitted when approx disables MAD, got headers: {headers:?}"
     );
 }

--- a/tests/test_template.rs
+++ b/tests/test_template.rs
@@ -541,7 +541,7 @@ fn template_render_error() {
         .arg("Hello {{name}, invalid syntax!")
         .arg("data.csv");
 
-    wrk.assert_err(&mut *&mut cmd);
+    wrk.assert_err(&mut cmd);
     let got: String = wrk.output_stderr(&mut cmd);
     let expected = "syntax error: unexpected `}`, expected end of variable block (in template:1)\n";
     assert_eq!(got, expected);

--- a/tests/test_to.rs
+++ b/tests/test_to.rs
@@ -119,7 +119,7 @@ fn to_xlsx_dir() {
     wrk.assert_success(&mut cmd);
 
     let mut cmd = wrk.command("excel");
-    cmd.arg(xlsx_file.clone()).args(&["--sheet", "cities"]);
+    cmd.arg(xlsx_file.clone()).args(["--sheet", "cities"]);
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     assert_eq!(got, cities);
@@ -127,7 +127,7 @@ fn to_xlsx_dir() {
     wrk.assert_success(&mut cmd);
 
     let mut cmd = wrk.command("excel");
-    cmd.arg(xlsx_file).args(&["--sheet", "places"]);
+    cmd.arg(xlsx_file).args(["--sheet", "places"]);
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     assert_eq!(got, places);
@@ -513,7 +513,7 @@ fn to_ods_dir() {
 
     // Verify the content of the first sheet
     let mut cmd = wrk.command("excel");
-    cmd.arg(ods_file.clone()).args(&["--sheet", "file1"]);
+    cmd.arg(ods_file.clone()).args(["--sheet", "file1"]);
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     assert_eq!(got, file1_data);
@@ -522,7 +522,7 @@ fn to_ods_dir() {
 
     // Verify the content of the second sheet
     let mut cmd = wrk.command("excel");
-    cmd.arg(ods_file).args(&["--sheet", "file2"]);
+    cmd.arg(ods_file).args(["--sheet", "file2"]);
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     assert_eq!(got, file2_data);

--- a/tests/test_validate.rs
+++ b/tests/test_validate.rs
@@ -2405,7 +2405,7 @@ fn validate_multiple_files_quiet_mode() {
     // In quiet mode, there should be no output to stderr
     let got: String = wrk.output_stderr(&mut cmd);
     // The output might be "No error" if there's no stderr output
-    assert!(got == "" || got == "No error");
+    assert!(got.is_empty() || got == "No error");
 }
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -7,7 +7,7 @@ extern crate quickcheck;
 extern crate rand;
 extern crate stats;
 
-use std::{env, fmt, mem::transmute, ops};
+use std::{env, fmt, ops};
 
 use quickcheck::{Arbitrary, Gen, QuickCheck, Testable};
 use rand::RngExt;
@@ -235,11 +235,11 @@ impl Arbitrary for CsvRecord {
 
 impl Csv for Vec<CsvRecord> {
     fn to_vecs(self) -> CsvVecs {
-        unsafe { transmute(self) }
+        self.into_iter().map(CsvRecord::unwrap).collect()
     }
 
     fn from_vecs(vecs: CsvVecs) -> Vec<CsvRecord> {
-        unsafe { transmute(vecs) }
+        vecs.into_iter().map(CsvRecord).collect()
     }
 }
 
@@ -317,12 +317,12 @@ impl Arbitrary for CsvData {
 
 impl Csv for CsvData {
     fn to_vecs(self) -> CsvVecs {
-        unsafe { transmute::<Vec<CsvRecord>, CsvVecs>(self.data) }
+        self.data.into_iter().map(CsvRecord::unwrap).collect()
     }
 
     fn from_vecs(vecs: CsvVecs) -> CsvData {
         CsvData {
-            data: unsafe { transmute::<CsvVecs, Vec<CsvRecord>>(vecs) },
+            data: vecs.into_iter().map(CsvRecord).collect(),
         }
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -43,7 +43,7 @@ mod test_blake3;
 #[cfg(any(feature = "feature_capable", feature = "lite"))]
 mod test_cat;
 #[cfg(all(
-    any(feature = "feature_capable"),
+    feature = "feature_capable",
     any(target_os = "windows", target_os = "macos"),
     feature = "clipboard",
 ))]
@@ -79,7 +79,7 @@ mod test_fixlengths;
 mod test_flatten;
 #[cfg(any(feature = "feature_capable", feature = "lite"))]
 mod test_fmt;
-#[cfg(all(feature = "foreach"))]
+#[cfg(feature = "foreach")]
 mod test_foreach;
 mod test_frequency;
 #[cfg(feature = "geocode")]
@@ -317,12 +317,12 @@ impl Arbitrary for CsvData {
 
 impl Csv for CsvData {
     fn to_vecs(self) -> CsvVecs {
-        unsafe { transmute(self.data) }
+        unsafe { transmute::<Vec<CsvRecord>, CsvVecs>(self.data) }
     }
 
     fn from_vecs(vecs: CsvVecs) -> CsvData {
         CsvData {
-            data: unsafe { transmute(vecs) },
+            data: unsafe { transmute::<CsvVecs, Vec<CsvRecord>>(vecs) },
         }
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -198,13 +198,13 @@ impl CsvRecord {
 impl ops::Deref for CsvRecord {
     type Target = [String];
 
-    fn deref<'a>(&'a self) -> &'a [String] {
+    fn deref(&self) -> &[String] {
         &self.0
     }
 }
 
 impl ops::DerefMut for CsvRecord {
-    fn deref_mut<'a>(&'a mut self) -> &'a mut [String] {
+    fn deref_mut(&mut self) -> &mut [String] {
         &mut self.0
     }
 }
@@ -265,7 +265,7 @@ impl CsvData {
 impl ops::Deref for CsvData {
     type Target = [CsvRecord];
 
-    fn deref<'a>(&'a self) -> &'a [CsvRecord] {
+    fn deref(&self) -> &[CsvRecord] {
         &self.data
     }
 }
@@ -283,10 +283,11 @@ impl Arbitrary for CsvData {
         };
         // If the CSV data starts with a BOM, strip it, because it wreaks havoc
         // with tests that weren't designed to handle it.
-        if !d.data.is_empty() && !d.data[0].is_empty() {
-            if let Some(stripped) = d.data[0][0].strip_prefix('\u{FEFF}') {
-                d.data[0][0] = stripped.to_string();
-            }
+        if !d.data.is_empty()
+            && !d.data[0].is_empty()
+            && let Some(stripped) = d.data[0][0].strip_prefix('\u{FEFF}')
+        {
+            d.data[0][0] = stripped.to_string();
         }
         d
     }

--- a/tests/workdir.rs
+++ b/tests/workdir.rs
@@ -396,7 +396,7 @@ pub fn is_same_file(file1: &Path, file2: &Path) -> Result<bool, std::io::Error> 
         }
     }
 
-    return Ok(true);
+    Ok(true)
 }
 
 /// Build a multi-GB CSV (10M rows × 5 columns of padded strings) for tests


### PR DESCRIPTION
## Context

Bumping the MSRV to 1.96 brought clippy 1.96, which tightened several lints and surfaced new findings on `cargo clippy --tests`: **2 hard errors** (deny-by-default `approx_constant`) plus **~375 warnings**. This PR clears them.

## Commits

1. **`fix(clippy): avoid approx_constant false positives`** — clippy 1.96 now flags the coarse literal `3.14` as an approximation of `f64::consts::PI`, which broke `cargo clippy --tests` (deny-by-default). Both sites use `3.14` as a generic test value, not π:
   - `excel.rs`: `float_to_i64_safe` test only needs a non-integer → `3.5`
   - `test_luau.rs`: JSON round-trip test → `1.23` (non-exactly-representable, not near any math constant) for both the Luau input and the assertion

2. **`style(clippy): apply machine-applicable fixes to tests`** — 354 warnings auto-fixed via `cargo clippy --fix --tests` (semantics-preserving) + `cargo +nightly fmt`. Dominated by `needless_borrows_for_generic_args` (219), then `collapsible_if` (→ let-chains), `len_zero`, `manual_range_contains`, `useless_vec`, and others. 26 test files touched.

3. **`style(clippy): clear remaining test warnings`** — the non-auto-fixable tail:
   - `moarstats`: const-invariant asserts → `const { }` block
   - `help_markdown_gen`: `get(k).is_none()` → `!contains_key(k)`
   - `test_describegpt`: `assert!(false, msg)` → `panic!(msg)`; dropped no-op `assert!(true, …)`
   - `tests.rs`: minimized single-condition `cfg(all(..))`; annotated transmute type params in the quickcheck `Csv` infra
   - `test_pragmastat`: zip-loop instead of range-index
   - `test_pseudo`: `std::u64::MAX` → `u64::MAX`
   - `test_moarstats`: scoped `#[allow(clippy::suspicious_command_arg_space)]` — `--stats-options` takes one space-separated string (false positive)

## Remaining

`cargo clippy --tests` now reports only **2 `missing_asserts_for_indexing` warnings**, which the project intentionally sets to `"warn"` in `Cargo.toml`.

## Verification

- `cargo clippy -F all_features --tests` — no errors, only the 2 intentional warnings
- All affected modules pass: stats 649, frequency 168, joinp/moarstats 88 each, pragmastat 47, property tests 27, pseudo 7, split 44, pivotp 62, partition 13, plus affected `src` unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)