### PR TITLE
fix(get): gate dc: tests needing cat/schema on feature_capable (fix qsvdp CI)

### DIFF
--- a/tests/test_get.rs
+++ b/tests/test_get.rs
@@ -1010,10 +1010,9 @@ fn get_cache_verify_detects_corruption() {
 // slice, join, …) must honor the `dc:` prefix rather than reject it as a missing
 // file — previously only `Config::new` resolved `dc:`, so process_input's raw
 // `path.exists()` check failed for "dc:…". Uses a local get (no network) to
-// isolate the dc: read path.
-// `cat` is not bundled in reduced binaries (e.g. qsvdp), so gate on
-// `feature_capable`; `slice`/`count` still cover the process_input dc: path there.
-#[cfg(feature = "feature_capable")]
+// isolate the dc: read path. `slice` is bundled in reduced binaries (e.g. qsvdp)
+// too, so it keeps the process_input dc: regression covered there; only the
+// `cat` assertion is `feature_capable`-gated (qsvdp does not bundle `cat`).
 #[test]
 #[serial]
 fn get_dc_works_with_process_input_commands() {
@@ -1028,11 +1027,16 @@ fn get_dc_works_with_process_input_commands() {
         .arg(src.to_str().unwrap());
     wrk.assert_success(&mut g);
 
-    // `cat` routes inputs through process_input -> must echo the dc: content
-    let mut cat = wrk.command("cat");
-    cat.env("QSV_CACHE_DIR", &cache_dir)
-        .args(["rows", "dc:src.csv"]);
-    assert_eq!(wrk.stdout::<String>(&mut cat), "id,name\n0,a\n1,b\n2,c");
+    // `cat` routes inputs through process_input -> must echo the dc: content.
+    // Gated because qsvdp does not bundle `cat`; the `slice` check below covers
+    // the same process_input dc: path on reduced binaries.
+    #[cfg(feature = "feature_capable")]
+    {
+        let mut cat = wrk.command("cat");
+        cat.env("QSV_CACHE_DIR", &cache_dir)
+            .args(["rows", "dc:src.csv"]);
+        assert_eq!(wrk.stdout::<String>(&mut cat), "id,name\n0,a\n1,b\n2,c");
+    }
 
     // `slice` likewise (and uses the materialized sibling .idx for --index)
     let mut slice = wrk.command("slice");

--- a/tests/test_get.rs
+++ b/tests/test_get.rs
@@ -1011,6 +1011,9 @@ fn get_cache_verify_detects_corruption() {
 // file — previously only `Config::new` resolved `dc:`, so process_input's raw
 // `path.exists()` check failed for "dc:…". Uses a local get (no network) to
 // isolate the dc: read path.
+// `cat` is not bundled in reduced binaries (e.g. qsvdp), so gate on
+// `feature_capable`; `slice`/`count` still cover the process_input dc: path there.
+#[cfg(feature = "feature_capable")]
 #[test]
 #[serial]
 fn get_dc_works_with_process_input_commands() {
@@ -1072,6 +1075,10 @@ fn dir_has_file_suffix(dir: &Path, suffix: &str) -> bool {
 // errored because the raw "dc:" string failed canonicalize — and (b) have the
 // .stats.csv.data.jsonl sidecar they build captured into a durable, content-
 // addressed blob so it survives temp-dir cleanup.
+// Uses `schema`, which reduced binaries (e.g. qsvdp) do not bundle; gate on
+// `feature_capable`. `frequency` coverage of the dc: stats-cache path on qsvdp
+// is provided by `get_dc_stats_cache_not_shared_across_extensions`.
+#[cfg(feature = "feature_capable")]
 #[test]
 #[serial]
 fn get_dc_stats_cache_for_smart_commands() {


### PR DESCRIPTION
## Problem

The qsvdp (`datapusher_plus`) CI on master went red after #3958 merged — two `get` tests fail there ([run](https://github.com/dathere/qsv/actions/runs/27079961823/job/79923945733)):

- `test_get::get_dc_works_with_process_input_commands` — invokes `cat`
- `test_get::get_dc_stats_cache_for_smart_commands` — invokes `schema`

The qsvdp binary bundles `get`/`slice`/`count`/`frequency`/`stats`/`profile` but **not** `cat` or `schema`, so those commands aren't recognized and the tests fail. They pass under `all_features` because that build has every command — which is why this slipped through (the PR was validated with `-F all_features`, not `--features=datapusher_plus`).

## Fix

Gate both tests on `#[cfg(feature = "feature_capable")]` — the same convention `tests/test_profile.rs` already uses for a schema-using test ("not qsvdp, which enables `profile` but not `schema`"). The change only *removes* the tests from non-`feature_capable` builds, so it can't introduce a failure anywhere.

dc: coverage on qsvdp is preserved by the other get tests: `slice`/`count` still exercise the `process_input` dc: path, and `get_dc_stats_cache_not_shared_across_extensions` covers `frequency` on dc:.

## Verification

- `cargo test --features=datapusher_plus get_` → **26 passed, 0 failed** (the two gated tests excluded).
- `cargo test -F all_features get_dc` → all **3 run and pass** (gate satisfied — no feature-name typo).
- `qsvmcp` includes `feature_capable`, so the tests still run + pass there; `lite` doesn't include `get`, so test_get doesn't compile there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)