### PR TITLE
perf: `py` review-driven cleanup post pyo3 0.29 bump

### DIFF
--- a/docs/help/TableOfContents.md
+++ b/docs/help/TableOfContents.md
@@ -90,7 +90,7 @@
 🧠: expensive operations are memoized with available inter-session Redis/Disk caching for fetch commands.  
 🗄️: [Extended input support](../../README.md#extended-input-support).  
 🗃️: [Limited Extended input support](../../README.md#limited-extended-input-support).  
-🐻‍❄️: command powered/accelerated by [![polars 0.54.4:f8b8fa4](https://img.shields.io/badge/polars-0.54.4:f8b8fa4-blue?logo=polars)](https://github.com/pola-rs/polars/releases/tag/rs-0.54.4) vectorized query engine.  
+🐻‍❄️: command powered/accelerated by [![polars 0.54.4:e1d24de](https://img.shields.io/badge/polars-0.54.4:e1d24de-blue?logo=polars)](https://github.com/pola-rs/polars/releases/tag/rs-0.54.4) vectorized query engine.  
 🤖: command uses Natural Language Processing or Generative AI.  
 🏎️: multithreaded and/or faster when an index (📇) is available.  
 🚀: multithreaded even without an index.  

--- a/docs/help/py.md
+++ b/docs/help/py.md
@@ -152,7 +152,7 @@ qsv py --help
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Option&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Type | Description | Default |
 |--------|------|-------------|--------|
 | &nbsp;`‑f,`<br>`‑‑helper`&nbsp; | string | File containing Python code that's loaded into the qsv_uh Python module. Functions with a return statement in the file can be called with the prefix "qsv_uh". The returned value is used in the map or filter operation. |  |
-| &nbsp;`‑b,`<br>`‑‑batch`&nbsp; | integer | The number of rows per batch to process before releasing memory and acquiring a new GILpool. Set to 0 to process the entire file in one batch. | `50000` |
+| &nbsp;`‑b,`<br>`‑‑batch`&nbsp; | integer | The number of rows per batch to process before releasing memory and reattaching to the Python interpreter. Set to 0 to process the entire file in one batch. | `50000` |
 
 <a name="common-options"></a>
 

--- a/src/cmd/python.rs
+++ b/src/cmd/python.rs
@@ -292,9 +292,14 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         args.flag_batch
     };
 
-    // reuse batch buffers; cap the initial allocation as batch_size is
-    // usize::MAX for "--batch 0" stdin input
-    let mut batch = Vec::with_capacity(batch_size.min(50_000));
+    // reuse batch buffers; batch_size is usize::MAX for "--batch 0" stdin
+    // input, so cap that initial allocation while keeping the exact
+    // pre-allocation when the row count is known
+    let mut batch = Vec::with_capacity(if batch_size == usize::MAX {
+        50_000
+    } else {
+        batch_size
+    });
 
     // safety: safe to unwrap as these are statically defined
     let helpers_code = CString::new(HELPERS).unwrap();

--- a/src/cmd/python.rs
+++ b/src/cmd/python.rs
@@ -282,9 +282,9 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
     let batch_size = if args.flag_batch == 0 {
         if rconfig.is_stdin() {
-            // counting rows would consume stdin before the main read loop,
-            // so fall back to the default batch size
-            50_000
+            // we can't pre-count stdin rows without consuming the stream,
+            // so read until EOF to honor "0 = entire file in one batch"
+            usize::MAX
         } else {
             util::count_rows(&rconfig)? as usize
         }
@@ -292,8 +292,9 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         args.flag_batch
     };
 
-    // reuse batch buffers
-    let mut batch = Vec::with_capacity(batch_size);
+    // reuse batch buffers; cap the initial allocation as batch_size is
+    // usize::MAX for "--batch 0" stdin input
+    let mut batch = Vec::with_capacity(batch_size.min(50_000));
 
     // safety: safe to unwrap as these are statically defined
     let helpers_code = CString::new(HELPERS).unwrap();

--- a/src/cmd/python.rs
+++ b/src/cmd/python.rs
@@ -107,8 +107,9 @@ py options:
                            The returned value is used in the map or filter operation.
 
     -b, --batch <size>     The number of rows per batch to process before
-                           releasing memory and acquiring a new GILpool.
-                           Set to 0 to process the entire file in one batch.
+                           releasing memory and reattaching to the Python
+                           interpreter. Set to 0 to process the entire file
+                           in one batch.
                            [default: 50000]
 
 Common options:
@@ -129,7 +130,7 @@ use indicatif::{ProgressBar, ProgressDrawTarget};
 use pyo3::{
     PyErr, PyResult, Python, intern,
     prelude::*,
-    types::{PyDict, PyList, PyModule},
+    types::{PyDict, PyList, PyModule, PyString},
 };
 use serde::Deserialize;
 
@@ -140,14 +141,6 @@ use crate::{
 };
 
 const HELPERS: &str = r#"
-def cast_as_string(value):
-    if isinstance(value, str):
-        return value
-    return str(value)
-
-def cast_as_bool(value):
-    return bool(value)
-
 class QSVRow(object):
     def __init__(self, headers):
         self.__data = None
@@ -200,8 +193,8 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let debug_flag = log::log_enabled!(log::Level::Debug);
 
     if debug_flag {
-        Python::attach(|py| {
-            let msg = format!("Detected Python={}", py.version());
+        Python::attach(|_| {
+            let msg = format!("Detected Python={}", Python::version_str());
             winfo!("{msg}");
         });
     }
@@ -288,7 +281,13 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let mut error_count = 0_usize;
 
     let batch_size = if args.flag_batch == 0 {
-        util::count_rows(&rconfig)? as usize
+        if rconfig.is_stdin() {
+            // counting rows would consume stdin before the main read loop,
+            // so fall back to the default batch size
+            50_000
+        } else {
+            util::count_rows(&rconfig)? as usize
+        }
     } else {
         args.flag_batch
     };
@@ -311,17 +310,18 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
     let mut row_number = 0_u64;
 
-    // Build modules and the QSVRow instance ONCE up front. They don't change
-    // across batches, so re-creating them each batch was wasted work.
-    // We hold them as Py<...> across Python::attach calls and re-bind per batch.
+    // Build modules, interned column-name keys and the QSVRow instance ONCE up
+    // front. They don't change across batches, so re-creating them each batch
+    // was wasted work. We hold them as Py<...> across Python::attach calls and
+    // re-bind per batch.
     let (
-        helpers_pymod,
         user_helpers_pymod,
         builtins_pymod,
         math_pymod,
         random_pymod,
         datetime_pymod,
         py_row_obj,
+        local_keys,
     ) = Python::attach(|py| -> PyResult<_> {
         let helpers =
             PyModule::from_code(py, &helpers_code, &helpers_filename, &helpers_module_name)?;
@@ -343,20 +343,27 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             .getattr("QSVRow")?
             .call1((headers.iter().take(headers_len).collect::<Vec<&str>>(),))?;
 
+        // Intern the Python-safe column names once so the per-row loop doesn't
+        // re-create a Python string per column for the batch_locals keys.
+        let local_keys: Vec<Py<PyString>> = header_vec
+            .iter()
+            .map(|k| PyString::intern(py, k).unbind())
+            .collect();
+
         Ok((
-            helpers.unbind(),
             user_helpers.unbind(),
             builtins.unbind(),
             math_module.unbind(),
             random_module.unbind(),
             datetime_module.unbind(),
             py_row.unbind(),
+            local_keys,
         ))
     })?;
 
     // main loop to read CSV and construct batches.
-    // we batch Python operations so that the GILPool does not get very large
-    // as we release the pool after each batch
+    // we batch Python operations to bound memory use - the per-batch Python
+    // objects are dropped when each Python::attach scope ends.
     // loop exits when batch is empty.
     'batch_loop: loop {
         for _ in 0..batch_size {
@@ -381,7 +388,6 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         }
 
         Python::attach(|py| -> PyResult<()> {
-            let helpers = helpers_pymod.bind(py);
             let user_helpers = user_helpers_pymod.bind(py);
             let builtins = builtins_pymod.bind(py);
             let math_module = math_pymod.bind(py);
@@ -406,14 +412,14 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                 row_number += 1;
 
                 // Tolerate jagged rows: short records yield "" via unwrap_or_default,
-                // long records are ignored beyond header_vec.len() (== headers_len).
+                // long records are ignored beyond local_keys.len() (== headers_len).
                 // The PyList is built in the same pass that sets the per-column
                 // locals, and storing the row data directly in a Python object
                 // releases the &str borrows on `record` before push_field below.
                 let row_data = PyList::empty(py);
-                for (i, key) in header_vec.iter().enumerate() {
+                for (i, key) in local_keys.iter().enumerate() {
                     let cell_value = record.get(i).unwrap_or_default();
-                    batch_locals.set_item(key, cell_value)?;
+                    batch_locals.set_item(key.bind(py), cell_value)?;
                     row_data.append(cell_value)?;
                 }
                 py_row.call_method1(intern!(py, "_update_underlying_data"), (row_data,))?;
@@ -432,10 +438,8 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                     };
 
                 if args.cmd_map {
-                    let result = helpers
-                        .getattr(intern!(py, "cast_as_string"))?
-                        .call1((result,))?;
-                    let value: String = result.extract()?;
+                    // equivalent to Python str(result)
+                    let value: String = result.str()?.extract()?;
 
                     record.push_field(&value);
                     if let Err(e) = wtr.write_record(&*record) {
@@ -447,10 +451,8 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                         )));
                     }
                 } else if args.cmd_filter {
-                    let result = helpers
-                        .getattr(intern!(py, "cast_as_bool"))?
-                        .call1((result,))?;
-                    let include_record: bool = result.extract()?;
+                    // equivalent to Python bool(result)
+                    let include_record = result.is_truthy()?;
 
                     if include_record && let Err(e) = wtr.write_record(&*record) {
                         return Err(pyo3::PyErr::new::<pyo3::exceptions::PyIOError, _>(format!(

--- a/src/util.rs
+++ b/src/util.rs
@@ -688,8 +688,8 @@ pub fn version() -> String {
     #[cfg(all(feature = "python", not(feature = "lite")))]
     {
         enabled_features.push_str("python-");
-        pyo3::Python::attach(|py| {
-            enabled_features.push_str(py.version());
+        pyo3::Python::attach(|_| {
+            enabled_features.push_str(pyo3::Python::version_str());
             enabled_features.push(';');
         });
     }

--- a/tests/test_py.rs
+++ b/tests/test_py.rs
@@ -663,3 +663,32 @@ fn py_map_jagged_rows_error() {
         "expected csv reader error about field count, got: {stderr}"
     );
 }
+
+// Locks in that `--batch 0` ("entire file in one batch") works with stdin
+// input, where the row count can't be pre-computed without consuming the
+// stream.
+#[test]
+fn py_map_batch_zero_stdin() {
+    use std::io::Write;
+
+    let wrk = Workdir::new("py");
+    let mut cmd = wrk.command("py");
+    cmd.arg("map")
+        .arg("c")
+        .arg("int(a) + int(b)")
+        .args(["--batch", "0"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped());
+
+    let mut child = cmd.spawn().unwrap();
+    let mut stdin = child.stdin.take().unwrap();
+    std::thread::spawn(move || {
+        stdin.write_all(b"a,b\n1,2\n3,4\n").unwrap();
+    });
+
+    let output = child.wait_with_output().unwrap();
+    assert!(output.status.success());
+
+    let got = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    assert_eq!(got.replace("\r\n", "\n"), "a,b,c\n1,2,3\n3,4,7");
+}


### PR DESCRIPTION
## Summary

Code review of `src/cmd/python.rs` following the pyo3 0.28.3 → 0.29.0 bump (#3981). The command was already fully 0.29-compatible (modern `Python::attach`, `&CStr` code/eval APIs, `Py<T>` unbind/bind pattern) — this PR applies the quality fixes the review surfaced:

### Perf
- **Drop per-row Python cast helpers**: `helpers.getattr("cast_as_string"/"cast_as_bool")?.call1(...)` ran for *every* row. Replaced with pyo3-native `result.str()` / `result.is_truthy()` — exact `str(x)`/`bool(x)` equivalents — eliminating a getattr + Python function call per row. The now-unused helpers are removed from the embedded `HELPERS` source (only `QSVRow` remains).
- **Intern column-name keys once**: `batch_locals.set_item(key, …)` converted each header name from a Rust `String` to a fresh Python string on every row × column. Keys are now interned once up front as `Vec<Py<PyString>>` and re-bound per batch.

### Fixes
- **`--batch 0` + stdin**: `util::count_rows()` falls back to re-reading via the config reader, which consumes stdin before the main read loop. Since stdin rows can't be pre-counted without consuming the stream, `--batch 0` on stdin now reads until EOF (`usize::MAX` sentinel) so the documented "0 = entire file in one batch" contract holds for stdin too — the same whole-input memory profile `--batch 0` already has for file input. The initial batch `Vec` allocation is capped for the sentinel case, while file input keeps its exact `count_rows`-based pre-allocation. Regression test: `py_map_batch_zero_stdin`.
- **Deprecated `Python::version`** → `Python::version_str()` in `python.rs` and `util.rs` — the only actual 0.29 fallout, flagged by clippy.

### Docs
- Reworded stale "GILpool" references in the `--batch` help text and batch-loop comment (`GILPool` was removed from pyo3 with the Bound API migration; batching still bounds memory via per-`attach`-scope object lifetimes). Help md regenerated via `qsv --generate-help-md`.

## Test plan

- [x] `cargo t test_py:: -F all_features,python` — 19/19 pass (includes new `py_map_batch_zero_stdin` regression test)
- [x] `cargo clippy -F all_features,python` — clean (deprecation warning resolved)
- [x] stdin smoke test: `printf 'a,b\n1,2\n3,4\n' | qsv py map c "int(a)+int(b)" --batch 0` produces correct output
- [x] `qsv --generate-help-md` — only `py.md` wording changed (+ polars rev badge refresh in ToC from the recent lockfile update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)