### PR TITLE
benchmarks: add delta & rank columns to results

### DIFF
--- a/scripts/benchmarks.sh
+++ b/scripts/benchmarks.sh
@@ -42,7 +42,7 @@
 arg_pat="$1"
 
 # the version of this script
-bm_version=9.2.0
+bm_version=9.3.0
 
 # CONFIGURABLE VARIABLES ---------------------------------------
 # change as needed to reflect your environment/workloads
@@ -1019,13 +1019,54 @@ total_mean=$(<total_mean.txt)
   -o results/results_work.csv
 mv results/results_work.csv results/benchmark_results.csv
 
+# ---------------------------------------
+# Add delta & rank columns over the full historical archive by dogfooding qsv sqlp.
+#   delta = percent FASTER than this benchmark's previous version (the most recent earlier
+#           version, by tstamp; same-version re-runs are collapsed to their latest run).
+#           Positive = faster, negative = regression. Empty when there is no earlier version.
+#   rank  = speed rank of this run among ALL runs of the same benchmark (1 = fastest),
+#           ranked by mean ascending.
+# We recompute over the whole archive on every run - this is self-healing: it backfills the
+# columns for pre-existing historical rows the first time, and keeps ranks correct as new runs
+# accrue. "user" is a reserved word in Polars SQL, so it is quoted as b."user". Base columns are
+# listed explicitly (not b.*) so re-runs whose input already has delta/rank drop them and
+# recompute cleanly, without duplicating columns.
+"$qsv_bin" sqlp results/benchmark_results.csv -q "
+with per_version as (
+  select name, version, tstamp, mean,
+         row_number() over (partition by name, version order by tstamp desc) as rn
+  from _t_1
+),
+with_prev as (
+  select name, version,
+         lag(mean) over (partition by name order by tstamp asc) as prev_mean
+  from per_version where rn = 1
+)
+select b.version, b.tstamp, b.name, b.mean, b.stddev, b.median,
+       b.\"user\", b.system, b.min, b.max, b.recs_per_sec,
+       round(((wp.prev_mean - b.mean) / wp.prev_mean) * 100, 2) as delta,
+       rank() over (partition by b.name order by b.mean asc) as rank
+from _t_1 b
+left join with_prev wp on b.name = wp.name and b.version = wp.version
+order by b.tstamp desc, b.name asc
+" -o results/results_work.csv
+mv results/results_work.csv results/benchmark_results.csv
+
+# re-derive latest_results.csv from the enriched archive so it too carries delta & rank
+# (total_mean was already captured above, so overwriting latest_results.csv here is safe)
+"$qsv_bin" sqlp results/benchmark_results.csv \
+  -q "select * from _t_1 where version = '$version' and tstamp = '$now'" \
+  -o results/results_work.csv
+"$qsv_bin" sort --select version,tstamp,name results/results_work.csv \
+  -o results/latest_results.csv
+
 # make "display" versions of the results
 # i.e. number of decimal places is reduced to 3, and column order is changed so it's easier to read
 # with recs_per_sec moved from the back after mean followed by the rest of the stats columns
 
 # first - for benchmark_results_display.csv, move the recs_per_sec column after the
 # mean column using the `qsv select` command
-"$qsv_bin" select version,tstamp,name,mean,recs_per_sec,stddev,median,user,system,min,max \
+"$qsv_bin" select version,tstamp,name,mean,recs_per_sec,delta,rank,stddev,median,user,system,min,max \
   results/benchmark_results.csv -o results/benchmark_results_display.csv
 
 # then, round the stats columns to 3 decimal places using the `qsv apply operations round` command
@@ -1035,7 +1076,7 @@ mv results/results_work.csv results/benchmark_results.csv
 mv results/results_work.csv results/benchmark_results_display.csv
 
 # do the same for latest_results_display.csv
-"$qsv_bin" select version,tstamp,name,mean,recs_per_sec,stddev,median,user,system,min,max \
+"$qsv_bin" select version,tstamp,name,mean,recs_per_sec,delta,rank,stddev,median,user,system,min,max \
   results/latest_results.csv -o results/latest_results_display.csv
 "$qsv_benchmarker_bin" apply operations round mean,stddev,median,user,system,min,max \
   results/latest_results_display.csv -o results/results_work.csv

--- a/scripts/benchmarks.sh
+++ b/scripts/benchmarks.sh
@@ -141,6 +141,13 @@ if [[ "$benchmarker_version" != *"Luau"* ]]; then
   exit 1
 fi
 
+# check if the benchmarker_bin has the polars feature enabled
+if [[ "$benchmarker_version" != *"polars"* ]]; then
+  echo "ERROR: $qsv_benchmarker_bin does not have the polars feature enabled."
+  echo "The qsv sqlp command is needed to compute the delta & rank columns in the benchmark results."
+  exit 1
+fi
+
 # check if the benchmarker_bin has the to feature enabled
 if [[ "$benchmarker_version" != *"to;"* ]]; then
   # check if benchmark_data.xlsx exists
@@ -1031,7 +1038,9 @@ mv results/results_work.csv results/benchmark_results.csv
 # accrue. "user" is a reserved word in Polars SQL, so it is quoted as b."user". Base columns are
 # listed explicitly (not b.*) so re-runs whose input already has delta/rank drop them and
 # recompute cleanly, without duplicating columns.
-"$qsv_bin" sqlp results/benchmark_results.csv -q "
+# We dogfood the benchmarker binary (not the binary under test) for sqlp, since the binary
+# under test may be a variant without the polars feature (e.g. qsvlite).
+"$qsv_benchmarker_bin" sqlp results/benchmark_results.csv -q "
 with per_version as (
   select name, version, tstamp, mean,
          row_number() over (partition by name, version order by tstamp desc) as rn
@@ -1054,7 +1063,7 @@ mv results/results_work.csv results/benchmark_results.csv
 
 # re-derive latest_results.csv from the enriched archive so it too carries delta & rank
 # (total_mean was already captured above, so overwriting latest_results.csv here is safe)
-"$qsv_bin" sqlp results/benchmark_results.csv \
+"$qsv_benchmarker_bin" sqlp results/benchmark_results.csv \
   -q "select * from _t_1 where version = '$version' and tstamp = '$now'" \
   -o results/results_work.csv
 "$qsv_bin" sort --select version,tstamp,name results/results_work.csv \

--- a/scripts/results/README.md
+++ b/scripts/results/README.md
@@ -8,3 +8,5 @@ The benchmarks were performed on a million row, 41 column, 520 MB sample of NYC'
 Each benchmark is executed five times using hyperfine v1.18.0. Two warmup runs followed by three benchmark runs.
 
 Records per second is calculated by dividing the number of records (1M) by the mean of the three benchmark runs. All other measurements are in seconds.
+
+The `delta` column shows how much *faster* a benchmark is versus its previous qsv version, as a percentage of the previous version's mean run time (positive = faster, negative = a regression). It is empty when there is no earlier version to compare against. The `rank` column is the speed rank of a run among all recorded runs of the same benchmark (`1` = the fastest run ever recorded), ranked by mean run time.


### PR DESCRIPTION
## Summary

Adds two cross-version performance signals to the benchmark result CSVs produced by `scripts/benchmarks.sh`, computed by dogfooding `qsv sqlp` (Polars SQL) over the historical archive:

- **`delta`** — percent *faster* than the same benchmark's **previous version**: `((prev_version_mean - mean) / prev_version_mean) * 100`, rounded to 2 dp. Positive = faster, negative = regression. Empty when there is no earlier version to compare against.
- **`rank`** — speed rank of a run among **all recorded runs of the same benchmark** (`1` = fastest ever), ranked by `mean` run time ascending.

## How it works

After the current run is merged into `results/benchmark_results.csv`, a single `qsv sqlp` query recomputes both columns over the **whole** archive:

- The "previous version" is found with a CTE that collapses same-version re-runs to their latest run (`row_number()`), then `LAG(mean)` over distinct versions ordered chronologically by `tstamp`, self-joined back to every row of that version. (Versions are stored as strings like `21.1.0` and are not lexically sortable, so `tstamp` drives chronology.)
- `rank` uses `RANK() OVER (PARTITION BY name ORDER BY mean ASC)`.

Recomputing over the full archive every run is intentional: it **backfills** the columns for all pre-existing historical rows the first time, and is **idempotent** thereafter (base columns are projected explicitly, so prior `delta`/`rank` are dropped and recomputed rather than duplicated).

All four outputs carry the new columns — `latest_results.csv`, `benchmark_results.csv`, and both `*_display.csv` variants (display files place `delta,rank` right after `recs_per_sec`).

## Other changes

- Bumps the benchmark script version `9.2.0` → `9.3.0` (output schema change).
- Documents the two columns in `scripts/results/README.md`.

## Verification

Validated end-to-end against the live 12,998-row `benchmark_results.csv` (without running the full suite):

- Row count preserved (12,998); correct semantics (e.g. `apply_calcconv` latest = `delta 4.76`, `rank 52`; earliest-version rows have empty `delta`).
- Idempotent: re-running the enrichment on the already-enriched 13-column file reproduces exactly 13 columns.
- All four output files produced with correct headers and values.

Note: the full `./benchmarks.sh` run was not executed (it downloads a 520 MB dataset and runs the real suite); instead the exact post-benchmark data pipeline was simulated on real archive data, exercising every new/changed command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)