### PR TITLE
diff: add `--drop-equal-columns` flag (#2000)

### DIFF
--- a/docs/help/diff.md
+++ b/docs/help/diff.md
@@ -86,6 +86,18 @@ qsv diff -k 0,1 --sort-columns 0,1 left.csv right.csv
 qsv diff --drop-equal-fields left.csv right.csv
 ```
 
+> Find the difference but drop entire columns that have no differences anywhere (key columns still appear)
+
+```console
+qsv diff --drop-equal-columns left.csv right.csv
+```
+
+> Combine both: keep only differing columns, and within them, blank out equal field values
+
+```console
+qsv diff --drop-equal-columns --drop-equal-fields left.csv right.csv
+```
+
 > Find the difference but do not output headers in the result
 
 ```console
@@ -115,7 +127,7 @@ qsv diff --help
 
 ## Diff Options [↩](#nav)
 
-| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Option&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Type | Description | Default |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Option&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Type | Description | Default |
 |--------|------|-------------|--------|
 | &nbsp;`‑‑no‑headers‑left`&nbsp; | flag | When set, the first row will be considered as part of the left CSV to diff. (When not set, the first row is the header row and will be skipped during the diff. It will always appear in the output.) |  |
 | &nbsp;`‑‑no‑headers‑right`&nbsp; | flag | When set, the first row will be considered as part of the right CSV to diff. (When not set, the first row is the header row and will be skipped during the diff. It will always appear in the output.) |  |
@@ -126,6 +138,7 @@ qsv diff --help
 | &nbsp;`‑k,`<br>`‑‑key`&nbsp; | string | The column indices that uniquely identify a record as a comma separated list of 0-based indices, e.g. 0,1,2 or column names, e.g. name,age. Note that when selecting columns by name, only the left CSV's headers are used to match the column names and it is assumed that the right CSV has the same selected column names in the same order as the left CSV. (default: 0) |  |
 | &nbsp;`‑‑sort‑columns`&nbsp; | string | The column indices by which the diff result should be sorted as a comma separated list of indices, e.g. 0,1,2 or column names, e.g. name,age. Records in the diff result that are marked as "modified" ("delete" and "add" records that have the same key, but have different content) will always be kept together in the sorted diff result and so won't be sorted independently from each other. Note that when selecting columns by name, only the left CSV's headers are used to match the column names and it is assumed that the right CSV has the same selected column names in the same order as the left CSV. |  |
 | &nbsp;`‑‑drop‑equal‑fields`&nbsp; | flag | Drop values of equal fields in modified rows of the CSV diff result (and replace them with the empty string). Key field values will not be dropped. |  |
+| &nbsp;`‑‑drop‑equal‑columns`&nbsp; | flag | Drop entire columns from the diff result that have no differences anywhere. A column is kept if it is a key column, if it differs in any modified row, or if it has a non-empty value in any added or deleted row. Otherwise it is dropped. Can be combined with --drop-equal-fields. |  |
 | &nbsp;`‑j,`<br>`‑‑jobs`&nbsp; | integer | The number of jobs to run in parallel. When not set, the number of jobs is set to the number of CPUs detected. |  |
 
 <a name="common-options"></a>

--- a/src/cmd/diff.rs
+++ b/src/cmd/diff.rs
@@ -40,6 +40,12 @@ qsv diff -k 0,1 --sort-columns 0,1 left.csv right.csv
 # Find the difference but replace equal field values with empty string (key fields still appear)
 qsv diff --drop-equal-fields left.csv right.csv
 
+# Find the difference but drop entire columns that have no differences anywhere (key columns still appear)
+qsv diff --drop-equal-columns left.csv right.csv
+
+# Combine both: keep only differing columns, and within them, blank out equal field values
+qsv diff --drop-equal-columns --drop-equal-fields left.csv right.csv
+
 # Find the difference but do not output headers in the result
 qsv diff --no-headers-output left.csv right.csv
 
@@ -94,6 +100,11 @@ diff options:
     --drop-equal-fields         Drop values of equal fields in modified rows of the CSV
                                 diff result (and replace them with the empty string).
                                 Key field values will not be dropped.
+    --drop-equal-columns        Drop entire columns from the diff result that have no
+                                differences anywhere. A column is kept if it is a key
+                                column, if it differs in any modified row, or if it has
+                                a non-empty value in any added or deleted row. Otherwise
+                                it is dropped. Can be combined with --drop-equal-fields.
     -j, --jobs <arg>            The number of jobs to run in parallel.
                                 When not set, the number of jobs is set to the number
                                 of CPUs detected.
@@ -125,20 +136,21 @@ use crate::{
 
 #[derive(Deserialize)]
 struct Args {
-    arg_input_left:         Option<String>,
-    arg_input_right:        Option<String>,
-    flag_output:            Option<String>,
-    flag_jobs:              Option<usize>,
-    flag_no_headers_left:   bool,
-    flag_no_headers_right:  bool,
-    flag_no_headers_output: bool,
-    flag_delimiter_left:    Option<Delimiter>,
-    flag_delimiter_right:   Option<Delimiter>,
-    flag_delimiter_output:  Option<Delimiter>,
-    flag_key:               Option<String>,
-    flag_sort_columns:      Option<String>,
-    flag_drop_equal_fields: bool,
-    flag_delimiter:         Option<Delimiter>,
+    arg_input_left:          Option<String>,
+    arg_input_right:         Option<String>,
+    flag_output:             Option<String>,
+    flag_jobs:               Option<usize>,
+    flag_no_headers_left:    bool,
+    flag_no_headers_right:   bool,
+    flag_no_headers_output:  bool,
+    flag_delimiter_left:     Option<Delimiter>,
+    flag_delimiter_right:    Option<Delimiter>,
+    flag_delimiter_output:   Option<Delimiter>,
+    flag_key:                Option<String>,
+    flag_sort_columns:       Option<String>,
+    flag_drop_equal_fields:  bool,
+    flag_drop_equal_columns: bool,
+    flag_delimiter:          Option<Delimiter>,
 }
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
@@ -211,11 +223,52 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         },
     }
 
+    // When --drop-equal-columns is set, compute which columns to keep with a single
+    // borrow-pass over the (already fully buffered) diff records. A column is kept if
+    // it is a key column, if it differs in any modified row, or if it has a non-empty
+    // value in any added or deleted row.
+    let keep_cols: Option<Vec<usize>> = if args.flag_drop_equal_columns {
+        let num_cols = diff_byte_records.num_columns().unwrap_or(0);
+        let mut keep = vec![false; num_cols];
+        for &k in &primary_key_cols {
+            if k < num_cols {
+                keep[k] = true;
+            }
+        }
+        for dbr in diff_byte_records.iter() {
+            match dbr {
+                DiffByteRecord::Modify { field_indices, .. } => {
+                    for &fi in field_indices {
+                        if fi < num_cols {
+                            keep[fi] = true;
+                        }
+                    }
+                },
+                DiffByteRecord::Add(rec) | DiffByteRecord::Delete(rec) => {
+                    for (i, field) in rec.byte_record().iter().enumerate() {
+                        if i < num_cols && !field.is_empty() {
+                            keep[i] = true;
+                        }
+                    }
+                },
+            }
+        }
+        Some(
+            keep.iter()
+                .enumerate()
+                .filter_map(|(i, &k)| k.then_some(i))
+                .collect(),
+        )
+    } else {
+        None
+    };
+
     let mut csv_diff_writer = CsvDiffWriter::new(
         wtr,
         args.flag_no_headers_output,
         args.flag_drop_equal_fields,
         primary_key_cols,
+        keep_cols,
     );
     Ok(csv_diff_writer.write_diff_byte_records(diff_byte_records)?)
 }
@@ -289,6 +342,9 @@ struct CsvDiffWriter<W: Write> {
     no_headers:        bool,
     drop_equal_fields: bool,
     key_fields:        Vec<usize>,
+    // When Some, only these (sorted) column indices are written to the output.
+    // None means all columns are written (the default).
+    keep_cols:         Option<Vec<usize>>,
 }
 
 impl<W: Write> CsvDiffWriter<W> {
@@ -297,12 +353,46 @@ impl<W: Write> CsvDiffWriter<W> {
         no_headers: bool,
         drop_equal_fields: bool,
         key_fields: impl IntoIterator<Item = usize>,
+        keep_cols: Option<Vec<usize>>,
     ) -> Self {
         Self {
             csv_writer,
             no_headers,
             drop_equal_fields,
             key_fields: key_fields.into_iter().collect(),
+            keep_cols,
+        }
+    }
+
+    /// Project a full-width header `ByteRecord` down to `keep_cols` (or clone it
+    /// unchanged when no columns are being dropped), then write it with the
+    /// `diffresult` prefix column.
+    fn write_projected_header(&mut self, header: &ByteRecord) -> csv::Result<()> {
+        match &self.keep_cols {
+            Some(keep) => {
+                let mut projected = ByteRecord::new();
+                for &c in keep {
+                    projected.push_field(&header[c]);
+                }
+                projected.write_diffresult_header(&mut self.csv_writer)
+            },
+            None => header.write_diffresult_header(&mut self.csv_writer),
+        }
+    }
+
+    /// Write a full-width row (prefix sign at index 0, then one entry per column),
+    /// projecting it down to `keep_cols` when columns are being dropped.
+    fn write_projected_record(&mut self, full_row: &[&[u8]]) -> csv::Result<()> {
+        match &self.keep_cols {
+            Some(keep) => {
+                let mut projected: Vec<&[u8]> = Vec::with_capacity(keep.len() + 1);
+                projected.push(full_row[0]);
+                for &c in keep {
+                    projected.push(full_row[c + 1]);
+                }
+                self.csv_writer.write_record(projected)
+            },
+            None => self.csv_writer.write_record(full_row),
         }
     }
 
@@ -317,12 +407,14 @@ impl<W: Write> CsvDiffWriter<W> {
                     "csv_diff invariant: left/right headers must match"
                 );
                 if !self.no_headers {
-                    lbh.write_diffresult_header(&mut self.csv_writer)?;
+                    let lbh = lbh.clone();
+                    self.write_projected_header(&lbh)?;
                 }
             },
             (Some(bh), None) | (None, Some(bh)) => {
                 if !self.no_headers {
-                    bh.write_diffresult_header(&mut self.csv_writer)?;
+                    let bh = bh.clone();
+                    self.write_projected_header(&bh)?;
                 }
             },
             (None, None) => {
@@ -330,8 +422,8 @@ impl<W: Write> CsvDiffWriter<W> {
                 {
                     let headers_generic = rename_headers_all_generic(num_cols);
                     let mut new_rdr = csv::Reader::from_reader(headers_generic.as_bytes());
-                    let new_headers = new_rdr.byte_headers()?;
-                    new_headers.write_diffresult_header(&mut self.csv_writer)?;
+                    let new_headers = new_rdr.byte_headers()?.clone();
+                    self.write_projected_header(&new_headers)?;
                 }
             },
         }
@@ -360,7 +452,7 @@ impl<W: Write> CsvDiffWriter<W> {
             DiffByteRecord::Add(add) => {
                 let mut vec = vec![add_sign];
                 vec.extend(add.byte_record());
-                self.csv_writer.write_record(vec)
+                self.write_projected_record(&vec)
             },
             DiffByteRecord::Modify {
                 delete,
@@ -379,7 +471,7 @@ impl<W: Write> CsvDiffWriter<W> {
                     tmp
                 };
 
-                self.csv_writer.write_record(vec_del)?;
+                self.write_projected_record(&vec_del)?;
 
                 let vec_add = if self.drop_equal_fields {
                     self.fill_modified_and_drop_equal_fields(
@@ -393,12 +485,12 @@ impl<W: Write> CsvDiffWriter<W> {
                     tmp
                 };
 
-                self.csv_writer.write_record(vec_add)
+                self.write_projected_record(&vec_add)
             },
             DiffByteRecord::Delete(del) => {
                 let mut vec = vec![remove_sign];
                 vec.extend(del.byte_record());
-                self.csv_writer.write_record(vec)
+                self.write_projected_record(&vec)
             },
         }
     }

--- a/tests/test_diff.rs
+++ b/tests/test_diff.rs
@@ -802,6 +802,143 @@ diffresult,h1,h2,h3,h4
     assert_eq!(got.as_str(), expected);
 }
 
+#[test]
+fn diff_drop_equal_columns_drops_unchanged_columns() {
+    let wrk = Workdir::new("diff_drop_equal_columns_drops_unchanged_columns");
+
+    let left = vec![
+        svec!["h1", "h2", "h3"],
+        svec!["1", "a", "x"],
+        svec!["2", "b", "y"],
+    ];
+    wrk.create("left.csv", left);
+
+    let right = vec![
+        svec!["h1", "h2", "h3"],
+        svec!["1", "a", "X"],
+        svec!["2", "b", "y"],
+    ];
+    wrk.create("right.csv", right);
+
+    let mut cmd = wrk.command("diff");
+    cmd.args(["left.csv", "right.csv", "--drop-equal-columns"]);
+
+    wrk.assert_success(&mut cmd);
+
+    let got: String = wrk.stdout(&mut cmd);
+    // h2 is unchanged everywhere, so it is dropped. h1 (key) and h3 (modified) remain.
+    let expected = "\
+diffresult,h1,h3
+-,1,x
++,1,X";
+    assert_eq!(got.as_str(), expected);
+}
+
+#[test]
+fn diff_drop_equal_columns_combined_with_drop_equal_fields() {
+    let wrk = Workdir::new("diff_drop_equal_columns_combined_with_drop_equal_fields");
+
+    let left = vec![
+        svec!["h1", "h2", "h3", "h4"],
+        svec!["1", "a", "x", "p"],
+        svec!["2", "b", "y", "q"],
+    ];
+    wrk.create("left.csv", left);
+
+    let right = vec![
+        svec!["h1", "h2", "h3", "h4"],
+        svec!["1", "a", "X", "p"],
+        svec!["2", "B", "y", "q"],
+    ];
+    wrk.create("right.csv", right);
+
+    let mut cmd = wrk.command("diff");
+    cmd.args([
+        "left.csv",
+        "right.csv",
+        "--drop-equal-columns",
+        "--drop-equal-fields",
+    ]);
+
+    wrk.assert_success(&mut cmd);
+
+    let got: String = wrk.stdout(&mut cmd);
+    // h4 is unchanged everywhere -> dropped. h2 differs in row 2, h3 differs in row 1,
+    // so both columns are kept; within them, equal fields are blanked per modified row.
+    let expected = "\
+diffresult,h1,h2,h3
+-,1,,x
++,1,,X
+-,2,b,
++,2,B,";
+    assert_eq!(got.as_str(), expected);
+}
+
+#[test]
+fn diff_drop_equal_columns_keeps_columns_with_added_or_deleted_data() {
+    let wrk = Workdir::new("diff_drop_equal_columns_keeps_columns_with_added_or_deleted_data");
+
+    let left = vec![
+        svec!["h1", "h2", "h3", "h4"],
+        svec!["1", "const", "x", ""],
+        svec!["5", "delconst", "dx", ""],
+    ];
+    wrk.create("left.csv", left);
+
+    let right = vec![
+        svec!["h1", "h2", "h3", "h4"],
+        svec!["1", "const", "X", ""],
+        svec!["2", "addconst", "z", ""],
+    ];
+    wrk.create("right.csv", right);
+
+    let mut cmd = wrk.command("diff");
+    cmd.args(["left.csv", "right.csv", "--drop-equal-columns"]);
+
+    wrk.assert_success(&mut cmd);
+
+    let got: String = wrk.stdout(&mut cmd);
+    // h2 is equal in the modified row but has data in the added/deleted rows, so it is
+    // kept. h4 is empty everywhere, so it is dropped.
+    let expected = "\
+diffresult,h1,h2,h3
+-,1,const,x
++,1,const,X
+-,5,delconst,dx
++,2,addconst,z";
+    assert_eq!(got.as_str(), expected);
+}
+
+#[test]
+fn diff_drop_equal_columns_with_no_headers_projects_generic_headers() {
+    let wrk = Workdir::new("diff_drop_equal_columns_with_no_headers_projects_generic_headers");
+
+    let left = vec![svec!["1", "a", "x"], svec!["2", "b", "y"]];
+    wrk.create("left.csv", left);
+
+    let right = vec![svec!["1", "a", "X"], svec!["2", "b", "y"]];
+    wrk.create("right.csv", right);
+
+    let mut cmd = wrk.command("diff");
+    cmd.args([
+        "--no-headers-left",
+        "--no-headers-right",
+        "left.csv",
+        "right.csv",
+        "--drop-equal-columns",
+    ]);
+
+    wrk.assert_success(&mut cmd);
+
+    let got: String = wrk.stdout(&mut cmd);
+    // generic headers are generated, then projected to the kept columns.
+    let expected = "\
+diffresult,_col_1,_col_3
+-,1,x
++,1,X";
+    assert_eq!(got.as_str(), expected);
+}
+
 fn create_file_with_delim(wrk: &Workdir, file_path_new: &str, file_path: &str, delimiter: u8) {
     let mut select_cmd = wrk.command("select");
     select_cmd.args(["1-", file_path]);


### PR DESCRIPTION
## Overview

Implements the remaining open checklist item in #2000: a `--drop-equal-columns` flag for `qsv diff` that drops entire columns from the diff result when they have no differences anywhere.

The `--drop-equal-fields` item from the same issue was already shipped in #2114; this PR completes the second item.

## Why this can be done without a `csv-diff` change

The issue notes this would require a change in [`csv-diff`](https://gitlab.com/janriemer/csv-diff) because it's costly to do while streaming. But `qsv diff` already **fully buffers** the diff (`try_to_diff_byte_records()` materializes everything, then sorts it in memory), so the set of columns to keep is computed with a single borrow-pass over the already-buffered records — no `csv-diff` change needed.

## Keep-column rule

A column is **kept** if ANY of:
1. it is a key column, OR
2. it differs in any modified row (`DiffByteRecord::Modify { field_indices }`), OR
3. it has a non-empty value in any added row, OR
4. it has a non-empty value in any deleted row.

Otherwise it is dropped. This is the most information-preserving interpretation — added/deleted data is never hidden. Composes with `--drop-equal-fields` (drop whole equal columns, then blank equal cells within the survivors).

## Example

```
# only key + actually-differing columns appear
qsv diff --drop-equal-columns left.csv right.csv

# combine: keep only differing columns, and within them blank equal cells
qsv diff --drop-equal-columns --drop-equal-fields left.csv right.csv
```

## Changes

- `src/cmd/diff.rs` — new flag + USAGE/examples; keep-set computation in `run()`; `keep_cols` on `CsvDiffWriter` with `write_projected_header`/`write_projected_record` helpers. Projection is a no-op when the flag is absent, so existing output is byte-for-byte unchanged.
- `tests/test_diff.rs` — 4 new tests: basic column drop, combination with `--drop-equal-fields`, add/delete rows keeping their data columns, and generic-header projection under `--no-headers`.
- `docs/help/diff.md` — regenerated via `qsv --generate-help-md`.

## Verification

- `cargo build -F all_features` ✓
- `cargo test diff -F all_features` → 44 passed (incl. 4 new) ✓
- `cargo clippy -F all_features` clean ✓
- `cargo +nightly fmt` applied ✓

Closes the second checklist item of #2000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)