### PR TITLE
feat: PGO-optimize prebuilt qsv binaries on native targets (closes #1448)

### DIFF
--- a/.github/workflows/macOS-arm64-selfhosted-publish.yml
+++ b/.github/workflows/macOS-arm64-selfhosted-publish.yml
@@ -51,15 +51,26 @@ jobs:
       with:
         submodules: recursive
         ref: ${{ needs.analyze-tags.outputs.previous-tag }}
-    - name: Build qsv
+    # ensure 7zip is present so PGO training can use the full NYC-311 dataset (the
+    # later "install 7zip" step runs post-build; this is idempotent on the self-hosted runner)
+    - name: install 7zip (for PGO training)
+      run: brew install sevenzip
+    # PGO-optimized qsv build (issue #1448). aarch64-apple-darwin is an ideal PGO target
+    # (native, already target-cpu=native). build-pgo.sh runs instrument -> train -> optimize
+    # and leaves the binary where the "Copy binaries" step looks. QSV_KIND=prebuilt-pgo.
+    - name: Build qsv (PGO)
+      shell: bash
       env:
-        RUSTFLAGS: --emit=asm -C target-cpu=native
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        use-cross: ${{ matrix.job.use-cross }}
-        toolchain: ${{ matrix.rust }}
-        args: --profile ${{ contains(matrix.job.addl-build-args, 'luau') && 'release-luau' || 'release' }} --locked --bin qsv --target ${{ matrix.job.target }} ${{ matrix.job.addl-build-args }},feature_capable ${{ matrix.job.default-features }}
+        QSV_KIND: prebuilt-pgo
+        TARGET: ${{ matrix.job.target }}
+        DEFAULT_FEATURES: ${{ matrix.job.default-features }}
+        RUSTFLAGS: -C target-cpu=native
+        ADDL_BUILD_ARGS: ${{ matrix.job.addl-build-args }}
+      run: |
+        # strip the leading "--features=" to get the bare comma-separated feature list
+        export QSV_FEATURES="${ADDL_BUILD_ARGS#--features=}"
+        chmod +x scripts/build-pgo.sh scripts/pgo-train.sh
+        ./scripts/build-pgo.sh
     - name: Build qsvlite
       env:
         RUSTFLAGS: --emit=asm -C target-cpu=native

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,10 @@ jobs:
             addl-qsvlite-features:
             addl-qsvdp-features:
             addl-rustflags:
+            # native runner - PGO-optimize the main qsv binary (issue #1448)
+            pgo: true
+            pgo-train-flags:
+            pgo-lto:
           - os: ubuntu-24.04
             os-name: linux
             target: x86_64-unknown-linux-musl
@@ -57,6 +61,10 @@ jobs:
             addl-qsvlite-features:
             addl-qsvdp-features:
             addl-rustflags:
+            # musl is a reduced-feature, lower-priority target - PGO deferred (plan #1448)
+            pgo: false
+            pgo-train-flags:
+            pgo-lto:
           # - os: ubuntu-24.04
           #   os-name: linux
           #   target: i686-unknown-linux-gnu
@@ -78,6 +86,11 @@ jobs:
             addl-qsvlite-features:
             addl-qsvdp-features:
             addl-rustflags:
+            # native runner - PGO with --minimal training (benchmarks.sh data prep
+            # does not run natively on Windows; train via git-bash on a synthesized CSV)
+            pgo: true
+            pgo-train-flags: --minimal
+            pgo-lto:
           # - os: windows-latest
           #   os-name: windows
           #   target: i686-pc-windows-msvc
@@ -99,6 +112,10 @@ jobs:
             addl-qsvlite-features:
             addl-qsvdp-features:
             addl-rustflags:
+            # native runner - PGO with --minimal training (Windows, see msvc note above)
+            pgo: true
+            pgo-train-flags: --minimal
+            pgo-lto:
           # - os: macos-12
           #   os-name: macos
           #   target: x86_64-apple-darwin
@@ -128,6 +145,12 @@ jobs:
             addl-qsvlite-features:
             addl-qsvdp-features:
             addl-rustflags:
+            # native ARM runner - PGO the qsv binary. The PGO optimize build is one more
+            # fat-LTO link of the same qsv that already builds here, so memory use matches
+            # today's working build. If it ever OOMs, set pgo-lto: thin as the escape hatch.
+            pgo: true
+            pgo-train-flags:
+            pgo-lto:
           # - os: ubuntu-20.04
           #   os-name: linux
           #   target: arm-unknown-linux-gnueabihf
@@ -175,7 +198,29 @@ jobs:
       run: |
         sudo apt-get install musl-tools musl-dev
         sudo ln -s /usr/bin/g++ /usr/bin/musl-g++
-    - name: Build qsv
+    # PGO-optimized qsv build for native-runner targets (issue #1448). build-pgo.sh
+    # runs the instrument -> train -> optimize cycle and leaves the binary in the same
+    # target/<target>/<profile>/ path the "Copy binaries" step globs. QSV_KIND is set to
+    # prebuilt-pgo so `qsv --version` reflects the PGO build (util.rs starts_with("prebuilt")
+    # still treats it as a prebuilt for self-update).
+    - name: Build qsv (PGO)
+      if: ${{ matrix.job.pgo }}
+      shell: bash
+      env:
+        QSV_KIND: prebuilt-pgo
+        TARGET: ${{ matrix.job.target }}
+        DEFAULT_FEATURES: ${{ matrix.job.default-features }}
+        RUSTFLAGS: ${{ matrix.job.addl-rustflags }}
+        PGO_LTO: ${{ matrix.job.pgo-lto }}
+        TRAIN_FLAGS: ${{ matrix.job.pgo-train-flags }}
+        ADDL_BUILD_ARGS: ${{ matrix.job.addl-build-args }}
+      run: |
+        # strip the leading "--features=" to get the bare comma-separated feature list
+        export QSV_FEATURES="${ADDL_BUILD_ARGS#--features=}"
+        chmod +x scripts/build-pgo.sh scripts/pgo-train.sh
+        ./scripts/build-pgo.sh
+    - name: Build qsv (normal)
+      if: ${{ !matrix.job.pgo }}
       # env:
       #   RUSTFLAGS: --emit=asm
       env:

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -94,6 +94,56 @@ rustc --print cfg -C target-cpu=native | grep -i target_feature
 rustc --print target-features
 ```
 
+## Profile-Guided Optimization (PGO)
+
+[Profile-Guided Optimization](https://doc.rust-lang.org/rustc/profile-guided-optimization.html) (PGO)
+is a compiler technique that makes qsv faster by optimizing it based on how it *actually* runs. It works
+in three steps: (1) build an **instrumented** binary, (2) **train** it by running a representative
+workload so it records which code paths are hot, then (3) **re-build** using those profiles so the
+compiler can lay out and inline hot code optimally. PGO measurably improves qsv performance on many
+commands (see [issue #1448](https://github.com/dathere/qsv/issues/1448)).
+
+The prebuilt qsv binaries for **native targets** are PGO-optimized: `x86_64-unknown-linux-gnu`,
+`aarch64-unknown-linux-gnu`, `x86_64-pc-windows-msvc`, `x86_64-pc-windows-gnu`, and
+`aarch64-apple-darwin`. These show `prebuilt-pgo` as their `QSV_KIND` in `qsv --version`.
+Cross-compiled / emulated targets (and `x86_64-unknown-linux-musl`) are **not** PGO-optimized, because
+the instrumented binary cannot be run on the build host to collect a training profile.
+
+### Building a PGO-optimized qsv yourself
+
+qsv ships two helper scripts that wrap [`cargo-pgo`](https://github.com/Kobzol/cargo-pgo):
+
+- [`scripts/build-pgo.sh`](../scripts/build-pgo.sh) — orchestrates the instrument → train → optimize
+  cycle for one binary/target. The optimized binary lands in `target/<target>/<profile>/qsv`.
+- [`scripts/pgo-train.sh`](../scripts/pgo-train.sh) — the training harness. It exercises a
+  representative spread of qsv subcommands once (no hyperfine). It downloads the same NYC-311 sample
+  used by `benchmarks.sh`, or, with `--minimal`, synthesizes a small dataset (used on Windows).
+
+The optimize step keeps qsv's normal fat-LTO release settings; only the instrument step drops to
+thin-LTO. Example (Linux/macOS), building a PGO `qsv` for your host target with the full feature set:
+
+```bash
+# one-time: PGO toolchain (build-pgo.sh also does this for you)
+rustup component add llvm-tools-preview
+cargo install cargo-pgo
+
+TARGET=$(rustc -vV | sed -n 's/host: //p') \
+QSV_FEATURES=apply,luau,fetch,foreach,self_update,geocode,polars,to,lens,prompt,magika,color \
+RUSTFLAGS='-C target-cpu=native' \
+  ./scripts/build-pgo.sh
+```
+
+For the best possible local binary, combine PGO with `target-cpu=native` (as above) — and, if you want
+to go further, with the Rust Nightly build settings described in [Nightly Release Builds](#nightly-release-builds).
+
+### Future: LLVM BOLT (Post-Link Optimization)
+
+[LLVM BOLT](https://github.com/llvm/llvm-project/tree/main/bolt) Post-Link Optimization (PLO) is a
+planned follow-up (Linux x86_64 first). BOLT re-orders the final binary's code layout using a profile,
+on top of PGO, for additional gains — the same way Clang and rustc themselves are built. `build-pgo.sh`
+contains a commented stub showing where the BOLT steps will go. Tracked in
+[issue #1448](https://github.com/dathere/qsv/issues/1448).
+
 ## Memory Management
 ### Memory Allocator
 
@@ -195,8 +245,8 @@ The `--version` option shows a lot of information about qsv. It displays:
 * memory-related OOM prevention info (max "non-streaming" input file size, free swap memory, available memory & total memory)
 * the target platform
 * the Rust version used to compile qsv
-* QSV_KIND - `prebuilt`, `prebuilt-*`, `installed` & `compiled`.
-   The prebuilts are the qsv binaries published on Github with every release. `prebuilt` is built using the current Rust stable at the time of release. `prebuilt-nightly` is built using Rust nightly that passes all CI tests at the time of release.
+* QSV_KIND - `prebuilt`, `prebuilt-pgo`, `prebuilt-nightly`, `prebuilt-*`, `installed` & `compiled`.
+   The prebuilts are the qsv binaries published on Github with every release. `prebuilt` is built using the current Rust stable at the time of release. `prebuilt-pgo` is a stable prebuilt that was additionally [Profile-Guided Optimized](#profile-guided-optimization-pgo) (the default for native targets). `prebuilt-nightly` is built using Rust nightly that passes all CI tests at the time of release (`prebuilt-nightly-pgo` is reserved for a future nightly+PGO build).
    `installed` is qsv built using `cargo install`. `compiled` is qsv built using `cargo build`.
 
 ```bash

--- a/scripts/build-pgo.sh
+++ b/scripts/build-pgo.sh
@@ -69,14 +69,18 @@ case "$TARGET" in
 esac
 bin_file="${BIN}${bin_ext}"
 
-# the qsv binary always builds with feature_capable (mirrors publish.yml)
+# the qsv binary requires feature_capable (Cargo.toml required-features), so always
+# include it for BIN=qsv - even when QSV_FEATURES is empty - or the build fails
+# (mirrors publish.yml)
 features_arg=""
-if [[ -n "$QSV_FEATURES" ]]; then
-  if [[ "$BIN" == "qsv" ]]; then
+if [[ "$BIN" == "qsv" ]]; then
+  if [[ -n "$QSV_FEATURES" ]]; then
     features_arg="--features=${QSV_FEATURES},feature_capable"
   else
-    features_arg="--features=${QSV_FEATURES}"
+    features_arg="--features=feature_capable"
   fi
+elif [[ -n "$QSV_FEATURES" ]]; then
+  features_arg="--features=${QSV_FEATURES}"
 fi
 
 # cargo's per-profile env override key: profile name uppercased, '-' -> '_'
@@ -105,7 +109,7 @@ echo ">>> [0/3] toolchain check (llvm-tools-preview + cargo-pgo)"
 rustup component add llvm-tools-preview
 if ! cargo pgo info &>/dev/null; then
   echo "cargo-pgo not found; installing..."
-  cargo install cargo-pgo
+  cargo install cargo-pgo --locked
 fi
 cargo pgo info || true
 

--- a/scripts/build-pgo.sh
+++ b/scripts/build-pgo.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+#
+# build-pgo.sh - parameterized Profile-Guided Optimization (PGO) build orchestrator
+#                for qsv, used by both CI (publish workflows) and local users.
+#
+# It wraps cargo-pgo to run the three-step PGO cycle for ONE binary/target:
+#   1. instrument build  (thin-LTO - fat-LTO + instrumentation is slow/fragile)
+#   2. train             (scripts/pgo-train.sh exercises representative code paths)
+#   3. optimize build    (keeps the fat-LTO from [profile.release], using the
+#                         collected profiles via -Cprofile-use)
+#
+# The optimized binary is left in target/<target>/<profile>/<bin>, exactly where the
+# publish workflows already look, so no packaging changes are needed.
+#
+# Configuration is via environment variables (CI sets these from the matrix; locally
+# you can export them or rely on the defaults):
+#
+#   TARGET            REQUIRED. Rust target triple, e.g. x86_64-unknown-linux-gnu
+#   BIN               Binary to build (default: qsv)
+#   QSV_FEATURES      Comma-separated feature list WITHOUT the --features= prefix,
+#                     e.g. "apply,luau,fetch,self_update,geocode,polars,to,lens".
+#                     For the qsv binary, ",feature_capable" is appended automatically.
+#   DEFAULT_FEATURES  Passthrough, e.g. "--no-default-features" (Windows) or "" (default)
+#   PROFILE           Cargo profile (default: auto - "release-luau" if QSV_FEATURES
+#                     contains "luau" else "release"). The main qsv binary needs
+#                     release-luau (panic=unwind) when built with luau (qsv #3937).
+#   PGO_LTO           OPTIONAL optimize-build LTO override (e.g. "thin" or "off").
+#                     Leave unset to keep the fat-LTO from Cargo.toml. This is the
+#                     escape hatch for memory-constrained runners (aarch64 OOM).
+#   RUSTFLAGS         OPTIONAL passthrough (e.g. "-C target-cpu=native"). cargo-pgo
+#                     appends its own -Cprofile-generate/-use flags to this.
+#   TRAIN_FLAGS       OPTIONAL flags for pgo-train.sh (e.g. "--minimal" on Windows)
+#
+# Example (local, host target):
+#   TARGET=$(rustc -vV | sed -n 's/host: //p') \
+#   QSV_FEATURES=apply,luau,fetch,self_update,geocode,polars,to,lens,prompt,magika,color \
+#   ./scripts/build-pgo.sh
+
+set -euo pipefail
+
+# locate repo root (this script lives in <root>/scripts/)
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+cd "$repo_root"
+
+# ---- configuration ----------------------------------------------------------
+: "${TARGET:?ERROR: TARGET (rust target triple) must be set}"
+BIN="${BIN:-qsv}"
+QSV_FEATURES="${QSV_FEATURES:-}"
+DEFAULT_FEATURES="${DEFAULT_FEATURES:-}"
+TRAIN_FLAGS="${TRAIN_FLAGS:-}"
+RUSTFLAGS="${RUSTFLAGS:-}"
+export RUSTFLAGS
+
+# derive the profile if not explicitly set
+if [[ -z "${PROFILE:-}" ]]; then
+  if [[ ",$QSV_FEATURES," == *",luau,"* ]]; then
+    PROFILE="release-luau"
+  else
+    PROFILE="release"
+  fi
+fi
+
+# the qsv binary always builds with feature_capable (mirrors publish.yml)
+features_arg=""
+if [[ -n "$QSV_FEATURES" ]]; then
+  if [[ "$BIN" == "qsv" ]]; then
+    features_arg="--features=${QSV_FEATURES},feature_capable"
+  else
+    features_arg="--features=${QSV_FEATURES}"
+  fi
+fi
+
+# cargo's per-profile env override key: profile name uppercased, '-' -> '_'
+profile_env_key="$(echo "$PROFILE" | tr '[:lower:]-' '[:upper:]_')"
+
+echo "================ qsv PGO build ================"
+echo "  target          : $TARGET"
+echo "  bin             : $BIN"
+echo "  profile         : $PROFILE"
+echo "  features        : ${features_arg:-(none)}"
+echo "  default-features: ${DEFAULT_FEATURES:-(default)}"
+echo "  RUSTFLAGS       : ${RUSTFLAGS:-(none)}"
+echo "  PGO_LTO override: ${PGO_LTO:-(none - keep Cargo.toml fat-LTO)}"
+echo "  train flags     : ${TRAIN_FLAGS:-(none)}"
+echo "==============================================="
+
+cargo_args=(--bin "$BIN" --target "$TARGET" --profile "$PROFILE" --locked)
+[[ -n "$features_arg" ]] && cargo_args+=("$features_arg")
+# DEFAULT_FEATURES is a single token (e.g. --no-default-features); intentional split
+# shellcheck disable=SC2206
+[[ -n "$DEFAULT_FEATURES" ]] && cargo_args+=($DEFAULT_FEATURES)
+
+# ---- toolchain gate ---------------------------------------------------------
+echo ""
+echo ">>> [0/3] toolchain check (llvm-tools-preview + cargo-pgo)"
+rustup component add llvm-tools-preview
+if ! cargo pgo info &>/dev/null; then
+  echo "cargo-pgo not found; installing..."
+  cargo install cargo-pgo
+fi
+cargo pgo info || true
+
+# ---- 1. instrument build (thin-LTO) ----------------------------------------
+echo ""
+echo ">>> [1/3] instrument build (thin-LTO)"
+# start from a clean profile set so stale profraw data does not leak in
+rm -rf target/pgo-profiles
+# override LTO to thin for the instrument build only (fat-LTO + instrumentation is
+# slow and historically fragile, rustc #115344). We set the env keys for both the
+# release and release-luau profiles so whichever PROFILE is active is covered.
+CARGO_PROFILE_RELEASE_LTO=thin \
+CARGO_PROFILE_RELEASE_LUAU_LTO=thin \
+  cargo pgo instrument build -- "${cargo_args[@]}"
+
+instrumented_bin="target/$TARGET/$PROFILE/$BIN"
+if [[ ! -x "$instrumented_bin" ]]; then
+  echo "ERROR: instrumented binary not found at $instrumented_bin" >&2
+  exit 1
+fi
+
+# ---- 2. train ---------------------------------------------------------------
+echo ""
+echo ">>> [2/3] train"
+# shellcheck disable=SC2086
+"$script_dir/pgo-train.sh" "$instrumented_bin" $TRAIN_FLAGS
+
+# ---- 3. optimize build ------------------------------------------------------
+echo ""
+echo ">>> [3/3] optimize build (keeps Cargo.toml fat-LTO unless PGO_LTO is set)"
+if [[ -n "${PGO_LTO:-}" ]]; then
+  echo "    (LTO override: ${profile_env_key} -> $PGO_LTO)"
+  env "CARGO_PROFILE_${profile_env_key}_LTO=$PGO_LTO" \
+    cargo pgo optimize build -- "${cargo_args[@]}"
+else
+  cargo pgo optimize build -- "${cargo_args[@]}"
+fi
+
+optimized_bin="target/$TARGET/$PROFILE/$BIN"
+echo ""
+echo "================ PGO build done ================"
+echo "  optimized binary: $repo_root/$optimized_bin"
+echo "================================================"
+
+# ---- future: LLVM BOLT (Post-Link Optimization) -----------------------------
+# BOLT is a later phase (Linux x86_64 first). cargo-pgo can drive it after the PGO
+# optimize build, e.g.:
+#   cargo pgo bolt build -- "${cargo_args[@]}"        # BOLT-instrument
+#   "$script_dir/pgo-train.sh" <bolt-instrumented> $TRAIN_FLAGS
+#   cargo pgo bolt optimize -- "${cargo_args[@]}"     # apply BOLT profile
+# Intentionally NOT enabled yet - see issue #1448.

--- a/scripts/build-pgo.sh
+++ b/scripts/build-pgo.sh
@@ -61,6 +61,14 @@ if [[ -z "${PROFILE:-}" ]]; then
   fi
 fi
 
+# Windows targets produce <bin>.exe; resolve the suffix so the path checks and the
+# training invocation find the actual executable (the Windows PGO jobs build qsv.exe)
+bin_ext=""
+case "$TARGET" in
+  *windows*) bin_ext=".exe" ;;
+esac
+bin_file="${BIN}${bin_ext}"
+
 # the qsv binary always builds with feature_capable (mirrors publish.yml)
 features_arg=""
 if [[ -n "$QSV_FEATURES" ]]; then
@@ -113,7 +121,7 @@ CARGO_PROFILE_RELEASE_LTO=thin \
 CARGO_PROFILE_RELEASE_LUAU_LTO=thin \
   cargo pgo instrument build -- "${cargo_args[@]}"
 
-instrumented_bin="target/$TARGET/$PROFILE/$BIN"
+instrumented_bin="target/$TARGET/$PROFILE/$bin_file"
 if [[ ! -x "$instrumented_bin" ]]; then
   echo "ERROR: instrumented binary not found at $instrumented_bin" >&2
   exit 1
@@ -136,7 +144,7 @@ else
   cargo pgo optimize build -- "${cargo_args[@]}"
 fi
 
-optimized_bin="target/$TARGET/$PROFILE/$BIN"
+optimized_bin="target/$TARGET/$PROFILE/$bin_file"
 echo ""
 echo "================ PGO build done ================"
 echo "  optimized binary: $repo_root/$optimized_bin"

--- a/scripts/pgo-train.sh
+++ b/scripts/pgo-train.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+#
+# pgo-train.sh - lean, single-pass PGO training harness for qsv.
+#
+# Usage: ./pgo-train.sh <path-to-instrumented-qsv> [--minimal]
+#
+#   <path-to-instrumented-qsv>  REQUIRED. The PGO-instrumented qsv binary built by
+#                               `cargo pgo instrument build` (see build-pgo.sh).
+#   --minimal                   Skip the large data download and the heavier feature
+#                               paths (polars/geocode/to). Use on Windows runners and
+#                               for reduced-feature binaries (qsvlite-style).
+#
+# Unlike benchmarks.sh, this is NOT a benchmark: it does not use hyperfine and runs
+# each command exactly ONCE. Its sole purpose is to exercise a representative spread
+# of qsv's hot and feature-gated code paths so the instrumented binary emits useful
+# PGO profile data (.profraw files). cargo-pgo bakes an absolute -Cprofile-generate
+# path into the instrumented binary, so the profraw files land in target/pgo-profiles/
+# regardless of this script's working directory.
+#
+# Commands that are not compiled into a given binary variant are tolerated and skipped
+# (see the `t` helper), so the same harness works against full and reduced builds.
+#
+# Data is mirrored from benchmarks.sh: the 520MB NYC 311 1M-row sample. Keep the
+# benchmark_data_url / filename variables below in sync with scripts/benchmarks.sh.
+
+set -uo pipefail
+
+# ---- args -------------------------------------------------------------------
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <path-to-instrumented-qsv> [--minimal]" >&2
+  exit 1
+fi
+
+# resolve the instrumented binary to an absolute path BEFORE we cd into the work dir
+qsv_bin="$1"
+shift
+if command -v realpath &>/dev/null; then
+  qsv_bin=$(realpath "$qsv_bin" 2>/dev/null || echo "$qsv_bin")
+fi
+if [[ ! -x "$qsv_bin" ]]; then
+  echo "ERROR: instrumented qsv binary not found or not executable: $qsv_bin" >&2
+  exit 1
+fi
+
+minimal=0
+for a in "$@"; do
+  case "$a" in
+    --minimal) minimal=1 ;;
+    *) echo "WARNING: ignoring unknown argument: $a" >&2 ;;
+  esac
+done
+
+# ---- data variables (keep in sync with benchmarks.sh) -----------------------
+benchmark_data_url=https://raw.githubusercontent.com/wiki/dathere/qsv/files/NYC_311_SR_2010-2020-sample-1M.7z
+communityboards_url=https://raw.githubusercontent.com/wiki/dathere/qsv/files/communityboards.csv
+datazip=NYC_311_SR_2010-2020-sample-1M.7z
+data=NYC_311_SR_2010-2020-sample-1M.csv
+
+# 7z is 7zz on macOS, 7z elsewhere (Linux/Cygwin/git-bash) - same as benchmarks.sh
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sevenz_bin=7zz
+else
+  sevenz_bin=7z
+fi
+
+# isolated working dir so we never pollute scripts/ or the repo root
+work_dir="${PGO_TRAIN_DIR:-target/pgo-train}"
+mkdir -p "$work_dir"
+cd "$work_dir" || { echo "ERROR: cannot cd into $work_dir" >&2; exit 1; }
+
+echo "> PGO training qsv: $qsv_bin"
+echo "  work dir: $(pwd)"
+echo "  minimal mode: $minimal"
+"$qsv_bin" --version || true
+echo ""
+
+# ---- training-command helper ------------------------------------------------
+# Runs a qsv invocation once, tolerating non-zero exits (a reduced binary may not
+# have the subcommand, or the command may need an optional feature). The whole point
+# is to drive instrumented code, not to assert success - so failures are logged and
+# training continues.
+t() {
+  echo "  train: qsv $*"
+  "$qsv_bin" "$@" >/dev/null 2>&1 || echo "    (skipped/failed: qsv $1)"
+}
+
+# ---- data acquisition -------------------------------------------------------
+if [[ "$minimal" -eq 0 ]]; then
+  if ! command -v "$sevenz_bin" &>/dev/null; then
+    echo "WARNING: $sevenz_bin not found; falling back to --minimal training." >&2
+    minimal=1
+  fi
+fi
+
+if [[ "$minimal" -eq 0 && ! -r "$data" ]]; then
+  echo "> Downloading training data..."
+  if ! curl --fail -sS "$benchmark_data_url" -o "$datazip"; then
+    echo "WARNING: failed to download $benchmark_data_url; falling back to --minimal." >&2
+    rm -f "$datazip"
+    minimal=1
+  elif ! "$sevenz_bin" e -y "$datazip" >/dev/null; then
+    echo "WARNING: failed to extract $datazip; falling back to --minimal." >&2
+    rm -f "$datazip"
+    minimal=1
+  fi
+  rm -f "$datazip"
+fi
+
+# In minimal mode (or if the download failed), synthesize a small but non-trivial
+# CSV by dogfooding qsv itself, so we still train the core CSV engine on Windows or
+# when the network/7z is unavailable.
+if [[ "$minimal" -eq 1 || ! -r "$data" ]]; then
+  data=pgo_train_minimal.csv
+  if [[ ! -r "$data" ]]; then
+    echo "> Generating minimal training data ($data)..."
+    {
+      echo "id,name,category,amount,city,date"
+      for i in $(seq 1 20000); do
+        echo "$i,name_$((i % 997)),cat_$((i % 13)),$(( (i * 7) % 10000 )).$((i % 100)),city_$((i % 53)),2024-$(printf '%02d' $((i % 12 + 1)))-$(printf '%02d' $((i % 28 + 1)))"
+      done
+    } >"$data"
+  fi
+fi
+
+echo "> Training on: $data ($(wc -l <"$data" 2>/dev/null || echo '?') lines)"
+echo ""
+
+# ---- support data (best-effort; tolerated) ----------------------------------
+if [[ "$minimal" -eq 0 && ! -r communityboards.csv ]]; then
+  curl --fail -sS "$communityboards_url" -o communityboards.csv || rm -f communityboards.csv
+fi
+
+# index speeds up & exercises multithreaded code paths during training
+t index "$data"
+
+# ---- core CSV-engine training (all binary variants) -------------------------
+t count "$data"
+t count --no-polars "$data"
+t headers "$data"
+t select 1-5 "$data"
+t slice --start 0 --len 5000 "$data"
+t sample --seed 42 10000 "$data"
+t search -s 1 "[0-9]" "$data"
+t frequency "$data"
+t stats "$data"
+t stats --everything "$data"
+t dedup "$data"
+t sort "$data"
+t cat rows "$data" "$data"
+t behead "$data"
+
+# ---- feature-gated paths (skipped automatically on reduced binaries) --------
+t apply operations lower 2 "$data"
+t schema "$data" --stdout
+t tojsonl "$data"
+t snappy compress "$data" --output pgo_train.snappy
+t validate "$data"
+
+if [[ "$minimal" -eq 0 ]]; then
+  # heavier paths that need the real dataset and the full-feature build
+  t searchset <(printf "homeless\npark\nNoise\n") "$data"
+  t to xlsx pgo_train.xlsx "$data"
+  # polars-backed paths - the biggest PGO win
+  t sqlp "$data" "select * from _t_1 limit 1000"
+  t sqlp "$data" "select \"Borough\", count(*) from _t_1 group by \"Borough\""
+  if [[ -r communityboards.csv ]]; then
+    t joinp "Community Board" "$data" community_board communityboards.csv
+  fi
+  t luau map newcol "1 + 1" "$data"
+fi
+
+echo ""
+echo "> PGO training complete."
+profile_dir="../pgo-profiles"
+[[ -d "$profile_dir" ]] && echo "  profraw files: $(ls -1 "$profile_dir"/*.profraw 2>/dev/null | wc -l | tr -d ' ') in $(cd "$profile_dir" && pwd)"
+exit 0

--- a/scripts/pgo-train.sh
+++ b/scripts/pgo-train.sh
@@ -171,6 +171,10 @@ fi
 
 echo ""
 echo "> PGO training complete."
-profile_dir="../pgo-profiles"
-[[ -d "$profile_dir" ]] && echo "  profraw files: $(ls -1 "$profile_dir"/*.profraw 2>/dev/null | wc -l | tr -d ' ') in $(cd "$profile_dir" && pwd)"
+# cargo-pgo writes profiles to <project>/target/pgo-profiles. Derive that from the
+# instrumented binary path (target/<triple>/<profile>/qsv) - which we resolved to an
+# absolute path above - so the summary is correct even when PGO_TRAIN_DIR is elsewhere.
+target_dir="$(cd "$(dirname "$qsv_bin")/../.." 2>/dev/null && pwd)"
+profile_dir="$target_dir/pgo-profiles"
+[[ -d "$profile_dir" ]] && echo "  profraw files: $(ls -1 "$profile_dir"/*.profraw 2>/dev/null | wc -l | tr -d ' ') in $profile_dir"
 exit 0


### PR DESCRIPTION
## What

Implements **Profile-Guided Optimization (PGO)** for the prebuilt `qsv` binary on native-runner targets, per issue #1448 (v4.0 milestone). PGO compiles an instrumented binary, runs a representative workload to record hot paths, then re-compiles using those profiles so the compiler can lay out and inline hot code optimally.

Scope (as agreed): **full CI rollout** of **PGO** now (BOLT/PLO designed for a later phase), keeping the existing **fat-LTO** on the optimize build.

## Changes

**New scripts**
- `scripts/pgo-train.sh` — lean single-pass training harness (no hyperfine). Reuses `benchmarks.sh`'s NYC-311 dataset; runs a representative spread of subcommands once; tolerates commands absent from reduced binaries; `--minimal` mode synthesizes a small CSV for Windows/offline.
- `scripts/build-pgo.sh` — parameterized `cargo-pgo` orchestrator: toolchain gate → **instrument build (thin-LTO)** → train → **optimize build (keeps fat-LTO)**. Auto-derives `release-luau` when `luau` is present; `PGO_LTO` escape hatch for memory-constrained runners; commented BOLT stub for the future phase.

**CI**
- `.github/workflows/publish.yml` — `pgo`/`pgo-train-flags`/`pgo-lto` matrix fields; PGO enabled on `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, and both Windows targets (Windows trains `--minimal`). Splits the qsv build into mutually-exclusive **PGO** and **normal** steps; sets `QSV_KIND=prebuilt-pgo`. `x86_64-unknown-linux-musl` and all cross/QEMU targets stay on the normal path (the instrumented binary can't be trained there).
- `.github/workflows/macOS-arm64-selfhosted-publish.yml` — PGO build for `aarch64-apple-darwin` (ideal target; full training).

**Docs**
- `docs/PERFORMANCE.md` — new "Profile-Guided Optimization (PGO)" section + future-BOLT note; `prebuilt-pgo` added to the `QSV_KIND` list.

No `Cargo.toml` change required.

## Verification

Ran `build-pgo.sh` end-to-end locally on **Rust 1.96 / Apple Silicon** with `luau` (the `release-luau` panic=unwind path) and **fat-LTO**:
- ✅ **Fat-LTO + PGO builds successfully** — the 2023 rustc [#115344](https://github.com/rust-lang/rust/issues/115344) LTO+PGO conflict is resolved on the current toolchain, so the contingency `release-pgo` thin-LTO profile is **not needed**.
- ✅ Binary functional; `luau map` works (PGO + unwind sound); profile data (`.profraw`) collected.

`QSV_KIND=prebuilt-pgo` is applied via the same step-env mechanism that already ships `prebuilt`; `util.rs` `starts_with("prebuilt")` keeps self-update working.

## Notes / follow-ups
- CI cost: PGO ~triples the `qsv` build time on PGO targets; it's gated to the tag-triggered publish workflows only (never PR/CI test runs).
- `aarch64-unknown-linux-gnu` has a `pgo-lto: thin` escape hatch ready in case the fat-LTO optimize link OOMs on the hosted ARM runner.
- Deferred: LLVM BOLT (PLO, Linux x86_64), and PGO for the other binaries (qsvlite/qsvdp/qsvmcp) and musl.
- `build.rs` doesn't emit `rerun-if-env-changed=QSV_KIND`, so the marker relies on CI's fresh builds (same as today's `prebuilt`).

Closes #1448

🤖 Generated with [Claude Code](https://claude.com/claude-code)