### PR TITLE
docs: nested special formats in a .zip are unsupported by design (#3988)

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,8 @@ Finally, if its just a regular file, it will be treated as a regular input file.
 #### Limited Extended Input Support
 The `describegpt`, `lens`, `slice` & `tojsonl` commands have limited extended input support (🗃️). They are different in that they only process one file. If provided an `.infile-list` or a compressed `.sz` or `.zip` file, they will only process the first file.
 
+> **Note on `.zip` inputs.** qsv treats a `.zip` archive as a container of **delimited-text** files (CSV/TSV/TAB/SSV). The first such entry (in archive order) is used; commands with full Extended Input Support use _all_ of them. Directory and system entries (`__MACOSX`, `.DS_Store`, …) are skipped, and path-traversal ("zip-slip") entries are rejected. Nesting a **special binary format** (Parquet, Avro, or Arrow) inside a `.zip` is **not** a supported workflow — those formats are already compressed, so zipping them serves no purpose. Provide such files _directly_ instead (qsv reads `.parquet`/`.avro`/`.arrow` natively). See [#3988](https://github.com/dathere/qsv/issues/3988).
+
 ### Automatic Compression/Decompression
 
 qsv supports _automatic compression/decompression_ using the [Snappy frame format](https://github.com/google/snappy/blob/main/framing_format.txt). Snappy was chosen instead of more popular compression formats like gzip because it was designed for [high-performance streaming compression & decompression](https://github.com/google/snappy/tree/main/docs#readme) (up to 2.58 gb/sec compression, 0.89 gb/sec decompression).

--- a/src/util.rs
+++ b/src/util.rs
@@ -3610,6 +3610,12 @@ const ZIP_TABULAR_EXTS: [&str; 4] = ["csv", "tsv", "tab", "ssv"];
 /// 3. Error if no tabular entry exists — including the single-entry case. We do NOT silently treat
 ///    an arbitrary file as CSV, matching the documented "first CSV/TSV/TAB/SSV entry" behavior.
 ///
+/// By design, a `.zip` is treated as a container of delimited text. A **special
+/// binary format** (Parquet/Avro/Arrow) nested inside a `.zip` is intentionally
+/// NOT selectable here — those formats are already compressed, so zipping them is
+/// not an expected workflow; provide such files directly instead. (Issue #3988 —
+/// "nested special formats": won't-support, documented in README.)
+///
 /// Generic over `Read + Seek` so it serves both file-backed archives
 /// (`extract_zip_to_temp`) and in-memory `Cursor`-backed ones (`diskcache`).
 pub fn select_zip_entry<R: Read + std::io::Seek>(


### PR DESCRIPTION
## Summary

Documents the decision on the remaining **#3988 "nested special formats"** item — **won't support**, by design.

A special binary format (Parquet/Avro/Arrow) nested inside a `.zip` is not a real-world workflow: those formats are already compressed, so wrapping them in a `.zip` serves no purpose. qsv reads `.parquet`/`.avro`/`.arrow` natively, so users should provide such files directly.

## Changes (docs only, no behavior change)
- **README** "Extended Input Support" — adds a note that a `.zip` is treated as a container of delimited text (CSV/TSV/TAB/SSV), how entries are selected (first tabular / all for full-support commands), the system-file + zip-slip handling, and that nested special binary formats are unsupported.
- **`src/util.rs`** — extends `select_zip_entry`'s doc comment with the same rationale (it's the reader-level selector that only accepts CSV/TSV/TAB/SSV entries).

Closes the last "decide" item under #3988's "Decompression semantics" group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)