### PR TITLE
pgo-train: add 10 more commands to broaden PGO coverage

### DIFF
--- a/scripts/pgo-train.sh
+++ b/scripts/pgo-train.sh
@@ -148,6 +148,12 @@ t dedup "$data"
 t sort "$data"
 t cat rows "$data" "$data"
 t behead "$data"
+t fixlengths "$data"
+t replace "[0-9]" "X" "$data"
+t extdedup "$data" pgo_train_extdedup.csv
+t extdedup "$data" --select 1-5
+t extsort "$data" pgo_train_extsort.csv
+t extsort "$data" --select 1-5
 
 # ---- feature-gated paths (skipped automatically on reduced binaries) --------
 t apply operations lower 2 "$data"
@@ -155,11 +161,16 @@ t schema "$data" --stdout
 t tojsonl "$data"
 t snappy compress "$data" --output pgo_train.snappy
 t validate "$data"
+t blake3 "$data"
+t luau map newcol "1 + 1" "$data"
+t profile "$data"
+t synthesize "$data" -n 1000 --seed 42 -o pgo_train_synth.csv
 
 if [[ "$minimal" -eq 0 ]]; then
   # heavier paths that need the real dataset and the full-feature build
   t searchset <(printf "homeless\npark\nNoise\n") "$data"
   t to xlsx pgo_train.xlsx "$data"
+  t excel pgo_train.xlsx
   # polars-backed paths - the biggest PGO win
   t sqlp "$data" "select * from _t_1 limit 1000"
   t sqlp "$data" "select \"Borough\", count(*) from _t_1 group by \"Borough\""
@@ -167,6 +178,9 @@ if [[ "$minimal" -eq 0 ]]; then
     t joinp "Community Board" "$data" community_board communityboards.csv
   fi
   t luau map newcol "1 + 1" "$data"
+  # geocode auto-downloads the Geonames index on first run (network required)
+  t geocode suggest City --new-column geocoded_city "$data"
+  t geocode reverse Location --new-column geocoded_location "$data"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

Broadens `scripts/pgo-train.sh` PGO training coverage with ten more commands so the instrumented binary exercises additional hot and feature-gated code paths.

Invocations were verified against the command sources and the canonical NYC311 lines already in `scripts/benchmarks.sh`. The `t` helper runs each command once and tolerates non-zero exits, so commands not compiled into a given binary variant are harmlessly skipped.

### Core CSV-engine paths (always compiled — train in both full and minimal modes)
- `fixlengths`
- `replace` (`[0-9]` → `X`, guarantees a match in both datasets)
- `extdedup` (line mode + CSV `--select 1-5` mode)
- `extsort` (line mode + CSV `--select 1-5` mode)

### Feature-gated paths (skipped automatically on reduced binaries; train on minimal data too)
- `blake3`
- `luau map` (also promotes luau training into minimal mode)
- `profile` (runs stats+frequency internally)
- `synthesize` (offline, deterministic via `--seed 42`)

### Heavier paths (non-minimal block — need the real dataset / network)
- `excel` — reads the `pgo_train.xlsx` produced by the preceding `to xlsx`
- `geocode suggest` / `reverse` — use the NYC311 `City`/`Location` columns (mirrored from `benchmarks.sh`); auto-downloads the Geonames index on first run

## Testing
- `bash -n scripts/pgo-train.sh` passes
- Minimal smoke run (`./scripts/pgo-train.sh target/debug/qsv --minimal`): all six core + four feature-gated lines execute with **no `skipped/failed`** on a full-feature build
- `excel`/`geocode` correctly remain gated to the non-minimal block

🤖 Generated with [Claude Code](https://claude.com/claude-code)