### PR TITLE
get: CSV/TSV-aware features (sniff, sampling preview, glob) for #654

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6209,6 +6209,7 @@ dependencies = [
  "geosuggest-core",
  "geosuggest-utils",
  "geozero",
+ "glob",
  "governor",
  "grex",
  "gzp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,6 +198,7 @@ fake = { version = "5", features = [
 fast-float2 = "0.2"
 flate2 = { version = "1", optional = true }
 foldhash = "0.2"
+glob = { version = "0.3", optional = true }
 file-format = { version = "0.29", features = ["reader"] }
 filetime = "0.2"
 flexi_logger = { version = "0.31", features = [
@@ -570,7 +571,7 @@ foreach = []
 # Last-Modified conditional revalidation with streaming, ranged (parallel)
 # fetches for large objects. Backs the `dc:` input prefix usable by any qsv
 # command. See `qsv get --help`.
-get = ["zstd", "flate2"]
+get = ["zstd", "flate2", "glob"]
 # get_cloud: adds cloud object-storage sources (s3://, gs://, az://) to `get`,
 # via the object_store crate. Opt-in so a bare `-F get` build stays lean;
 # included in distrib_features/qsvmcp/datapusher_plus (where polars already

--- a/docs/help/get.md
+++ b/docs/help/get.md
@@ -41,6 +41,12 @@ Cloud credentials are read from the standard AWS_*/AZURE_*/GOOGLE_* environment
 variables (and IAM roles); use --cloud-opt for one-off overrides such as region
 or endpoint. (sftp:// is planned for a later release.)
 
+`--sample` PREVIEW vs the `sample` command: `get --sample N` is a cheap PEEK — it
+streams just the first N rows from the head (stopping early, so a huge remote file
+is barely touched) and caches nothing. It is NOT a statistical sample. For a random,
+representative subset use `qsv sample` instead (which downloads the whole remote
+file first, except for its streaming --bernoulli method).
+
 
 <a name="examples"></a>
 

--- a/docs/help/get.md
+++ b/docs/help/get.md
@@ -157,7 +157,7 @@ qsv get --help
 | &nbsp;`‑‑force`&nbsp; | flag | Re-fetch even if a fresh cached copy exists. |  |
 | &nbsp;`‑‑sample`&nbsp; | integer | PREVIEW: stream the first N data records of <source> to stdout (or the --output file) WITHOUT caching. No `dc:` entry is created. The sniffed header row is re-attached. Single <source> only. |  |
 | &nbsp;`‑‑offset`&nbsp; | integer | PREVIEW: skip ~<mb> megabytes (via an HTTP Range request) before sampling, realigning to the next record boundary. Implies --sample. Requires a Range-capable source. |  |
-| &nbsp;`‑‑random`&nbsp; | flag | PREVIEW: random sampling when the source supports Range requests; otherwise streams and reservoir-samples. Random sampling is approximate. |  |
+| &nbsp;`‑‑random`&nbsp; | flag | PREVIEW: random (reservoir) sampling. Streams the full source and parses it from the start, so quoted multi-line records stay intact. Slower than --sample (which only reads the head); use it when you need a uniform sample. |  |
 | &nbsp;`‑‑cloud‑opt`&nbsp; | string | Extra cloud object-store config as a `key=value` pair (repeatable), e.g. region=us-east-1 or skip_signature=true. Overrides the AWS_*/AZURE_*/GOOGLE_* environment. (get_cloud only) |  |
 | &nbsp;`‑‑ckan‑api`&nbsp; | string | CKAN Action API base URL. Overrides the QSV_CKAN_API env var. | `https://data.dathere.com/api/3/action` |
 | &nbsp;`‑‑ckan‑token`&nbsp; | string | CKAN API token. Overrides the QSV_CKAN_TOKEN env var. |  |

--- a/docs/help/get.md
+++ b/docs/help/get.md
@@ -24,8 +24,12 @@ the QSV_GET_PART_SIZE and QSV_GET_CONCURRENCY env vars).
 Once cached, a resource can be read by ANY qsv command using the `dc:` prefix,
 e.g. `qsv stats dc:data.csv`. Stale `dc:` entries are auto-refreshed.
 
+A glob (e.g. data/*.csv) or directory source fetches every matching tabular file
+(.csv/.tsv/.tab/.ssv) — supported for local paths and (with the get_cloud feature)
+cloud buckets/prefixes. --name is ignored when a source expands to multiple files.
+
 Supported sources:  
-local file path
+local file path, directory, or glob (e.g. /data/*.csv)
 http:// or https:// URL
 dathere://<path>          datHere qsv-lookup-tables repo
 ckan://<id>               a CKAN resource by id
@@ -51,9 +55,31 @@ qsv get https://example.com/data.csv --name data.csv
 qsv stats dc:data.csv
 ```
 
+Peek at a remote CSV WITHOUT caching it (preview mode, streams to stdout):  
+```console
+qsv get https://example.com/big.csv --sample 10
+```
+
+```console
+qsv get https://example.com/big.csv --offset 500 --sample 10
+```
+
+```console
+qsv get https://example.com/big.csv --sample 20 --random
+```
+
 Seed a CKAN reference table:  
 ```console
 qsv get "ckan://covid-vaccinations?" --name vax.csv
+```
+
+Fetch every matching file via a glob or directory (each is cached separately):  
+```console
+qsv get '/data/*.csv'
+```
+
+```console
+qsv get /data/
 ```
 
 Fetch from cloud object storage (requires the get_cloud feature):  
@@ -63,6 +89,10 @@ qsv get s3://my-bucket/data.csv --name data.csv
 
 ```console
 qsv get gs://my-bucket/data.csv --cloud-opt skip_signature=true
+```
+
+```console
+qsv get 's3://my-bucket/exports/*.csv'
 ```
 
 Show what's in the cache, then prune old entries:  
@@ -125,6 +155,9 @@ qsv get --help
 | &nbsp;`‑‑refresh`&nbsp; | string | Staleness policy for `dc:` use: on-stale, always or never. Also the value applied by cache-set-policy. | `on-stale` |
 | &nbsp;`‑‑compress`&nbsp; | string | Transparent blob compression: zstd or none. | `zstd` |
 | &nbsp;`‑‑force`&nbsp; | flag | Re-fetch even if a fresh cached copy exists. |  |
+| &nbsp;`‑‑sample`&nbsp; | integer | PREVIEW: stream the first N data records of <source> to stdout (or the --output file) WITHOUT caching. No `dc:` entry is created. The sniffed header row is re-attached. Single <source> only. |  |
+| &nbsp;`‑‑offset`&nbsp; | integer | PREVIEW: skip ~<mb> megabytes (via an HTTP Range request) before sampling, realigning to the next record boundary. Implies --sample. Requires a Range-capable source. |  |
+| &nbsp;`‑‑random`&nbsp; | flag | PREVIEW: random sampling when the source supports Range requests; otherwise streams and reservoir-samples. Random sampling is approximate. |  |
 | &nbsp;`‑‑cloud‑opt`&nbsp; | string | Extra cloud object-store config as a `key=value` pair (repeatable), e.g. region=us-east-1 or skip_signature=true. Overrides the AWS_*/AZURE_*/GOOGLE_* environment. (get_cloud only) |  |
 | &nbsp;`‑‑ckan‑api`&nbsp; | string | CKAN Action API base URL. Overrides the QSV_CKAN_API env var. | `https://data.dathere.com/api/3/action` |
 | &nbsp;`‑‑ckan‑token`&nbsp; | string | CKAN API token. Overrides the QSV_CKAN_TOKEN env var. |  |

--- a/src/cmd/get.rs
+++ b/src/cmd/get.rs
@@ -12,8 +12,12 @@ the QSV_GET_PART_SIZE and QSV_GET_CONCURRENCY env vars).
 Once cached, a resource can be read by ANY qsv command using the `dc:` prefix,
 e.g. `qsv stats dc:data.csv`. Stale `dc:` entries are auto-refreshed.
 
+A glob (e.g. data/*.csv) or directory source fetches every matching tabular file
+(.csv/.tsv/.tab/.ssv) — supported for local paths and (with the get_cloud feature)
+cloud buckets/prefixes. --name is ignored when a source expands to multiple files.
+
 Supported sources:
-    local file path
+    local file path, directory, or glob (e.g. /data/*.csv)
     http:// or https:// URL
     dathere://<path>          datHere qsv-lookup-tables repo
     ckan://<id>               a CKAN resource by id
@@ -30,12 +34,22 @@ Examples:
         $ qsv get https://example.com/data.csv --name data.csv
         $ qsv stats dc:data.csv
 
+    Peek at a remote CSV WITHOUT caching it (preview mode, streams to stdout):
+        $ qsv get https://example.com/big.csv --sample 10
+        $ qsv get https://example.com/big.csv --offset 500 --sample 10
+        $ qsv get https://example.com/big.csv --sample 20 --random
+
     Seed a CKAN reference table:
         $ qsv get "ckan://covid-vaccinations?" --name vax.csv
+
+    Fetch every matching file via a glob or directory (each is cached separately):
+        $ qsv get '/data/*.csv'
+        $ qsv get /data/
 
     Fetch from cloud object storage (requires the get_cloud feature):
         $ qsv get s3://my-bucket/data.csv --name data.csv
         $ qsv get gs://my-bucket/data.csv --cloud-opt skip_signature=true
+        $ qsv get 's3://my-bucket/exports/*.csv'
 
     Show what's in the cache, then prune old entries:
         $ qsv get cache-list
@@ -74,6 +88,16 @@ get options:
     --compress <algo>      Transparent blob compression: zstd or none.
                            [default: zstd]
     --force                Re-fetch even if a fresh cached copy exists.
+    --sample <n>           PREVIEW: stream the first N data records of <source> to
+                           stdout (or the --output file) WITHOUT caching. No `dc:`
+                           entry is created. The sniffed header row is re-attached.
+                           Single <source> only.
+    --offset <mb>          PREVIEW: skip ~<mb> megabytes (via an HTTP Range request)
+                           before sampling, realigning to the next record boundary.
+                           Implies --sample. Requires a Range-capable source.
+    --random               PREVIEW: random sampling when the source supports Range
+                           requests; otherwise streams and reservoir-samples. Random
+                           sampling is approximate.
     --cloud-opt <kv>       Extra cloud object-store config as a `key=value` pair
                            (repeatable), e.g. region=us-east-1 or
                            skip_signature=true. Overrides the
@@ -106,6 +130,9 @@ use crate::{
     util,
 };
 
+/// Records emitted by a `--offset`/`--random` preview when `--sample` is omitted.
+const DEFAULT_PREVIEW_SAMPLE: u64 = 10;
+
 #[derive(Deserialize)]
 struct Args {
     arg_source:           Vec<String>,
@@ -116,6 +143,9 @@ struct Args {
     flag_refresh:         String,
     flag_compress:        String,
     flag_force:           bool,
+    flag_sample:          Option<u64>,
+    flag_offset:          Option<u64>,
+    flag_random:          bool,
     flag_cloud_opt:       Vec<String>,
     flag_ckan_api:        Option<String>,
     flag_ckan_token:      Option<String>,
@@ -179,10 +209,6 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         return Ok(());
     }
 
-    // ---- main get form ----
-    let refresh_policy = diskcache::RefreshPolicy::parse(&args.flag_refresh)?;
-    let compression = diskcache::Compression::parse(&args.flag_compress)?;
-
     let ckan_api_url = args
         .flag_ckan_api
         .clone()
@@ -193,9 +219,44 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         .clone()
         .or_else(|| std::env::var("QSV_CKAN_TOKEN").ok());
 
-    let multiple = args.arg_source.len() > 1;
+    // ---- preview mode (--sample/--offset/--random): peek WITHOUT caching ----
+    if args.flag_sample.is_some() || args.flag_offset.is_some() || args.flag_random {
+        if args.arg_source.len() != 1 {
+            return Err(CliError::Other(
+                "get: preview mode (--sample/--offset/--random) requires exactly one <source>."
+                    .to_string(),
+            ));
+        }
+        let preview = diskcache::PreviewOptions {
+            source:       args.arg_source[0].clone(),
+            sample:       args.flag_sample.unwrap_or(DEFAULT_PREVIEW_SAMPLE),
+            offset_mb:    args.flag_offset,
+            random:       args.flag_random,
+            ckan_api_url: ckan_api_url.clone(),
+            ckan_token:   ckan_token.clone(),
+            timeout_secs: args.flag_timeout,
+            cloud_opts:   args.flag_cloud_opt.clone(),
+        };
+        return diskcache::preview_resource(&preview, args.flag_output.as_deref());
+    }
 
-    for source in &args.arg_source {
+    // ---- main get form ----
+    let refresh_policy = diskcache::RefreshPolicy::parse(&args.flag_refresh)?;
+    let compression = diskcache::Compression::parse(&args.flag_compress)?;
+
+    // Expand any glob/directory sources (local and, with get_cloud, cloud) into
+    // concrete sources; non-glob sources pass through unchanged.
+    let expand_ctx = diskcache::ExpandCtx {
+        cloud_opts: args.flag_cloud_opt.clone(),
+    };
+    let mut sources = Vec::with_capacity(args.arg_source.len());
+    for s in &args.arg_source {
+        sources.extend(diskcache::expand_source(s, &expand_ctx)?);
+    }
+
+    let multiple = sources.len() > 1;
+
+    for source in &sources {
         let opts = diskcache::GetOptions {
             source: source.clone(),
             name: if multiple {
@@ -295,8 +356,10 @@ fn run_cache_list(cache_dir: &str, json: bool, info: bool, verify: bool) -> CliR
                 records += e.record_count.unwrap_or(0);
             }
         }
+        let with_schema = entries.iter().filter(|e| e.sniffed.is_some()).count();
         println!("cache directory   : {cache_dir}/get");
         println!("names             : {names}");
+        println!("with schema       : {with_schema}");
         println!("unique blobs      : {blobs}");
         println!("total records     : {records}");
         println!("on disk (comp)    : {comp} bytes");
@@ -310,8 +373,8 @@ fn run_cache_list(cache_dir: &str, json: bool, info: bool, verify: bool) -> CliR
     }
 
     println!(
-        "{:<24} {:>10} {:>12} {:>12} {:>4} {:<16} SOURCE",
-        "NAME", "RECORDS", "COMP", "UNCOMP", "IDX", "BLAKE3"
+        "{:<24} {:>10} {:>12} {:>12} {:>4} {:<5} {:<16} SOURCE",
+        "NAME", "RECORDS", "COMP", "UNCOMP", "IDX", "DELIM", "BLAKE3"
     );
     for e in &entries {
         let records = e
@@ -319,12 +382,13 @@ fn run_cache_list(cache_dir: &str, json: bool, info: bool, verify: bool) -> CliR
             .map_or_else(|| "?".to_string(), |c| c.to_string());
         let b3 = &e.blake3[..e.blake3.len().min(16)];
         println!(
-            "{:<24} {:>10} {:>12} {:>12} {:>4} {:<16} {}",
+            "{:<24} {:>10} {:>12} {:>12} {:>4} {:<5} {:<16} {}",
             truncate(&e.logical_name, 24),
             records,
             e.size_compressed,
             e.size_uncompressed,
             if e.indexed { "yes" } else { "no" },
+            delim_label(e.sniffed.as_ref()),
             b3,
             e.source_uri,
         );
@@ -343,6 +407,18 @@ fn truncate(s: &str, max: usize) -> String {
 
 fn plural(n: usize) -> &'static str {
     if n == 1 { "y" } else { "ies" }
+}
+
+/// Short label for a sniffed delimiter, shown in the `cache-list` DELIM column.
+fn delim_label(sniffed: Option<&diskcache::SniffedDialect>) -> &'static str {
+    match sniffed.map(|s| s.delimiter) {
+        Some(',') => "csv",
+        Some('\t') => "tsv",
+        Some(';') => "ssv",
+        Some('|') => "psv",
+        Some(_) => "oth",
+        None => "?",
+    }
 }
 
 /// Parse a `--older-than` value into seconds. Accepts a bare integer (seconds)

--- a/src/cmd/get.rs
+++ b/src/cmd/get.rs
@@ -29,6 +29,12 @@ Cloud credentials are read from the standard AWS_*/AZURE_*/GOOGLE_* environment
 variables (and IAM roles); use --cloud-opt for one-off overrides such as region
 or endpoint. (sftp:// is planned for a later release.)
 
+`--sample` PREVIEW vs the `sample` command: `get --sample N` is a cheap PEEK — it
+streams just the first N rows from the head (stopping early, so a huge remote file
+is barely touched) and caches nothing. It is NOT a statistical sample. For a random,
+representative subset use `qsv sample` instead (which downloads the whole remote
+file first, except for its streaming --bernoulli method).
+
 Examples:
     Fetch a CSV into the cache and read it back with another command:
         $ qsv get https://example.com/data.csv --name data.csv

--- a/src/cmd/get.rs
+++ b/src/cmd/get.rs
@@ -95,9 +95,10 @@ get options:
     --offset <mb>          PREVIEW: skip ~<mb> megabytes (via an HTTP Range request)
                            before sampling, realigning to the next record boundary.
                            Implies --sample. Requires a Range-capable source.
-    --random               PREVIEW: random sampling when the source supports Range
-                           requests; otherwise streams and reservoir-samples. Random
-                           sampling is approximate.
+    --random               PREVIEW: random (reservoir) sampling. Streams the full
+                           source and parses it from the start, so quoted multi-line
+                           records stay intact. Slower than --sample (which only
+                           reads the head); use it when you need a uniform sample.
     --cloud-opt <kv>       Extra cloud object-store config as a `key=value` pair
                            (repeatable), e.g. region=us-east-1 or
                            skip_signature=true. Overrides the

--- a/src/diskcache.rs
+++ b/src/diskcache.rs
@@ -1290,7 +1290,8 @@ mod rich {
     /// Build (and cache) the qsv index for an entry's blob, recording the exact
     /// record count. No-op if already indexed.
     fn ensure_indexed(root: &Path, entry: &mut StoredEntry) -> CliResult<()> {
-        if entry.meta.indexed {
+        // Already fully processed (indexed AND schema sniffed) → nothing to do.
+        if entry.meta.indexed && entry.meta.sniffed.is_some() {
             return Ok(());
         }
         let body = read_blob(root, &entry.meta.blake3, entry.meta.compression)?;
@@ -1298,6 +1299,13 @@ mod rich {
         // Sniff the dialect/schema once from the head (best-effort).
         if entry.meta.sniffed.is_none() {
             entry.meta.sniffed = sniff_dialect(&body);
+        }
+
+        // Entry is already indexed but predates the `sniffed` field: persist the
+        // backfilled schema and return without rebuilding the index.
+        if entry.meta.indexed {
+            write_entry(root, entry)?;
+            return Ok(());
         }
 
         let tmp_dir = std::env::temp_dir().join("qsv-getidx");
@@ -2339,6 +2347,18 @@ mod rich {
         Ok(())
     }
 
+    /// The first newline-terminated record within a random byte window: skip the
+    /// (partial) first line, then return the next record's bytes ONLY if it is
+    /// bounded by a terminating newline inside the window. Returns None when the
+    /// window holds no complete record, so a row truncated by the window boundary
+    /// (`PREVIEW_RANDOM_WINDOW`) is never emitted.
+    fn first_complete_record(window: &[u8]) -> Option<&[u8]> {
+        let start = window.iter().position(|&b| b == b'\n')? + 1;
+        let rest = &window[start..];
+        let end = rest.iter().position(|&b| b == b'\n')?;
+        Some(&rest[..end])
+    }
+
     /// Dispatch a preview to the right backend (mirrors `get_resource`).
     pub fn preview_resource(opts: &PreviewOptions, output: Option<&str>) -> CliResult<()> {
         let resolved = resolve_uri_prefix(&opts.source, opts.ckan_api_url.as_deref());
@@ -2538,15 +2558,16 @@ mod rich {
             let resp = http_get(Some(format!("bytes={off}-{end}")))?;
             let mut win = Vec::new();
             resp.take(PREVIEW_RANDOM_WINDOW).read_to_end(&mut win)?;
-            // Realign past the first (partial) line, then take one whole record.
-            let Some(nl) = win.iter().position(|&b| b == b'\n') else {
+            // Emit only a record that is fully terminated inside the window, so a
+            // row straddling the window boundary is never written truncated.
+            let Some(record) = first_complete_record(&win) else {
                 continue;
             };
             let mut rdr = csv::ReaderBuilder::new()
                 .delimiter(delimiter)
                 .flexible(true)
                 .has_headers(false)
-                .from_reader(&win[nl + 1..]);
+                .from_reader(record);
             let mut rec = csv::ByteRecord::new();
             if rdr.read_byte_record(&mut rec)? && !rec.is_empty() {
                 wtr.write_byte_record(&rec)?;
@@ -2632,14 +2653,16 @@ mod rich {
                 let off = rng.random_range(0..span);
                 let end = (off + PREVIEW_RANDOM_WINDOW).min(total);
                 let win = fetch(off, end)?;
-                let Some(nl) = win.iter().position(|&b| b == b'\n') else {
+                // Emit only a record fully terminated inside the window, so a row
+                // straddling the window boundary is never written truncated.
+                let Some(record) = first_complete_record(&win) else {
                     continue;
                 };
                 let mut rdr = csv::ReaderBuilder::new()
                     .delimiter(delim)
                     .flexible(true)
                     .has_headers(false)
-                    .from_reader(&win[nl + 1..]);
+                    .from_reader(record);
                 let mut rec = csv::ByteRecord::new();
                 if rdr.read_byte_record(&mut rec)? && !rec.is_empty() {
                     wtr.write_byte_record(&rec)?;
@@ -2739,6 +2762,12 @@ mod rich {
             return Ok(vec![source.to_string()]);
         }
         let path = Path::new(source);
+        // A literal file that exists takes precedence over glob interpretation,
+        // so a real filename containing glob metacharacters (e.g. `data[2026].csv`,
+        // `a?b.csv`) is still fetched as a single file rather than globbed.
+        if path.is_file() {
+            return Ok(vec![source.to_string()]);
+        }
         if path.is_dir() {
             return expand_local_dir(path);
         }

--- a/src/diskcache.rs
+++ b/src/diskcache.rs
@@ -528,6 +528,36 @@ mod rich {
         /// extension (and thus delimiter). None for plain or unknown sources.
         #[serde(default)]
         pub inner_ext:          Option<String>,
+        /// Best-effort CSV dialect/schema sniffed from the cached blob during
+        /// indexing (delimiter, header, field names & types). None for
+        /// non-tabular blobs, when sniffing failed, or for entries cached before
+        /// this field existed (backfilled on next `ensure_indexed`).
+        #[serde(default)]
+        pub sniffed:            Option<SniffedDialect>,
+    }
+
+    /// CSV dialect + schema sniffed from a cached blob, surfaced by
+    /// `cache-list`/`cache-info`. Captured once during `ensure_indexed`.
+    #[derive(Serialize, Deserialize, Clone)]
+    pub struct SniffedDialect {
+        /// Field delimiter (`,` for CSV, `\t` for TSV, `;` for SSV, …).
+        pub delimiter:     char,
+        /// Whether the first row was detected as a header.
+        pub has_header:    bool,
+        /// Number of preamble rows before the tabular data begins.
+        pub preamble_rows: usize,
+        /// Quote character, if any was detected.
+        pub quote:         Option<char>,
+        /// Whether records have a varying number of fields.
+        pub flexible:      bool,
+        /// Whether the sampled content is valid UTF-8.
+        pub is_utf8:       bool,
+        /// Number of fields (columns) detected.
+        pub num_fields:    usize,
+        /// Detected header/field names.
+        pub fields:        Vec<String>,
+        /// Detected per-field types (as strings).
+        pub types:         Vec<String>,
     }
 
     /// The on-disk record: per-entry metadata. The data blob is content-addressed
@@ -1226,6 +1256,37 @@ mod rich {
         }
     }
 
+    /// Max bytes fed to the CSV sniffer. Sniffing the head is enough to detect
+    /// the dialect/schema; reading a whole multi-GB blob would be wasteful.
+    const SNIFF_SAMPLE_BYTES: usize = 1 << 20; // 1 MiB
+
+    /// Best-effort sniff of a CSV blob's dialect + schema from its head. Returns
+    /// None for non-tabular content or on any sniff error — never fails ingest.
+    fn sniff_dialect(body: &[u8]) -> Option<SniffedDialect> {
+        use csv_nose::{SampleSize, Sniffer, metadata::Quote};
+
+        let head = &body[..body.len().min(SNIFF_SAMPLE_BYTES)];
+        let metadata = Sniffer::new()
+            .sample_size(SampleSize::All)
+            .sniff_reader(std::io::Cursor::new(head))
+            .ok()?;
+        let fields: Vec<String> = metadata.fields.iter().map(ToString::to_string).collect();
+        Some(SniffedDialect {
+            delimiter: metadata.dialect.delimiter as char,
+            has_header: metadata.dialect.header.has_header_row,
+            preamble_rows: metadata.dialect.header.num_preamble_rows,
+            quote: match metadata.dialect.quote {
+                Quote::Some(chr) => Some(char::from(chr)),
+                Quote::None => None,
+            },
+            flexible: metadata.dialect.flexible,
+            is_utf8: metadata.dialect.is_utf8,
+            num_fields: fields.len(),
+            fields,
+            types: metadata.types.iter().map(ToString::to_string).collect(),
+        })
+    }
+
     /// Build (and cache) the qsv index for an entry's blob, recording the exact
     /// record count. No-op if already indexed.
     fn ensure_indexed(root: &Path, entry: &mut StoredEntry) -> CliResult<()> {
@@ -1233,6 +1294,11 @@ mod rich {
             return Ok(());
         }
         let body = read_blob(root, &entry.meta.blake3, entry.meta.compression)?;
+
+        // Sniff the dialect/schema once from the head (best-effort).
+        if entry.meta.sniffed.is_none() {
+            entry.meta.sniffed = sniff_dialect(&body);
+        }
 
         let tmp_dir = std::env::temp_dir().join("qsv-getidx");
         fs::create_dir_all(&tmp_dir)?;
@@ -1329,6 +1395,7 @@ mod rich {
             cloud_identity: Vec::new(),
             ckan_api_url: None,
             inner_ext,
+            sniffed: None,
         };
         let mut entry = StoredEntry { meta };
         write_entry(root, &entry)?;
@@ -1645,6 +1712,7 @@ mod rich {
                         cloud_identity: identity.clone(),
                         ckan_api_url: None,
                         inner_ext,
+                        sniffed: None,
                     },
                 };
                 write_entry(root, &entry)?;
@@ -2011,6 +2079,7 @@ mod rich {
                             None
                         },
                         inner_ext,
+                        sniffed: None,
                     },
                 };
                 write_entry(root, &entry)?;
@@ -2108,6 +2177,686 @@ mod rich {
             ckan_hash,
             resolved.is_ckan,
         )
+    }
+
+    // ---- cache-bypassing CSV preview (`--sample`/`--offset`/`--random`) ----
+
+    /// Bytes sniffed (and used to extract the header) from the start of a source.
+    const PREVIEW_HEAD_BYTES: u64 = 256 * 1024;
+    /// Per-probe window for `--random` ranged reads.
+    const PREVIEW_RANDOM_WINDOW: u64 = 128 * 1024;
+    /// Max `--random` probe attempts is `sample * this` (records may straddle
+    /// windows, so allow several tries per wanted record before giving up).
+    const PREVIEW_RANDOM_ATTEMPTS_MULT: u64 = 20;
+    /// Cap on bytes pulled while accumulating windows for a cloud `--offset`/
+    /// first-N preview, so a tiny `--sample` never drags the whole object.
+    #[cfg(feature = "get_cloud")]
+    const PREVIEW_MAX_FETCH: u64 = 256 * 1024 * 1024;
+
+    /// Options for a cache-bypassing CSV preview. Unlike `GetOptions`, this never
+    /// touches the cache: rows are streamed straight to `--output`/stdout.
+    pub struct PreviewOptions {
+        pub source:       String,
+        pub sample:       u64,
+        pub offset_mb:    Option<u64>,
+        pub random:       bool,
+        pub ckan_api_url: Option<String>,
+        pub ckan_token:   Option<String>,
+        pub timeout_secs: u16,
+        #[cfg_attr(not(feature = "get_cloud"), allow(dead_code))]
+        pub cloud_opts:   Vec<String>,
+    }
+
+    /// Total object size from a `Content-Range` value ("bytes START-END/TOTAL").
+    /// None when the total is unknown ("*").
+    fn parse_total_from_content_range(cr: &str) -> Option<u64> {
+        let rest = cr.trim().strip_prefix("bytes ")?.trim();
+        let (_, total) = rest.split_once('/')?;
+        let total = total.trim();
+        if total == "*" {
+            None
+        } else {
+            total.parse().ok()
+        }
+    }
+
+    /// Sniff the head buffer for its delimiter and extract the header record,
+    /// returning `(delimiter, header_record)`. Defaults to comma when sniffing
+    /// fails so a preview still emits something usable for an unrecognized source.
+    fn sniff_preview_head(head: &[u8]) -> (u8, Option<csv::ByteRecord>) {
+        // Use the sniffer only for the delimiter. Header detection on a small,
+        // all-string sample is unreliable (csv-nose often reports "no header"
+        // for text-only columns), so — matching qsv's default — a preview always
+        // treats the first row as the header and re-attaches it.
+        let delimiter = sniff_dialect(head).map_or(b',', |s| s.delimiter as u8);
+        let header = csv::ReaderBuilder::new()
+            .delimiter(delimiter)
+            .flexible(true)
+            .has_headers(true)
+            .from_reader(head)
+            .byte_headers()
+            .ok()
+            .cloned();
+        (delimiter, header)
+    }
+
+    /// Open the preview output sink: a file, or stdout for `-`/None.
+    fn preview_writer(output: Option<&str>) -> CliResult<Box<dyn Write>> {
+        let w: Box<dyn Write> = match output {
+            Some(p) if p != "-" => Box::new(BufWriter::new(fs::File::create(p)?)),
+            _ => Box::new(BufWriter::new(std::io::stdout())),
+        };
+        Ok(w)
+    }
+
+    /// Emit a header (explicit, or read from the stream) plus the first `take`
+    /// data records parsed from `data`.
+    fn emit_preview<R: Read>(
+        data: R,
+        delimiter: u8,
+        data_has_header: bool,
+        explicit_header: Option<&csv::ByteRecord>,
+        take: u64,
+        output: Option<&str>,
+    ) -> CliResult<u64> {
+        let mut rdr = csv::ReaderBuilder::new()
+            .delimiter(delimiter)
+            .flexible(true)
+            .has_headers(data_has_header)
+            .from_reader(data);
+        let mut wtr = csv::WriterBuilder::new()
+            .delimiter(delimiter)
+            .from_writer(preview_writer(output)?);
+        if let Some(h) = explicit_header {
+            wtr.write_byte_record(h)?;
+        } else if data_has_header {
+            let h = rdr.byte_headers()?.clone();
+            wtr.write_byte_record(&h)?;
+        }
+        let mut n = 0u64;
+        let mut rec = csv::ByteRecord::new();
+        while n < take && rdr.read_byte_record(&mut rec)? {
+            wtr.write_byte_record(&rec)?;
+            n += 1;
+        }
+        wtr.flush()?;
+        Ok(n)
+    }
+
+    /// Reservoir-sample (Algorithm R) `take` records from a single streaming pass.
+    /// Used for `--random` when the source does not support ranged reads.
+    fn emit_preview_reservoir<R: Read>(
+        data: R,
+        delimiter: u8,
+        data_has_header: bool,
+        take: u64,
+        output: Option<&str>,
+    ) -> CliResult<u64> {
+        use rand::RngExt;
+        let mut rdr = csv::ReaderBuilder::new()
+            .delimiter(delimiter)
+            .flexible(true)
+            .has_headers(data_has_header)
+            .from_reader(data);
+        let header = if data_has_header {
+            Some(rdr.byte_headers()?.clone())
+        } else {
+            None
+        };
+        let mut rng = rand::rng();
+        let mut reservoir: Vec<csv::ByteRecord> = Vec::new();
+        let mut seen = 0u64;
+        let mut rec = csv::ByteRecord::new();
+        while rdr.read_byte_record(&mut rec)? {
+            if (reservoir.len() as u64) < take {
+                reservoir.push(rec.clone());
+            } else if take > 0 {
+                let j = rng.random_range(0..=seen);
+                if j < take {
+                    reservoir[j as usize] = rec.clone();
+                }
+            }
+            seen += 1;
+        }
+        let mut wtr = csv::WriterBuilder::new()
+            .delimiter(delimiter)
+            .from_writer(preview_writer(output)?);
+        if let Some(h) = &header {
+            wtr.write_byte_record(h)?;
+        }
+        for r in &reservoir {
+            wtr.write_byte_record(r)?;
+        }
+        wtr.flush()?;
+        Ok(reservoir.len() as u64)
+    }
+
+    /// Skip the (likely partial) first line of a ranged read so parsing starts on
+    /// a clean record boundary.
+    fn skip_partial_line<R: std::io::BufRead>(r: &mut R) -> CliResult<()> {
+        let mut discard = Vec::new();
+        r.read_until(b'\n', &mut discard)?;
+        Ok(())
+    }
+
+    /// Dispatch a preview to the right backend (mirrors `get_resource`).
+    pub fn preview_resource(opts: &PreviewOptions, output: Option<&str>) -> CliResult<()> {
+        let resolved = resolve_uri_prefix(&opts.source, opts.ckan_api_url.as_deref());
+        let is_http = resolved.url.to_ascii_lowercase().starts_with("http");
+
+        if !is_http {
+            if is_cloud_scheme(&opts.source) {
+                #[cfg(feature = "get_cloud")]
+                {
+                    return preview_cloud(&opts.source, opts, output);
+                }
+                #[cfg(not(feature = "get_cloud"))]
+                {
+                    return Err(CliError::Other(format!(
+                        "get: cloud source '{}' requires cloud support. Rebuild qsv with \
+                         `--features get_cloud`.",
+                        opts.source
+                    )));
+                }
+            }
+            let local_path = Path::new(&opts.source);
+            if local_path.exists() {
+                return preview_local(local_path, opts, output);
+            }
+            return Err(CliError::Other(format!(
+                "get: unsupported source '{}' for preview. Supported: local file, http(s)://, \
+                 dathere://, ckan://, and (with get_cloud) s3://, gs://, az://.",
+                opts.source
+            )));
+        }
+
+        let client = util::create_reqwest_blocking_client(
+            None,
+            opts.timeout_secs,
+            Some(resolved.url.clone()),
+        )?;
+        let (final_url, auth) = if resolved.is_ckan {
+            let ckan = resolve_ckan_resource(
+                &client,
+                &resolved.url,
+                resolved.ckan_resource_search,
+                opts.ckan_api_url.as_deref(),
+                opts.ckan_token.as_deref(),
+            )
+            .map_err(|e| CliError::Other(format!("get: CKAN resolution failed: {e}")))?;
+            let auth = if ckan.send_auth {
+                opts.ckan_token.clone()
+            } else {
+                None
+            };
+            (ckan.data_url, auth)
+        } else {
+            (resolved.url.clone(), None)
+        };
+        preview_http(&client, &final_url, auth.as_deref(), opts, output)
+    }
+
+    fn preview_local(path: &Path, opts: &PreviewOptions, output: Option<&str>) -> CliResult<()> {
+        use std::io::{Read, Seek, SeekFrom};
+
+        let mut head = Vec::new();
+        fs::File::open(path)?
+            .take(PREVIEW_HEAD_BYTES)
+            .read_to_end(&mut head)?;
+        let (delim, header) = sniff_preview_head(&head);
+
+        if opts.random {
+            let f = std::io::BufReader::new(fs::File::open(path)?);
+            emit_preview_reservoir(f, delim, true, opts.sample, output)?;
+            return Ok(());
+        }
+        if let Some(mb) = opts.offset_mb {
+            let mut f = fs::File::open(path)?;
+            f.seek(SeekFrom::Start(mb.saturating_mul(1 << 20)))?;
+            let mut br = std::io::BufReader::new(f);
+            skip_partial_line(&mut br)?;
+            emit_preview(br, delim, false, header.as_ref(), opts.sample, output)?;
+            return Ok(());
+        }
+        let f = std::io::BufReader::new(fs::File::open(path)?);
+        emit_preview(f, delim, true, None, opts.sample, output)?;
+        Ok(())
+    }
+
+    fn preview_http(
+        client: &reqwest::blocking::Client,
+        url: &str,
+        auth: Option<&str>,
+        opts: &PreviewOptions,
+        output: Option<&str>,
+    ) -> CliResult<()> {
+        use reqwest::header::{AUTHORIZATION, CONTENT_RANGE, RANGE};
+
+        let http_get = |range: Option<String>| -> CliResult<reqwest::blocking::Response> {
+            let mut req = client.get(url);
+            if let Some(r) = range {
+                req = req.header(RANGE, r);
+            }
+            if let Some(t) = auth {
+                req = req.header(AUTHORIZATION, t);
+            }
+            Ok(req.send()?.error_for_status()?)
+        };
+
+        // Head probe: doubles as the dialect sniff and the range-support detector.
+        let probe = http_get(Some(format!("bytes=0-{}", PREVIEW_HEAD_BYTES - 1)))?;
+        let supports_range = probe.status() == reqwest::StatusCode::PARTIAL_CONTENT;
+        let total = probe
+            .headers()
+            .get(CONTENT_RANGE)
+            .and_then(|v| v.to_str().ok())
+            .and_then(parse_total_from_content_range);
+        let mut head = Vec::new();
+        probe.take(PREVIEW_HEAD_BYTES).read_to_end(&mut head)?;
+        let (delim, header) = sniff_preview_head(&head);
+
+        if opts.random {
+            if supports_range && let Some(total) = total {
+                return preview_http_random(
+                    &http_get,
+                    delim,
+                    header.as_ref(),
+                    opts.sample,
+                    total,
+                    output,
+                );
+            }
+            let resp = http_get(None)?;
+            emit_preview_reservoir(
+                std::io::BufReader::new(resp),
+                delim,
+                true,
+                opts.sample,
+                output,
+            )?;
+            return Ok(());
+        }
+
+        if let Some(mb) = opts.offset_mb {
+            if !supports_range {
+                return Err(CliError::Other(
+                    "get: source does not support HTTP Range requests; --offset is unavailable. \
+                     Use --sample without --offset."
+                        .to_string(),
+                ));
+            }
+            let off = mb.saturating_mul(1 << 20);
+            let resp = http_get(Some(format!("bytes={off}-")))?;
+            let mut br = std::io::BufReader::new(resp);
+            skip_partial_line(&mut br)?;
+            emit_preview(br, delim, false, header.as_ref(), opts.sample, output)?;
+            return Ok(());
+        }
+
+        let resp = http_get(None)?;
+        emit_preview(
+            std::io::BufReader::new(resp),
+            delim,
+            true,
+            None,
+            opts.sample,
+            output,
+        )?;
+        Ok(())
+    }
+
+    /// Approximate uniform-random sampling over a range-capable HTTP source: read
+    /// a small window at random offsets, realign to a record boundary, and take
+    /// the first whole record from each, until `take` records are collected.
+    fn preview_http_random(
+        http_get: &dyn Fn(Option<String>) -> CliResult<reqwest::blocking::Response>,
+        delimiter: u8,
+        header: Option<&csv::ByteRecord>,
+        take: u64,
+        total: u64,
+        output: Option<&str>,
+    ) -> CliResult<()> {
+        use rand::RngExt;
+
+        let mut rng = rand::rng();
+        let mut wtr = csv::WriterBuilder::new()
+            .delimiter(delimiter)
+            .from_writer(preview_writer(output)?);
+        if let Some(h) = header {
+            wtr.write_byte_record(h)?;
+        }
+        let mut got = 0u64;
+        let mut attempts = 0u64;
+        let max_attempts = take
+            .saturating_mul(PREVIEW_RANDOM_ATTEMPTS_MULT)
+            .max(take + 8);
+        while got < take && attempts < max_attempts {
+            attempts += 1;
+            let span = total.saturating_sub(1).max(1);
+            let off = rng.random_range(0..span);
+            let end = (off + PREVIEW_RANDOM_WINDOW).min(total).saturating_sub(1);
+            let resp = http_get(Some(format!("bytes={off}-{end}")))?;
+            let mut win = Vec::new();
+            resp.take(PREVIEW_RANDOM_WINDOW).read_to_end(&mut win)?;
+            // Realign past the first (partial) line, then take one whole record.
+            let Some(nl) = win.iter().position(|&b| b == b'\n') else {
+                continue;
+            };
+            let mut rdr = csv::ReaderBuilder::new()
+                .delimiter(delimiter)
+                .flexible(true)
+                .has_headers(false)
+                .from_reader(&win[nl + 1..]);
+            let mut rec = csv::ByteRecord::new();
+            if rdr.read_byte_record(&mut rec)? && !rec.is_empty() {
+                wtr.write_byte_record(&rec)?;
+                got += 1;
+            }
+        }
+        wtr.flush()?;
+        Ok(())
+    }
+
+    #[cfg(feature = "get_cloud")]
+    fn preview_cloud(source: &str, opts: &PreviewOptions, output: Option<&str>) -> CliResult<()> {
+        use object_store::{GetOptions as OsGetOptions, GetRange, ObjectStore, parse_url_opts};
+        use rand::RngExt;
+        use url::Url;
+
+        let url = Url::parse(source)
+            .map_err(|e| CliError::Other(format!("get: invalid cloud URL '{source}': {e}")))?;
+        let all_opts = cloud_opts_for(&opts.cloud_opts);
+        let (store, path) = parse_url_opts(&url, all_opts).map_err(|e| {
+            CliError::Other(format!("get: cannot open cloud store for '{source}': {e}"))
+        })?;
+        let rt = tokio::runtime::Runtime::new()?;
+
+        let fetch = |start: u64, end: u64| -> CliResult<Vec<u8>> {
+            rt.block_on(async {
+                let r = store
+                    .get_opts(
+                        &path,
+                        OsGetOptions {
+                            range: Some(GetRange::Bounded(start..end)),
+                            ..OsGetOptions::default()
+                        },
+                    )
+                    .await
+                    .map_err(|e| CliError::Other(format!("get: fetching {source} failed: {e}")))?;
+                let b = r
+                    .bytes()
+                    .await
+                    .map_err(|e| CliError::Other(format!("get: reading {source} failed: {e}")))?;
+                Ok::<_, CliError>(b.to_vec())
+            })
+        };
+
+        // Head probe also yields the total object size.
+        let (head, total) = rt.block_on(async {
+            let r = store
+                .get_opts(
+                    &path,
+                    OsGetOptions {
+                        range: Some(GetRange::Bounded(0..PREVIEW_HEAD_BYTES)),
+                        ..OsGetOptions::default()
+                    },
+                )
+                .await
+                .map_err(|e| CliError::Other(format!("get: fetching {source} failed: {e}")))?;
+            let total = r.meta.size;
+            let b = r
+                .bytes()
+                .await
+                .map_err(|e| CliError::Other(format!("get: reading {source} failed: {e}")))?;
+            Ok::<_, CliError>((b.to_vec(), total))
+        })?;
+        let (delim, header) = sniff_preview_head(&head);
+
+        if opts.random {
+            let mut rng = rand::rng();
+            let mut wtr = csv::WriterBuilder::new()
+                .delimiter(delim)
+                .from_writer(preview_writer(output)?);
+            if let Some(h) = &header {
+                wtr.write_byte_record(h)?;
+            }
+            let mut got = 0u64;
+            let mut attempts = 0u64;
+            let max_attempts = opts
+                .sample
+                .saturating_mul(PREVIEW_RANDOM_ATTEMPTS_MULT)
+                .max(opts.sample + 8);
+            while got < opts.sample && attempts < max_attempts {
+                attempts += 1;
+                let span = total.saturating_sub(1).max(1);
+                let off = rng.random_range(0..span);
+                let end = (off + PREVIEW_RANDOM_WINDOW).min(total);
+                let win = fetch(off, end)?;
+                let Some(nl) = win.iter().position(|&b| b == b'\n') else {
+                    continue;
+                };
+                let mut rdr = csv::ReaderBuilder::new()
+                    .delimiter(delim)
+                    .flexible(true)
+                    .has_headers(false)
+                    .from_reader(&win[nl + 1..]);
+                let mut rec = csv::ByteRecord::new();
+                if rdr.read_byte_record(&mut rec)? && !rec.is_empty() {
+                    wtr.write_byte_record(&rec)?;
+                    got += 1;
+                }
+            }
+            wtr.flush()?;
+            return Ok(());
+        }
+
+        // first-N / offset: accumulate bounded windows until enough lines or EOF.
+        let start = opts.offset_mb.map_or(0, |mb| mb.saturating_mul(1 << 20));
+        let needed_lines = opts.sample + 2;
+        let mut buf = Vec::new();
+        let mut pos = start;
+        while pos < total && (buf.len() as u64) < PREVIEW_MAX_FETCH {
+            let end = (pos + DEFAULT_PART_SIZE).min(total);
+            let chunk = fetch(pos, end)?;
+            if chunk.is_empty() {
+                break;
+            }
+            pos = end;
+            buf.extend_from_slice(&chunk);
+            if (buf.iter().filter(|&&b| b == b'\n').count() as u64) >= needed_lines {
+                break;
+            }
+        }
+
+        if start > 0 {
+            let data = match buf.iter().position(|&b| b == b'\n') {
+                Some(nl) => buf[nl + 1..].to_vec(),
+                None => Vec::new(),
+            };
+            emit_preview(
+                std::io::Cursor::new(data),
+                delim,
+                false,
+                header.as_ref(),
+                opts.sample,
+                output,
+            )?;
+        } else {
+            emit_preview(
+                std::io::Cursor::new(buf),
+                delim,
+                true,
+                None,
+                opts.sample,
+                output,
+            )?;
+        }
+        Ok(())
+    }
+
+    // ---- glob / directory expansion (multi-fetch) ----
+
+    /// Context for `expand_source` (cloud listing needs the same `--cloud-opt`s).
+    pub struct ExpandCtx {
+        #[cfg_attr(not(feature = "get_cloud"), allow(dead_code))]
+        pub cloud_opts: Vec<String>,
+    }
+
+    /// True if `s` ends with a tabular extension we auto-collect from a directory.
+    fn is_tabular_path(s: &str) -> bool {
+        let lower = s.to_ascii_lowercase();
+        [".csv", ".tsv", ".tab", ".ssv"]
+            .iter()
+            .any(|e| lower.ends_with(e))
+    }
+
+    /// True if `s` contains a glob metacharacter (`*`, `?` or `[`).
+    fn has_glob_meta(s: &str) -> bool {
+        s.contains(['*', '?', '['])
+    }
+
+    /// Expand a glob/directory `source` into concrete sources. A non-glob,
+    /// non-directory source returns unchanged (as a one-element vec). Local
+    /// globs/directories and (with `get_cloud`) cloud globs/prefixes expand to
+    /// the matching files/objects; http/ckan/dathere/dc sources pass through.
+    #[cfg_attr(not(feature = "get_cloud"), allow(unused_variables))]
+    pub fn expand_source(source: &str, ctx: &ExpandCtx) -> CliResult<Vec<String>> {
+        if is_cloud_scheme(source) {
+            #[cfg(feature = "get_cloud")]
+            if source.ends_with('/') || has_glob_meta(source) {
+                return expand_cloud(source, ctx);
+            }
+            return Ok(vec![source.to_string()]);
+        }
+        // Only local filesystem paths expand; remote schemes pass through.
+        let lower = source.to_ascii_lowercase();
+        let remote = lower.starts_with("http://")
+            || lower.starts_with("https://")
+            || lower.starts_with("ckan://")
+            || lower.starts_with("dathere://")
+            || lower.starts_with("dc:");
+        if remote {
+            return Ok(vec![source.to_string()]);
+        }
+        let path = Path::new(source);
+        if path.is_dir() {
+            return expand_local_dir(path);
+        }
+        if has_glob_meta(source) {
+            return expand_local_glob(source);
+        }
+        Ok(vec![source.to_string()])
+    }
+
+    fn expand_local_dir(dir: &Path) -> CliResult<Vec<String>> {
+        let mut out = Vec::new();
+        for entry in fs::read_dir(dir)? {
+            let p = entry?.path();
+            if p.is_file() && is_tabular_path(&p.to_string_lossy()) {
+                out.push(p.to_string_lossy().to_string());
+            }
+        }
+        out.sort();
+        if out.is_empty() {
+            return Err(CliError::Other(format!(
+                "get: no tabular files (.csv/.tsv/.tab/.ssv) found in directory '{}'.",
+                dir.display()
+            )));
+        }
+        Ok(out)
+    }
+
+    fn expand_local_glob(pattern: &str) -> CliResult<Vec<String>> {
+        let mut out = Vec::new();
+        let paths = glob::glob(pattern)
+            .map_err(|e| CliError::Other(format!("get: invalid glob '{pattern}': {e}")))?;
+        for p in paths {
+            let p = p.map_err(|e| CliError::Other(format!("get: glob error: {e}")))?;
+            if p.is_file() {
+                out.push(p.to_string_lossy().to_string());
+            }
+        }
+        out.sort();
+        if out.is_empty() {
+            return Err(CliError::Other(format!(
+                "get: no files matched glob '{pattern}'."
+            )));
+        }
+        Ok(out)
+    }
+
+    /// List a cloud bucket/prefix and expand a glob (or trailing-slash directory)
+    /// into concrete `scheme://host/key` object URLs.
+    #[cfg(feature = "get_cloud")]
+    fn expand_cloud(source: &str, ctx: &ExpandCtx) -> CliResult<Vec<String>> {
+        use futures_util::stream::StreamExt;
+        use object_store::{ObjectStore, parse_url_opts, path::Path as OsPath};
+        use url::Url;
+
+        let url = Url::parse(source)
+            .map_err(|e| CliError::Other(format!("get: invalid cloud URL '{source}': {e}")))?;
+        let scheme = url.scheme().to_string();
+        let host = url.host_str().unwrap_or_default().to_string();
+        let base = format!("{scheme}://{host}");
+        let key = url.path().trim_start_matches('/').to_string();
+
+        let all_opts = cloud_opts_for(&ctx.cloud_opts);
+        let (store, _path) = parse_url_opts(&url, all_opts).map_err(|e| {
+            CliError::Other(format!("get: cannot open cloud store for '{source}': {e}"))
+        })?;
+
+        let is_glob = has_glob_meta(&key);
+        let pattern = if is_glob {
+            Some(
+                glob::Pattern::new(&key)
+                    .map_err(|e| CliError::Other(format!("get: invalid glob '{source}': {e}")))?,
+            )
+        } else {
+            None
+        };
+        // List under the literal prefix preceding the first glob metacharacter
+        // (or the whole key for a trailing-slash directory).
+        let literal: String = key
+            .chars()
+            .take_while(|c| !matches!(c, '*' | '?' | '['))
+            .collect();
+        let list_prefix = match literal.rfind('/') {
+            Some(i) => literal[..=i].to_string(),
+            None if is_glob => String::new(),
+            None => literal,
+        };
+
+        let rt = tokio::runtime::Runtime::new()?;
+        let results = rt.block_on(async {
+            let osp = if list_prefix.is_empty() {
+                None
+            } else {
+                Some(OsPath::from(list_prefix.as_str()))
+            };
+            let mut stream = store.list(osp.as_ref());
+            let mut out = Vec::new();
+            while let Some(meta) = stream.next().await {
+                let meta = meta
+                    .map_err(|e| CliError::Other(format!("get: listing {source} failed: {e}")))?;
+                let loc = meta.location.as_ref().to_string();
+                let keep = match &pattern {
+                    Some(p) => p.matches(&loc),
+                    None => is_tabular_path(&loc),
+                };
+                if keep {
+                    out.push(format!("{base}/{loc}"));
+                }
+            }
+            out.sort();
+            Ok::<_, CliError>(out)
+        })?;
+
+        if results.is_empty() {
+            return Err(CliError::Other(format!(
+                "get: no objects matched '{source}'."
+            )));
+        }
+        Ok(results)
     }
 
     /// Resolve a `dc:<name>` input path to a usable (decompressed) CSV file path,

--- a/src/diskcache.rs
+++ b/src/diskcache.rs
@@ -2347,16 +2347,41 @@ mod rich {
         Ok(())
     }
 
-    /// The first newline-terminated record within a random byte window: skip the
-    /// (partial) first line, then return the next record's bytes ONLY if it is
-    /// bounded by a terminating newline inside the window. Returns None when the
-    /// window holds no complete record, so a row truncated by the window boundary
-    /// (`PREVIEW_RANDOM_WINDOW`) is never emitted.
-    fn first_complete_record(window: &[u8]) -> Option<&[u8]> {
-        let start = window.iter().position(|&b| b == b'\n')? + 1;
-        let rest = &window[start..];
-        let end = rest.iter().position(|&b| b == b'\n')?;
-        Some(&rest[..end])
+    /// The first COMPLETE record within a random byte window: skip the (partial)
+    /// first line, then let the CSV parser read one record and accept it only if
+    /// the parser found a record boundary strictly before the window end. Using
+    /// the parser (not raw newline scanning) keeps quoted embedded newlines
+    /// intact, and the "boundary before window end" check guarantees the record
+    /// was not truncated by the window edge (`PREVIEW_RANDOM_WINDOW`). Returns
+    /// None when no complete record fits — the caller then re-samples.
+    fn random_window_record(window: &[u8], delimiter: u8) -> CliResult<Option<csv::ByteRecord>> {
+        let Some(nl) = window.iter().position(|&b| b == b'\n') else {
+            return Ok(None);
+        };
+        let rest = &window[nl + 1..];
+        if rest.is_empty() {
+            return Ok(None);
+        }
+        let mut rdr = csv::ReaderBuilder::new()
+            .delimiter(delimiter)
+            .flexible(true)
+            .has_headers(false)
+            .from_reader(rest);
+        let mut rec = csv::ByteRecord::new();
+        // A window may start mid-record, so a parse error is not fatal — just
+        // treat it as "no complete record here" and let the caller re-sample.
+        match rdr.read_byte_record(&mut rec) {
+            Ok(true) => {},
+            Ok(false) | Err(_) => return Ok(None),
+        }
+        // The record is complete only if the parser found its terminator before
+        // consuming the whole window (i.e. there is more data after it). A record
+        // that runs to the window end may have been cut off mid-field — reject it
+        // (conservatively also dropping a record that ends exactly at the edge).
+        if rec.is_empty() || rdr.position().byte() >= rest.len() as u64 {
+            return Ok(None);
+        }
+        Ok(Some(rec))
     }
 
     /// Dispatch a preview to the right backend (mirrors `get_resource`).
@@ -2558,18 +2583,9 @@ mod rich {
             let resp = http_get(Some(format!("bytes={off}-{end}")))?;
             let mut win = Vec::new();
             resp.take(PREVIEW_RANDOM_WINDOW).read_to_end(&mut win)?;
-            // Emit only a record that is fully terminated inside the window, so a
-            // row straddling the window boundary is never written truncated.
-            let Some(record) = first_complete_record(&win) else {
-                continue;
-            };
-            let mut rdr = csv::ReaderBuilder::new()
-                .delimiter(delimiter)
-                .flexible(true)
-                .has_headers(false)
-                .from_reader(record);
-            let mut rec = csv::ByteRecord::new();
-            if rdr.read_byte_record(&mut rec)? && !rec.is_empty() {
+            // Emit only a record the CSV parser fully terminates inside the
+            // window, so a row straddling the window boundary is never truncated.
+            if let Some(rec) = random_window_record(&win, delimiter)? {
                 wtr.write_byte_record(&rec)?;
                 got += 1;
             }
@@ -2653,18 +2669,10 @@ mod rich {
                 let off = rng.random_range(0..span);
                 let end = (off + PREVIEW_RANDOM_WINDOW).min(total);
                 let win = fetch(off, end)?;
-                // Emit only a record fully terminated inside the window, so a row
-                // straddling the window boundary is never written truncated.
-                let Some(record) = first_complete_record(&win) else {
-                    continue;
-                };
-                let mut rdr = csv::ReaderBuilder::new()
-                    .delimiter(delim)
-                    .flexible(true)
-                    .has_headers(false)
-                    .from_reader(record);
-                let mut rec = csv::ByteRecord::new();
-                if rdr.read_byte_record(&mut rec)? && !rec.is_empty() {
+                // Emit only a record the CSV parser fully terminates inside the
+                // window, so a row straddling the window boundary is never
+                // truncated.
+                if let Some(rec) = random_window_record(&win, delim)? {
                     wtr.write_byte_record(&rec)?;
                     got += 1;
                 }
@@ -3170,5 +3178,73 @@ mod rich {
             out.push((e.logical_name, ok));
         }
         Ok(out)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::random_window_record;
+
+        #[test]
+        fn random_window_complete_followed_by_more() {
+            // realign drops the partial first line; the next record is terminated
+            // and followed by more data -> accepted.
+            let rec = random_window_record(b"partial-tail\na,b\nc,d\n", b',')
+                .unwrap()
+                .unwrap();
+            assert_eq!(&rec[0], b"a");
+            assert_eq!(&rec[1], b"b");
+        }
+
+        #[test]
+        fn random_window_keeps_quoted_embedded_newline() {
+            // a quoted field with an embedded newline stays ONE record, not split
+            // at the embedded '\n' — the regression this fix targets.
+            let rec = random_window_record(b"tail\n\"x\ny\",z\nmore,data\n", b',')
+                .unwrap()
+                .unwrap();
+            assert_eq!(rec.len(), 2);
+            assert_eq!(&rec[0], b"x\ny");
+            assert_eq!(&rec[1], b"z");
+        }
+
+        #[test]
+        fn random_window_rejects_unterminated_record() {
+            // the record after realign runs to the window end with no terminator
+            // -> possibly truncated -> rejected.
+            assert!(
+                random_window_record(b"tail\na,b,truncated-no-newline", b',')
+                    .unwrap()
+                    .is_none()
+            );
+        }
+
+        #[test]
+        fn random_window_rejects_unterminated_quote() {
+            // an open quote at the window edge must not error or emit a partial
+            // row -> rejected.
+            assert!(
+                random_window_record(b"tail\n\"open quote with no close", b',')
+                    .unwrap()
+                    .is_none()
+            );
+        }
+
+        #[test]
+        fn random_window_none_without_newline() {
+            assert!(
+                random_window_record(b"no newline at all", b',')
+                    .unwrap()
+                    .is_none()
+            );
+        }
+
+        #[test]
+        fn random_window_respects_tab_delimiter() {
+            let rec = random_window_record(b"tail\na\tb\tc\nx\ty\tz\n", b'\t')
+                .unwrap()
+                .unwrap();
+            assert_eq!(rec.len(), 3);
+            assert_eq!(&rec[0], b"a");
+        }
     }
 }

--- a/src/diskcache.rs
+++ b/src/diskcache.rs
@@ -2191,11 +2191,6 @@ mod rich {
 
     /// Bytes sniffed (and used to extract the header) from the start of a source.
     const PREVIEW_HEAD_BYTES: u64 = 256 * 1024;
-    /// Per-probe window for `--random` ranged reads.
-    const PREVIEW_RANDOM_WINDOW: u64 = 128 * 1024;
-    /// Max `--random` probe attempts is `sample * this` (records may straddle
-    /// windows, so allow several tries per wanted record before giving up).
-    const PREVIEW_RANDOM_ATTEMPTS_MULT: u64 = 20;
     /// Cap on bytes pulled while accumulating windows for a cloud `--offset`/
     /// first-N preview, so a tiny `--sample` never drags the whole object.
     #[cfg(feature = "get_cloud")]
@@ -2213,19 +2208,6 @@ mod rich {
         pub timeout_secs: u16,
         #[cfg_attr(not(feature = "get_cloud"), allow(dead_code))]
         pub cloud_opts:   Vec<String>,
-    }
-
-    /// Total object size from a `Content-Range` value ("bytes START-END/TOTAL").
-    /// None when the total is unknown ("*").
-    fn parse_total_from_content_range(cr: &str) -> Option<u64> {
-        let rest = cr.trim().strip_prefix("bytes ")?.trim();
-        let (_, total) = rest.split_once('/')?;
-        let total = total.trim();
-        if total == "*" {
-            None
-        } else {
-            total.parse().ok()
-        }
     }
 
     /// Sniff the head buffer for its delimiter and extract the header record,
@@ -2347,43 +2329,6 @@ mod rich {
         Ok(())
     }
 
-    /// The first COMPLETE record within a random byte window: skip the (partial)
-    /// first line, then let the CSV parser read one record and accept it only if
-    /// the parser found a record boundary strictly before the window end. Using
-    /// the parser (not raw newline scanning) keeps quoted embedded newlines
-    /// intact, and the "boundary before window end" check guarantees the record
-    /// was not truncated by the window edge (`PREVIEW_RANDOM_WINDOW`). Returns
-    /// None when no complete record fits — the caller then re-samples.
-    fn random_window_record(window: &[u8], delimiter: u8) -> CliResult<Option<csv::ByteRecord>> {
-        let Some(nl) = window.iter().position(|&b| b == b'\n') else {
-            return Ok(None);
-        };
-        let rest = &window[nl + 1..];
-        if rest.is_empty() {
-            return Ok(None);
-        }
-        let mut rdr = csv::ReaderBuilder::new()
-            .delimiter(delimiter)
-            .flexible(true)
-            .has_headers(false)
-            .from_reader(rest);
-        let mut rec = csv::ByteRecord::new();
-        // A window may start mid-record, so a parse error is not fatal — just
-        // treat it as "no complete record here" and let the caller re-sample.
-        match rdr.read_byte_record(&mut rec) {
-            Ok(true) => {},
-            Ok(false) | Err(_) => return Ok(None),
-        }
-        // The record is complete only if the parser found its terminator before
-        // consuming the whole window (i.e. there is more data after it). A record
-        // that runs to the window end may have been cut off mid-field — reject it
-        // (conservatively also dropping a record that ends exactly at the edge).
-        if rec.is_empty() || rdr.position().byte() >= rest.len() as u64 {
-            return Ok(None);
-        }
-        Ok(Some(rec))
-    }
-
     /// Dispatch a preview to the right backend (mirrors `get_resource`).
     pub fn preview_resource(opts: &PreviewOptions, output: Option<&str>) -> CliResult<()> {
         let resolved = resolve_uri_prefix(&opts.source, opts.ckan_api_url.as_deref());
@@ -2475,7 +2420,7 @@ mod rich {
         opts: &PreviewOptions,
         output: Option<&str>,
     ) -> CliResult<()> {
-        use reqwest::header::{AUTHORIZATION, CONTENT_RANGE, RANGE};
+        use reqwest::header::{AUTHORIZATION, RANGE};
 
         let http_get = |range: Option<String>| -> CliResult<reqwest::blocking::Response> {
             let mut req = client.get(url);
@@ -2491,26 +2436,16 @@ mod rich {
         // Head probe: doubles as the dialect sniff and the range-support detector.
         let probe = http_get(Some(format!("bytes=0-{}", PREVIEW_HEAD_BYTES - 1)))?;
         let supports_range = probe.status() == reqwest::StatusCode::PARTIAL_CONTENT;
-        let total = probe
-            .headers()
-            .get(CONTENT_RANGE)
-            .and_then(|v| v.to_str().ok())
-            .and_then(parse_total_from_content_range);
         let mut head = Vec::new();
         probe.take(PREVIEW_HEAD_BYTES).read_to_end(&mut head)?;
         let (delim, header) = sniff_preview_head(&head);
 
         if opts.random {
-            if supports_range && let Some(total) = total {
-                return preview_http_random(
-                    &http_get,
-                    delim,
-                    header.as_ref(),
-                    opts.sample,
-                    total,
-                    output,
-                );
-            }
+            // Random sampling streams the whole body through a reservoir sampler
+            // (parsing from the start, so quoted multi-line records are never
+            // split). Ranged random-offset reads are deliberately NOT used: a
+            // random byte offset can land inside a quoted field, where record
+            // boundaries are indeterminable without parsing from the start.
             let resp = http_get(None)?;
             emit_preview_reservoir(
                 std::io::BufReader::new(resp),
@@ -2550,54 +2485,48 @@ mod rich {
         Ok(())
     }
 
-    /// Approximate uniform-random sampling over a range-capable HTTP source: read
-    /// a small window at random offsets, realign to a record boundary, and take
-    /// the first whole record from each, until `take` records are collected.
-    fn preview_http_random(
-        http_get: &dyn Fn(Option<String>) -> CliResult<reqwest::blocking::Response>,
-        delimiter: u8,
-        header: Option<&csv::ByteRecord>,
-        take: u64,
+    /// A synchronous `Read` over an `object_store` source that pulls fixed-size
+    /// byte-range windows on demand (bounded memory) and reads to the true end of
+    /// the object — so a CSV parser over it sees only complete records, never one
+    /// truncated by a window boundary. Backs the cloud `--random` reservoir path.
+    #[cfg(feature = "get_cloud")]
+    struct CloudRangeReader<'a> {
+        fetch: &'a dyn Fn(u64, u64) -> CliResult<Vec<u8>>,
+        pos:   u64,
         total: u64,
-        output: Option<&str>,
-    ) -> CliResult<()> {
-        use rand::RngExt;
+        buf:   Vec<u8>,
+        off:   usize,
+    }
 
-        let mut rng = rand::rng();
-        let mut wtr = csv::WriterBuilder::new()
-            .delimiter(delimiter)
-            .from_writer(preview_writer(output)?);
-        if let Some(h) = header {
-            wtr.write_byte_record(h)?;
-        }
-        let mut got = 0u64;
-        let mut attempts = 0u64;
-        let max_attempts = take
-            .saturating_mul(PREVIEW_RANDOM_ATTEMPTS_MULT)
-            .max(take + 8);
-        while got < take && attempts < max_attempts {
-            attempts += 1;
-            let span = total.saturating_sub(1).max(1);
-            let off = rng.random_range(0..span);
-            let end = (off + PREVIEW_RANDOM_WINDOW).min(total).saturating_sub(1);
-            let resp = http_get(Some(format!("bytes={off}-{end}")))?;
-            let mut win = Vec::new();
-            resp.take(PREVIEW_RANDOM_WINDOW).read_to_end(&mut win)?;
-            // Emit only a record the CSV parser fully terminates inside the
-            // window, so a row straddling the window boundary is never truncated.
-            if let Some(rec) = random_window_record(&win, delimiter)? {
-                wtr.write_byte_record(&rec)?;
-                got += 1;
+    #[cfg(feature = "get_cloud")]
+    impl std::io::Read for CloudRangeReader<'_> {
+        fn read(&mut self, out: &mut [u8]) -> std::io::Result<usize> {
+            if self.off >= self.buf.len() {
+                if self.pos >= self.total {
+                    return Ok(0);
+                }
+                let end = (self.pos + DEFAULT_PART_SIZE).min(self.total);
+                let chunk = (self.fetch)(self.pos, end)
+                    .map_err(|e| std::io::Error::other(e.to_string()))?;
+                self.pos = end;
+                if chunk.is_empty() {
+                    // Defensive: stop rather than loop if the store yields nothing.
+                    self.pos = self.total;
+                    return Ok(0);
+                }
+                self.buf = chunk;
+                self.off = 0;
             }
+            let n = out.len().min(self.buf.len() - self.off);
+            out[..n].copy_from_slice(&self.buf[self.off..self.off + n]);
+            self.off += n;
+            Ok(n)
         }
-        wtr.flush()?;
-        Ok(())
     }
 
     #[cfg(feature = "get_cloud")]
     fn preview_cloud(source: &str, opts: &PreviewOptions, output: Option<&str>) -> CliResult<()> {
         use object_store::{GetOptions as OsGetOptions, GetRange, ObjectStore, parse_url_opts};
-        use rand::RngExt;
         use url::Url;
 
         let url = Url::parse(source)
@@ -2650,34 +2579,21 @@ mod rich {
         let (delim, header) = sniff_preview_head(&head);
 
         if opts.random {
-            let mut rng = rand::rng();
-            let mut wtr = csv::WriterBuilder::new()
-                .delimiter(delim)
-                .from_writer(preview_writer(output)?);
-            if let Some(h) = &header {
-                wtr.write_byte_record(h)?;
-            }
-            let mut got = 0u64;
-            let mut attempts = 0u64;
-            let max_attempts = opts
-                .sample
-                .saturating_mul(PREVIEW_RANDOM_ATTEMPTS_MULT)
-                .max(opts.sample + 8);
-            while got < opts.sample && attempts < max_attempts {
-                attempts += 1;
-                let span = total.saturating_sub(1).max(1);
-                let off = rng.random_range(0..span);
-                let end = (off + PREVIEW_RANDOM_WINDOW).min(total);
-                let win = fetch(off, end)?;
-                // Emit only a record the CSV parser fully terminates inside the
-                // window, so a row straddling the window boundary is never
-                // truncated.
-                if let Some(rec) = random_window_record(&win, delim)? {
-                    wtr.write_byte_record(&rec)?;
-                    got += 1;
-                }
-            }
-            wtr.flush()?;
+            // Stream the whole object through a reservoir sampler (parsing from
+            // the start, so quoted multi-line records are never split). Memory is
+            // bounded to one byte-range window at a time via CloudRangeReader,
+            // which reads to the true object end so no record is truncated.
+            // Ranged random-offset reads are deliberately NOT used: a random byte
+            // offset can land inside a quoted field, where record boundaries are
+            // indeterminable without parsing from the start.
+            let reader = CloudRangeReader {
+                fetch: &fetch,
+                pos: 0,
+                total,
+                buf: Vec::new(),
+                off: 0,
+            };
+            emit_preview_reservoir(reader, delim, true, opts.sample, output)?;
             return Ok(());
         }
 
@@ -3182,69 +3098,30 @@ mod rich {
 
     #[cfg(test)]
     mod tests {
-        use super::random_window_record;
+        use std::io::Cursor;
 
+        use super::emit_preview_reservoir;
+
+        // The `--random` reservoir path parses the CSV from the start, so a quoted
+        // field containing an embedded newline must survive as ONE intact record
+        // rather than being split (the bug ranged random-offset sampling had).
         #[test]
-        fn random_window_complete_followed_by_more() {
-            // realign drops the partial first line; the next record is terminated
-            // and followed by more data -> accepted.
-            let rec = random_window_record(b"partial-tail\na,b\nc,d\n", b',')
-                .unwrap()
+        fn reservoir_preserves_quoted_multiline_record() {
+            let csv = b"h1,h2\n\"a\nb\",c\nd,e\n";
+            let out_path = std::env::temp_dir().join("qsv-reservoir-quoted-test.csv");
+            let out = out_path.to_string_lossy().to_string();
+            // take far exceeds the row count, so the reservoir keeps every row in
+            // order -> deterministic output.
+            emit_preview_reservoir(Cursor::new(csv.as_slice()), b',', true, 100, Some(&out))
                 .unwrap();
-            assert_eq!(&rec[0], b"a");
-            assert_eq!(&rec[1], b"b");
-        }
-
-        #[test]
-        fn random_window_keeps_quoted_embedded_newline() {
-            // a quoted field with an embedded newline stays ONE record, not split
-            // at the embedded '\n' — the regression this fix targets.
-            let rec = random_window_record(b"tail\n\"x\ny\",z\nmore,data\n", b',')
-                .unwrap()
-                .unwrap();
-            assert_eq!(rec.len(), 2);
-            assert_eq!(&rec[0], b"x\ny");
-            assert_eq!(&rec[1], b"z");
-        }
-
-        #[test]
-        fn random_window_rejects_unterminated_record() {
-            // the record after realign runs to the window end with no terminator
-            // -> possibly truncated -> rejected.
+            let got = std::fs::read_to_string(&out_path).unwrap();
+            let _ = std::fs::remove_file(&out_path);
+            assert!(got.contains("h1,h2"), "header missing:\n{got}");
             assert!(
-                random_window_record(b"tail\na,b,truncated-no-newline", b',')
-                    .unwrap()
-                    .is_none()
+                got.contains("\"a\nb\""),
+                "quoted multi-line record was split or corrupted:\n{got:?}"
             );
-        }
-
-        #[test]
-        fn random_window_rejects_unterminated_quote() {
-            // an open quote at the window edge must not error or emit a partial
-            // row -> rejected.
-            assert!(
-                random_window_record(b"tail\n\"open quote with no close", b',')
-                    .unwrap()
-                    .is_none()
-            );
-        }
-
-        #[test]
-        fn random_window_none_without_newline() {
-            assert!(
-                random_window_record(b"no newline at all", b',')
-                    .unwrap()
-                    .is_none()
-            );
-        }
-
-        #[test]
-        fn random_window_respects_tab_delimiter() {
-            let rec = random_window_record(b"tail\na\tb\tc\nx\ty\tz\n", b'\t')
-                .unwrap()
-                .unwrap();
-            assert_eq!(rec.len(), 3);
-            assert_eq!(&rec[0], b"a");
+            assert!(got.contains("d,e"), "second data row missing:\n{got}");
         }
     }
 }

--- a/tests/test_get.rs
+++ b/tests/test_get.rs
@@ -1643,3 +1643,217 @@ fn get_http_multimember_gz_decompresses() {
 fn get_http_zst_decompresses() {
     check_http_compressed_get("get_http_zst_decompresses", "boston311-100.csv.zst");
 }
+
+// Number of persisted cache entries (one `{keyhash}.json` per entry). Used to
+// prove preview mode creates NO cache entry.
+fn entry_json_count(cache_dir: &Path) -> usize {
+    let entries = cache_dir.join("get").join("entries");
+    std::fs::read_dir(&entries).map_or(0, |rd| {
+        rd.flatten()
+            .filter(|e| e.path().extension().is_some_and(|x| x == "json"))
+            .count()
+    })
+}
+
+// issue #654: `get` sniffs each cached blob's CSV dialect/schema during indexing
+// and surfaces it (DELIM column in cache-list; `sniffed` object in --json). A
+// comma source reports `csv`/`,`, a tab source `tsv`/`\t`.
+#[test]
+fn get_sniff_dialect_in_cache_list() {
+    let wrk = Workdir::new("get_sniff_dialect_in_cache_list");
+    wrk.create_from_string("c_src.csv", STATES_CSV);
+    wrk.create_from_string("t_src.csv", "name\tabbr\nAlabama\tAL\nAlaska\tAK\n");
+    let cache_dir = wrk.path("qsvcache");
+
+    for (name, src) in [("c.csv", "c_src.csv"), ("t.csv", "t_src.csv")] {
+        let mut g = wrk.command("get");
+        g.env("QSV_CACHE_DIR", &cache_dir)
+            .args(["--name", name])
+            .arg(src);
+        wrk.assert_success(&mut g);
+    }
+
+    // table form: DELIM column shows csv / tsv
+    let mut list = wrk.command("get");
+    list.env("QSV_CACHE_DIR", &cache_dir).arg("cache-list");
+    let table = String::from_utf8_lossy(&wrk.output(&mut list).stdout).to_string();
+    assert!(table.contains("DELIM"), "missing DELIM column:\n{table}");
+    assert!(table.contains("csv"), "csv delimiter not shown:\n{table}");
+    assert!(table.contains("tsv"), "tsv delimiter not shown:\n{table}");
+
+    // json form: the sniffed object carries the detected delimiter + fields
+    let mut json = wrk.command("get");
+    json.env("QSV_CACHE_DIR", &cache_dir)
+        .arg("cache-list")
+        .arg("--json");
+    let js = String::from_utf8_lossy(&wrk.output(&mut json).stdout).to_string();
+    assert!(js.contains("\"sniffed\""), "no sniffed object:\n{js}");
+    assert!(js.contains("\"delimiter\""), "no delimiter field:\n{js}");
+    assert!(js.contains("\"has_header\""), "no has_header field:\n{js}");
+
+    // cache-info reports how many entries carry a sniffed schema
+    let mut info = wrk.command("get");
+    info.env("QSV_CACHE_DIR", &cache_dir).arg("cache-info");
+    let inf = String::from_utf8_lossy(&wrk.output(&mut info).stdout).to_string();
+    assert!(
+        inf.contains("with schema"),
+        "cache-info missing schema line:\n{inf}"
+    );
+}
+
+// issue #654: `--sample N` is a cache-bypassing PREVIEW — it streams the header
+// plus the first N data records to stdout and creates NO cache entry.
+#[test]
+fn get_preview_local_first_n() {
+    let wrk = Workdir::new("get_preview_local_first_n");
+    wrk.create_from_string("src.csv", STATES_CSV);
+    let cache_dir = wrk.path("qsvcache");
+
+    let mut g = wrk.command("get");
+    g.env("QSV_CACHE_DIR", &cache_dir)
+        .args(["--sample", "2"])
+        .arg("src.csv");
+    let out = wrk.output(&mut g);
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(lines.len(), 3, "expected header + 2 rows:\n{stdout}");
+    assert_eq!(lines[0], "name,abbr");
+    assert_eq!(lines[1], "Alabama,AL");
+    assert_eq!(lines[2], "Alaska,AK");
+
+    // the key invariant: preview created NO cache entry
+    assert_eq!(
+        entry_json_count(&cache_dir),
+        0,
+        "preview must not write a cache entry"
+    );
+}
+
+// `--offset` skips ahead then samples, realigning to a record boundary and
+// re-attaching the sniffed header. `--random` reservoir-samples a local file.
+#[test]
+fn get_preview_local_offset_and_random() {
+    let wrk = Workdir::new("get_preview_local_offset_and_random");
+    wrk.create_from_string("src.csv", STATES_CSV);
+    let cache_dir = wrk.path("qsvcache");
+
+    // offset 0 skips the header line, then emits the sniffed header + 2 rows
+    let mut off = wrk.command("get");
+    off.env("QSV_CACHE_DIR", &cache_dir)
+        .args(["--offset", "0", "--sample", "2"])
+        .arg("src.csv");
+    let o = wrk.output(&mut off);
+    assert!(o.status.success());
+    let s = String::from_utf8_lossy(&o.stdout);
+    let lines: Vec<&str> = s.lines().collect();
+    assert_eq!(lines.len(), 3, "offset preview: header + 2 rows:\n{s}");
+    assert_eq!(lines[0], "name,abbr");
+    assert_eq!(lines[1], "Alabama,AL");
+
+    // random: exactly min(sample, rows) data records + header, still no cache
+    let mut rnd = wrk.command("get");
+    rnd.env("QSV_CACHE_DIR", &cache_dir)
+        .args(["--sample", "3", "--random"])
+        .arg("src.csv");
+    let r = wrk.output(&mut rnd);
+    assert!(r.status.success());
+    let rs = String::from_utf8_lossy(&r.stdout);
+    assert_eq!(
+        rs.lines().count(),
+        4,
+        "random preview: header + 3 rows:\n{rs}"
+    );
+    assert_eq!(rs.lines().next().unwrap(), "name,abbr");
+    assert_eq!(entry_json_count(&cache_dir), 0, "preview must not cache");
+}
+
+// preview is single-source only.
+#[test]
+fn get_preview_multi_source_rejected() {
+    let wrk = Workdir::new("get_preview_multi_source_rejected");
+    wrk.create_from_string("a.csv", STATES_CSV);
+    wrk.create_from_string("b.csv", STATES_CSV);
+    let cache_dir = wrk.path("qsvcache");
+
+    let mut g = wrk.command("get");
+    g.env("QSV_CACHE_DIR", &cache_dir)
+        .args(["--sample", "2"])
+        .arg("a.csv")
+        .arg("b.csv");
+    wrk.assert_err(&mut g);
+}
+
+// preview over HTTP: first-N streams header + N rows from a remote source and
+// caches nothing.
+#[test]
+fn get_preview_http_first_n() {
+    let server = GetWebServer::start();
+    let wrk = Workdir::new("get_preview_http_first_n");
+    let cache_dir = wrk.path("qsvcache");
+    let url = server.url("states.csv");
+
+    let mut g = wrk.command("get");
+    g.env("QSV_CACHE_DIR", &cache_dir)
+        .args(["--sample", "2"])
+        .arg(&url);
+    let out = wrk.output(&mut g);
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(stdout.lines().count(), 3, "header + 2 rows:\n{stdout}");
+    assert!(stdout.contains("name,abbr"));
+    assert_eq!(entry_json_count(&cache_dir), 0, "preview must not cache");
+}
+
+// preview --offset over a Range-capable HTTP source.
+#[test]
+fn get_preview_http_offset() {
+    let server = GetWebServer::start();
+    let wrk = Workdir::new("get_preview_http_offset");
+    let cache_dir = wrk.path("qsvcache");
+    let url = server.url("big.csv");
+
+    let mut g = wrk.command("get");
+    g.env("QSV_CACHE_DIR", &cache_dir)
+        .args(["--offset", "0", "--sample", "2"])
+        .arg(&url);
+    let out = wrk.output(&mut g);
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(lines.len(), 3, "header + 2 rows:\n{stdout}");
+    assert_eq!(lines[0], "id,name,value");
+    assert_eq!(lines[1], "0,row-0,0");
+    assert_eq!(entry_json_count(&cache_dir), 0, "preview must not cache");
+}
+
+// issue #654: a glob source fetches every matching tabular file. --name is
+// ignored; each file becomes its own dc: entry. A `.tsv` is excluded by `*.csv`.
+#[test]
+fn get_glob_local_expands() {
+    let wrk = Workdir::new("get_glob_local_expands");
+    wrk.create_from_string("one.csv", "a,b\n1,2\n");
+    wrk.create_from_string("two.csv", "a,b\n3,4\n");
+    wrk.create_from_string("skip.tsv", "a\tb\n5\t6\n");
+    let cache_dir = wrk.path("qsvcache");
+
+    let mut g = wrk.command("get");
+    g.env("QSV_CACHE_DIR", &cache_dir).arg("*.csv");
+    wrk.assert_success(&mut g);
+
+    assert_eq!(
+        entry_json_count(&cache_dir),
+        2,
+        "glob *.csv should cache exactly the two CSV files"
+    );
+
+    let mut list = wrk.command("get");
+    list.env("QSV_CACHE_DIR", &cache_dir).arg("cache-list");
+    let table = String::from_utf8_lossy(&wrk.output(&mut list).stdout).to_string();
+    assert!(table.contains("one.csv"), "missing one.csv:\n{table}");
+    assert!(table.contains("two.csv"), "missing two.csv:\n{table}");
+    assert!(
+        !table.contains("skip.tsv"),
+        "tsv should be excluded:\n{table}"
+    );
+}

--- a/tests/test_get.rs
+++ b/tests/test_get.rs
@@ -1857,3 +1857,22 @@ fn get_glob_local_expands() {
         "tsv should be excluded:\n{table}"
     );
 }
+
+// A literal local file whose NAME contains glob metacharacters must be fetched
+// as a single file, not interpreted as a glob pattern (regression guard).
+#[test]
+fn get_literal_filename_with_glob_metachars() {
+    let wrk = Workdir::new("get_literal_filename_with_glob_metachars");
+    wrk.create_from_string("data[2026].csv", "a,b\n1,2\n3,4\n");
+    let cache_dir = wrk.path("qsvcache");
+
+    let mut g = wrk.command("get");
+    g.env("QSV_CACHE_DIR", &cache_dir).arg("data[2026].csv");
+    wrk.assert_success(&mut g);
+
+    assert_eq!(
+        entry_json_count(&cache_dir),
+        1,
+        "a real file with glob chars in its name should fetch as one file"
+    );
+}


### PR DESCRIPTION
## What & why

Investigates #654 (a CSV/TSV-aware `download` command) and folds the missing CSV-aware pieces into the existing `get` command instead of adding a new command. `get` already implements the *transport half* of #654 — http/https/`ckan://`/`s3://`/`gs://`/`az://`, multi-source fetch, HTTP Range parallelism + conditional ETag/Last-Modified revalidation, http2 + brotli/gzip/deflate, and a roadmapped `sftp://`. This PR adds the genuinely CSV-aware bits.

All changes are behind the existing `get` feature.

## Changes

1. **Schema sniffing in cache metadata** — `ensure_indexed` sniffs each cached blob's dialect once (delimiter, header, field names & types) via `csv-nose` and stores it on `CacheEntry.sniffed` (`#[serde(default)]`, so old entries load fine and backfill on next index). Surfaced as a `DELIM` column in `cache-list`, a `with schema` line in `cache-info`, and a `sniffed` object in `--json`.

2. **Cache-bypassing preview** — new `--sample N` / `--offset <mb>` / `--random` flags stream rows straight to `--output`/stdout and **never** create a `dc:` cache entry (the cache stays canonical — only full resources get `dc:` handles). Works for local (seek / reservoir), HTTP (Range probe + early-stop streaming, Bernoulli fallback when the server lacks Range support), and cloud (`object_store` ranged gets). Preview assumes the first row is a header (qsv's default), since header detection on a small all-string sample is unreliable.

3. **Glob / directory multi-fetch** — `expand_source` flattens local globs/directories and cloud bucket prefixes/globs into the normal cache loop. `glob` is promoted from a transitive to a direct optional dep → **zero new crates in Cargo.lock** (1 line added).

## Deferred (follow-ups)

- **CKAN dataset expansion** (`package_show`) — the current `ckan://` resolver maps to a single *resource*; dataset-vs-resource disambiguation is non-trivial.
- **HTTP directory-listing scrape** — fragile HTML parsing, lowest priority.
- **`ftp://`** — only `sftp://` was ever roadmapped.

## Testing

- **51 `get` tests pass** (44 with `get_cloud`, incl. S3 mocks). 9 new tests cover sniffing, preview (local/http/offset/random), the no-cache-mutation invariant, multi-source rejection, and glob expansion.
- Clean `cargo +nightly fmt` + `cargo clippy` on `get` / `get_cloud` / `all_features`; qsvlite unaffected.
- `docs/help/get.md` regenerated via `qsv --generate-help-md`.

Closes #654 (partially — see deferred items above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)