### PR TITLE
ci+test(sample): cap test-job runtime; harden fixture-server teardown

### DIFF
--- a/.github/workflows/rust-beta.yml
+++ b/.github/workflows/rust-beta.yml
@@ -12,6 +12,8 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    # Hard cap so a hung test fails fast instead of burning the 6-hour GitHub default.
+    timeout-minutes: 90
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/rust-linux-polars.yml
+++ b/.github/workflows/rust-linux-polars.yml
@@ -18,6 +18,8 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    # Hard cap so a hung test fails fast instead of burning the 6-hour GitHub default.
+    timeout-minutes: 90
 
     steps:
     - uses: actions/checkout@v6        

--- a/.github/workflows/rust-macos-polars.yml
+++ b/.github/workflows/rust-macos-polars.yml
@@ -23,6 +23,8 @@ jobs:
 
     # runs-on: self-hosted
     runs-on: macos-26
+    # Hard cap so a hung test fails fast instead of burning the 6-hour GitHub default.
+    timeout-minutes: 90
 
     steps:
     - uses: actions/checkout@v6        

--- a/.github/workflows/rust-macos.yml
+++ b/.github/workflows/rust-macos.yml
@@ -23,6 +23,8 @@ jobs:
 
     # runs-on: self-hosted
     runs-on: macos-26
+    # Hard cap so a hung test fails fast instead of burning the 6-hour GitHub default.
+    timeout-minutes: 90
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/rust-musl.yml
+++ b/.github/workflows/rust-musl.yml
@@ -22,6 +22,8 @@ jobs:
       !contains(github.event.head_commit.message, '(mcp):')
 
     runs-on: ubuntu-latest
+    # Hard cap so a hung test fails fast instead of burning the 6-hour GitHub default.
+    timeout-minutes: 90
 
     steps:
     - name: apt-get update Ubuntu

--- a/.github/workflows/rust-nightly-bleeding-edge.yml
+++ b/.github/workflows/rust-nightly-bleeding-edge.yml
@@ -17,6 +17,8 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    # Hard cap so a hung test fails fast instead of burning the 6-hour GitHub default.
+    timeout-minutes: 90
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/rust-polars-nightly.yml
+++ b/.github/workflows/rust-polars-nightly.yml
@@ -10,6 +10,8 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    # Hard cap so a hung test fails fast instead of burning the 6-hour GitHub default.
+    timeout-minutes: 90
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/rust-polars-pinned-nightly.yml
+++ b/.github/workflows/rust-polars-pinned-nightly.yml
@@ -14,6 +14,8 @@ jobs:
   build:
 
     runs-on: ubuntu-24.04
+    # Hard cap so a hung test fails fast instead of burning the 6-hour GitHub default.
+    timeout-minutes: 90
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/rust-ppc64le.yml
+++ b/.github/workflows/rust-ppc64le.yml
@@ -14,6 +14,8 @@ jobs:
   build:
 
     runs-on: ubuntu-24.04-ppc64le
+    # Hard cap so a hung test fails fast instead of burning the 6-hour GitHub default.
+    timeout-minutes: 90
 
     steps:
     - name: apt-get update Ubuntu, libwayland-dev

--- a/.github/workflows/rust-qsvdp.yml
+++ b/.github/workflows/rust-qsvdp.yml
@@ -22,6 +22,8 @@ jobs:
       !contains(github.event.head_commit.message, '(mcp):')
 
     runs-on: ubuntu-latest
+    # Hard cap so a hung test fails fast instead of burning the 6-hour GitHub default.
+    timeout-minutes: 90
 
     steps:
     - name: Free disk space

--- a/.github/workflows/rust-qsvlite.yml
+++ b/.github/workflows/rust-qsvlite.yml
@@ -22,6 +22,8 @@ jobs:
       !contains(github.event.head_commit.message, '(mcp):')
 
     runs-on: ubuntu-latest
+    # Hard cap so a hung test fails fast instead of burning the 6-hour GitHub default.
+    timeout-minutes: 90
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/rust-s390x.yml
+++ b/.github/workflows/rust-s390x.yml
@@ -14,6 +14,8 @@ jobs:
   build:
 
     runs-on: ubuntu-24.04-s390x
+    # Hard cap so a hung test fails fast instead of burning the 6-hour GitHub default.
+    timeout-minutes: 90
 
     steps:
     - name: apt-get update Ubuntu, libwayland-dev

--- a/.github/workflows/rust-to.yml
+++ b/.github/workflows/rust-to.yml
@@ -22,6 +22,8 @@ jobs:
       !contains(github.event.head_commit.message, '(mcp):')
 
     runs-on: ubuntu-latest
+    # Hard cap so a hung test fails fast instead of burning the 6-hour GitHub default.
+    timeout-minutes: 90
 
     steps:
     - name: apt-get update Ubuntu, libwayland-dev

--- a/.github/workflows/rust-windows-arm64.yml
+++ b/.github/workflows/rust-windows-arm64.yml
@@ -22,6 +22,9 @@ jobs:
       !contains(github.event.head_commit.message, '(mcp):')
 
     runs-on: windows-11-arm
+    # Hard cap so a hung test (e.g. flaky streaming-URL sample tests) fails fast
+    # instead of burning the 6-hour GitHub default. Normal runs finish in ~45 min.
+    timeout-minutes: 90
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/rust-windows-lite.yml
+++ b/.github/workflows/rust-windows-lite.yml
@@ -22,6 +22,8 @@ jobs:
       !contains(github.event.head_commit.message, '(mcp):')
 
     runs-on: windows-latest
+    # Hard cap so a hung test fails fast instead of burning the 6-hour GitHub default.
+    timeout-minutes: 90
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/rust-windows.yml
+++ b/.github/workflows/rust-windows.yml
@@ -22,6 +22,8 @@ jobs:
       !contains(github.event.head_commit.message, '(mcp):')
 
     runs-on: windows-latest
+    # Hard cap so a hung test fails fast instead of burning the 6-hour GitHub default.
+    timeout-minutes: 90
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,6 +22,8 @@ jobs:
       !contains(github.event.head_commit.message, '(mcp):')
 
     runs-on: ubuntu-latest
+    # Hard cap so a hung test fails fast instead of burning the 6-hour GitHub default.
+    timeout-minutes: 90
 
     steps:
     - name: apt-get update Ubuntu, libwayland-dev

--- a/tests/test_sample.rs
+++ b/tests/test_sample.rs
@@ -2183,9 +2183,22 @@ impl SampleWebServer {
 impl Drop for SampleWebServer {
     fn drop(&mut self) {
         if let Some(handle) = self.handle.take() {
-            // block_on returns whatever stop() returns; we don't care about
-            // errors during teardown — best-effort cleanup.
-            rt::System::new().block_on(handle.stop(true));
+            // Non-graceful stop (graceful = false) so an abandoned mid-response
+            // connection — e.g. the --max-size test that stops reading early —
+            // can't wedge teardown waiting for in-flight requests to drain.
+            //
+            // Belt-and-suspenders: run the stop on a detached thread and only
+            // wait a bounded time for it. On a slow/contended runner (this hung
+            // the Windows ARM64 CI to the 6-hour ceiling) a wedged shutdown must
+            // never block the test thread forever; if it doesn't finish in time
+            // we leak the ephemeral-port server and move on — the next #[serial]
+            // test simply binds a fresh OS-assigned port.
+            let (done_tx, done_rx) = mpsc::channel();
+            thread::spawn(move || {
+                rt::System::new().block_on(handle.stop(false));
+                let _ = done_tx.send(());
+            });
+            let _ = done_rx.recv_timeout(std::time::Duration::from_secs(10));
         }
     }
 }


### PR DESCRIPTION
## Problem

The Windows ARM64 CI job hung for the full **6-hour GitHub ceiling** ([run 27184534175](https://github.com/dathere/qsv/actions/runs/27184534175/job/80250548307)) before being force-cancelled.

The log goes silent at `05:38:22` right after four `#[serial]` streaming-Bernoulli-URL `sample` tests (added in #3775) start:

```
test_sample::sample_bernoulli_url_404_fails_fast         has been running for over 60 seconds
test_sample::sample_bernoulli_url_custom_delimiter       has been running for over 60 seconds
test_sample::sample_bernoulli_url_max_size_truncation    has been running for over 60 seconds
test_sample::sample_bernoulli_url_quoted_newline_header  has been running for over 60 seconds
```

Only **one** test is actually executing — it hung, and the harness lists the other three as "running" only because their threads are parked on the serial mutex behind it.

## Root cause

Two layers:

1. **No timeout guard.** None of the Rust test workflows set `timeout-minutes`, so a hung test runs to GitHub's 6h default. The hang itself is flaky — the prior ~12 ARM64 runs all passed in ~45 min — so it's a race in the in-process actix fixture server / loopback HTTP streaming on the runner.
2. **Unbounded teardown.** qsv's own 30s request timeout protects the child process; it didn't help because the stall is on the **test** side — `SampleWebServer::drop` does an unbounded *graceful* `handle.stop(true)`, waiting for an abandoned mid-response connection to drain (the `--max-size` test deliberately stops reading early).

## Fixes

1. **`timeout-minutes: 90`** on the `build` job of **every Rust workflow that runs `cargo test` (17 in total)** — so a flake fails in ≤90 min instead of burning a 6h runner slot. The first commit capped the four that exercise the flaky `sample` path (`rust-windows-arm64.yml`, `rust-windows.yml`, `rust-windows-lite.yml`, `rust.yml`); a follow-up commit (addressing review feedback) extended the same cap to the remaining 13 for consistency: `rust-beta`, `rust-linux-polars`, `rust-macos-polars`, `rust-macos`, `rust-musl`, `rust-polars-pinned-nightly`, `rust-polars-nightly`, `rust-nightly-bleeding-edge`, `rust-ppc64le`, `rust-qsvlite`, `rust-s390x`, `rust-qsvdp`, `rust-to`. All historically complete well under 90 min (slowest observed ~46 min on ppc64le).
2. **`SampleWebServer::drop`** now uses non-graceful `stop(false)` and runs it on a detached thread with a bounded `recv_timeout(10s)`. A wedged shutdown can never block the test thread forever — it leaks the ephemeral-port server and the next `#[serial]` test simply binds a fresh OS-assigned port.

## Verification

- `cargo +nightly fmt` clean, YAML validated on all 17 workflows, `tests` target compiles.
- All four affected tests pass:

```
running 4 tests
test test_sample::sample_bernoulli_url_custom_delimiter ... ok
test test_sample::sample_bernoulli_url_quoted_newline_header ... ok
test test_sample::sample_bernoulli_url_404_fails_fast ... ok
test test_sample::sample_bernoulli_url_max_size_truncation ... ok

test result: ok. 4 passed; 0 failed; ...; finished in 10.62s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
