### PR TITLE
ci: add manual Bench QSV_THP workflow (dispatch-only)

### DIFF
--- a/.github/workflows/bench-qsv-thp.yml
+++ b/.github/workflows/bench-qsv-thp.yml
@@ -1,0 +1,249 @@
+name: Bench QSV_THP (jemalloc Transparent Huge Pages)
+
+# Manual benchmark for the opt-in `QSV_THP` lever (Lever C). On Linux + jemalloc,
+# setting QSV_THP=1 injects `thp:always,metadata_thp:always` into _RJEM_MALLOC_CONF
+# and re-execs qsv once so a fresh allocator reads it (thp/metadata_thp are read-only
+# jemalloc opt.* knobs that can't be set at runtime). 2 MB huge pages cut TLB misses
+# on aggregation-heavy commands over large arenas; the gamble is that huge-page
+# allocation overhead (plus the one-time re-exec) doesn't erase that win.
+#
+# This is a STRESS test, not a realistic workload: it generates a synthetic
+# high-cardinality dataset (id fully unique, hi ~ROWS distinct) that drives qsv's
+# cardinality/frequency hashmaps into the millions of entries — the large-arena,
+# TLB-pressure regime THP is meant to help. A null result here (where TLB pressure
+# is maximal) is strong evidence THP is inert for qsv's workloads.
+#
+# A single release binary is built (default features → jemalloc on). The only
+# variable is the QSV_THP env toggle; every other jemalloc lever (background_thread,
+# dirty/muzzy decay) stays at qsv's Linux default in both cells.
+#
+#   cells (per command):
+#     baseline — default tuning, no QSV_THP            (background_thread on)
+#     thp      — QSV_THP=1  → re-exec + thp:always,metadata_thp:always
+#
+# Context: docs/jemalloc-tuning.md (Lever C / Polars POLARS_THP); jemalloc TUNING.md.
+#
+# NOTE: GitHub-hosted runners are shared/noisy (no thermal pinning, noisy neighbours).
+# The signal can sit near the runner noise floor — read +/- sigma and the peak-RSS
+# table, not single means. Re-run a few times; report medians.
+
+on:
+  workflow_dispatch:
+    inputs:
+      rows:
+        description: "synthetic high-cardinality rows (TLB/arena pressure)"
+        required: false
+        default: "8000000"
+      runs:
+        description: "hyperfine runs per cell"
+        required: false
+        default: "7"
+      warmup:
+        description: "hyperfine warmup runs"
+        required: false
+        default: "2"
+
+permissions:
+  contents: read
+
+jobs:
+  bench:
+    name: QSV_THP A/B on ubuntu-latest
+    runs-on: ubuntu-latest
+    env:
+      DATA: synth_highcard.csv
+      HYPERFINE_VERSION: "1.18.0"
+      # Inputs are passed through env (not interpolated into `run:` shell) to avoid
+      # ${{ github.* }} script injection.
+      ROWS: ${{ github.event.inputs.rows }}
+      RUNS: ${{ github.event.inputs.runs }}
+      WARMUP: ${{ github.event.inputs.warmup }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install build & bench deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwayland-dev
+          # hyperfine is not reliably in apt; pull the official .deb
+          curl -fsSL -o /tmp/hyperfine.deb \
+            "https://github.com/sharkdp/hyperfine/releases/download/v${HYPERFINE_VERSION}/hyperfine_${HYPERFINE_VERSION}_amd64.deb"
+          sudo dpkg -i /tmp/hyperfine.deb
+          hyperfine --version
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          targets: x86_64-unknown-linux-gnu
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: qsv-thp-bench
+
+      - name: Show THP state + runner memory
+        run: |
+          echo "### Runner Transparent Huge Pages state" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "enabled: $(cat /sys/kernel/mm/transparent_hugepage/enabled 2>/dev/null || echo unavailable)" | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "defrag:  $(cat /sys/kernel/mm/transparent_hugepage/defrag 2>/dev/null || echo unavailable)"   | tee -a "$GITHUB_STEP_SUMMARY"
+          free -h | tee -a "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          # THP must be 'always' or 'madvise' for jemalloc thp:always to get huge pages.
+          if grep -qE '\[(always|madvise)\]' /sys/kernel/mm/transparent_hugepage/enabled 2>/dev/null; then
+            echo "kernel THP is enabled — thp:always can take effect ✓" | tee -a "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning::kernel THP is 'never' — QSV_THP will be inert; perf delta should be ~0 (modulo re-exec cost)"
+          fi
+
+      - name: Generate synthetic high-cardinality dataset
+        run: |
+          # Reproducible (srand(42)). id fully unique (cardinality == ROWS), hi ~ROWS
+          # distinct, mid ~100k, lo ~100, plus two numeric cols for quartile/median
+          # vectors. id+hi drive the cardinality/frequency hashmaps into the millions.
+          gawk -v rows="$ROWS" 'BEGIN{
+            srand(42);
+            print "id,hi,mid,lo,num1,num2";
+            for (i = 0; i < rows; i++) {
+              printf "%d,%d,%d,%d,%d,%.4f\n", \
+                i, int(rand()*2000000000), int(rand()*100000), int(rand()*100), \
+                int(rand()*1000000), rand()*1000;
+            }
+          }' > "$DATA"
+          ls -lh "$DATA"
+          echo "rows: $(($(wc -l < "$DATA") - 1))  cols: $(head -1 "$DATA" | tr ',' '\n' | wc -l)"
+
+      - name: Build release binary (default features → jemalloc)
+        run: |
+          cargo build --release --bin qsv -F feature_capable
+          cp target/release/qsv /tmp/qsv
+
+      - name: Sanity — QSV_THP re-exec fires and injects thp config
+        run: |
+          echo "### Binary sanity (QSV_THP re-exec)" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "version: $(/tmp/qsv --version)" | tee -a "$GITHUB_STEP_SUMMARY"
+
+          # Baseline: no QSV_THP → the re-exec sentinel must NOT be present.
+          if /tmp/qsv --envlist | grep -q '^QSV_THP_APPLIED'; then
+            echo "::error::QSV_THP_APPLIED leaked into the no-THP baseline — sentinel logic broken"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"; exit 1
+          fi
+
+          # QSV_THP=1 → re-exec must fire (sentinel set in the child) and inject THP
+          # into _RJEM_MALLOC_CONF. --envlist surfaces both (QSV_ prefix + the
+          # _RJEM_MALLOC_CONF row added in show_env_vars()).
+          THP_ENV="$(env QSV_THP=1 /tmp/qsv --envlist)"
+          if echo "$THP_ENV" | grep -q '^QSV_THP_APPLIED'; then
+            echo "QSV_THP=1 re-exec fired (QSV_THP_APPLIED set) ✓" | tee -a "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::error::QSV_THP=1 did NOT re-exec — sentinel missing"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"; exit 1
+          fi
+          if echo "$THP_ENV" | grep '^_RJEM_MALLOC_CONF' | grep -q 'thp:always'; then
+            echo "thp:always injected into _RJEM_MALLOC_CONF ✓" | tee -a "$GITHUB_STEP_SUMMARY"
+            echo "$THP_ENV" | grep '^_RJEM_MALLOC_CONF' | tee -a "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::error::thp:always NOT found in _RJEM_MALLOC_CONF after QSV_THP=1"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"; exit 1
+          fi
+
+          # User config must be preserved (we append, not clobber).
+          USER_ENV="$(env QSV_THP=1 _RJEM_MALLOC_CONF=stats_print:true /tmp/qsv --envlist)"
+          if echo "$USER_ENV" | grep '^_RJEM_MALLOC_CONF' | grep -q 'stats_print:true'; then
+            echo "pre-existing _RJEM_MALLOC_CONF preserved (appended, not clobbered) ✓" | tee -a "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::error::existing _RJEM_MALLOC_CONF was clobbered by QSV_THP"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"; exit 1
+          fi
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Confirm cardinality (TLB-pressure regime)
+        run: |
+          echo "### Column cardinality (drives arena/TLB pressure)" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          /tmp/qsv stats --cardinality "$DATA" | /tmp/qsv select field,cardinality - | tee -a "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Index dataset (parallel path)
+        run: /tmp/qsv index "$DATA"
+
+      - name: Parity check — frequency must be byte-identical across cells
+        run: |
+          # The allocator can never change computed values; frequency (deterministic
+          # integer counts) is the correct invariant. NOT stats -E, whose float
+          # aggregates have allocator-independent non-deterministic reduction order.
+          /tmp/qsv frequency "$DATA" > f_base.csv
+          env QSV_THP=1 /tmp/qsv frequency "$DATA" > f_thp.csv
+          if cmp f_base.csv f_thp.csv; then
+            echo "frequency byte-identical baseline vs thp ✓" | tee -a "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::error::frequency output DIFFERS with QSV_THP — correctness bug, not a perf question"
+            exit 1
+          fi
+
+      - name: Benchmark — frequency (A/B)
+        run: |
+          mkdir -p bench-results
+          hyperfine --warmup "$WARMUP" --runs "$RUNS" -N \
+            --export-markdown bench-results/frequency.md \
+            --export-json bench-results/frequency.json \
+            -n "baseline" "/tmp/qsv frequency $DATA" \
+            -n "thp"      "env QSV_THP=1 /tmp/qsv frequency $DATA"
+
+      - name: Benchmark — stats -E (A/B)
+        run: |
+          hyperfine --warmup "$WARMUP" --runs "$RUNS" -N \
+            --export-markdown bench-results/stats-E.md \
+            --export-json bench-results/stats-E.json \
+            -n "baseline" "/tmp/qsv stats -E -c 0 $DATA" \
+            -n "thp"      "env QSV_THP=1 /tmp/qsv stats -E -c 0 $DATA"
+
+      - name: Peak RSS & CPU time (THP tradeoff)
+        run: |
+          # THP trades a possible RSS bump (huge-page rounding) for fewer TLB misses.
+          # Capture peak RSS + user/sys SYNCHRONOUSLY (write to file, then parse).
+          # /usr/bin/time tracks the same PID across the QSV_THP re-exec (exec keeps
+          # the PID), so peak RSS reflects the real, re-exec'd child.
+          measure () {
+            local label="$1"; shift
+            /usr/bin/time -v "$@" >/dev/null 2>/tmp/time.txt || true
+            local rss user sys
+            rss=$(awk -F': ' '/Maximum resident set size/{print $2}' /tmp/time.txt)
+            user=$(awk -F': ' '/User time/{print $2}' /tmp/time.txt)
+            sys=$(awk -F': ' '/System time/{print $2}' /tmp/time.txt)
+            printf '%-10s peakRSS=%8s KB   user=%6ss   sys=%6ss\n' "$label" "$rss" "$user" "$sys" \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+          }
+          echo "### stats -E -c 0 — peak RSS & CPU time (single shot each)" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          measure "baseline" /tmp/qsv stats -E -c 0 "$DATA"
+          measure "thp"      env QSV_THP=1 /tmp/qsv stats -E -c 0 "$DATA"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Render results to job summary
+        if: always()
+        run: |
+          {
+            echo "## frequency (indexed, parallel path)"
+            cat bench-results/frequency.md
+            echo ""
+            echo "## stats -E (-c 0)"
+            cat bench-results/stats-E.md
+            echo ""
+            echo "**Primary comparison:** \`thp\` vs \`baseline\` on a deliberately"
+            echo "high-cardinality workload. \`thp\` includes a one-time re-exec; on this"
+            echo "multi-second workload that cost is negligible. Faster (or tied within"
+            echo "noise) with an acceptable peak-RSS delta argues QSV_THP is worth"
+            echo "documenting as a real lever; a null result where TLB pressure is maximal"
+            echo "is strong evidence THP is inert for qsv and should stay strictly opt-in."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload raw results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: bench-qsv-thp-${{ github.run_id }}
+          path: bench-results/


### PR DESCRIPTION
## Summary

Adds a **dispatch-only** GitHub Actions workflow to benchmark the opt-in `QSV_THP` lever from PR #3963.

This PR contains **only the workflow file** — no code changes — so merging it is low-risk and lets the workflow be registered on `master` (GitHub requires `workflow_dispatch` workflows to exist on the default branch before they can be triggered). Once merged, the workflow is dispatched against the feature branch:

```
gh workflow run bench-qsv-thp.yml --ref qsv-thp-lever
```

which checks out and builds the `qsv-thp-lever` branch's code (the actual `QSV_THP` implementation).

## What it measures
- A/B: `baseline` vs `QSV_THP=1` for `frequency` and `stats -E` on a synthetic ~8M-row high-cardinality dataset (drives cardinality/frequency hashmaps into the millions — the large-arena/TLB-pressure regime THP targets).
- Peak RSS + user/sys CPU time per cell.
- Deterministic sanity check that the `QSV_THP` re-exec fires (`QSV_THP_APPLIED` and `thp:always` surface in `--envlist`) and preserves user `_RJEM_MALLOC_CONF`.
- Frequency byte-parity across cells (the allocator must never change computed values).

Runner noise notes are in the workflow header — read sigma + RSS, not single means.

🤖 Generated with [Claude Code](https://claude.com/claude-code)