### PR TITLE
ci: migrate off Node 20 actions (actions-rs/*, mobiledevops/secret-to-file-action) (#4002)

### DIFF
--- a/.github/workflows/macOS-arm64-selfhosted-publish-nightly.yml
+++ b/.github/workflows/macOS-arm64-selfhosted-publish-nightly.yml
@@ -56,21 +56,17 @@ jobs:
     - name: Build qsv
       env:
         RUSTFLAGS: --emit=asm ${{ matrix.job.addl-rustflags }}
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        use-cross: ${{ matrix.job.use-cross }}
-        toolchain: ${{ matrix.rust }}
-        args: --profile ${{ contains(matrix.job.addl-build-args, 'luau') && 'release-luau' || 'release' }} --locked --bin qsv -Z build-std=std --target ${{ matrix.job.target }} ${{ matrix.job.addl-build-args }},feature_capable,nightly ${{ matrix.job.default-features }}
+      # actions-rs/cargo is archived/Node20-deprecated (qsv #4002); invoke cargo directly.
+      # `+${{ matrix.rust }}` pins the toolchain vs a stale per-directory rustup override on self-hosted runners.
+      shell: bash
+      run: cargo +${{ matrix.rust }} build --profile ${{ contains(matrix.job.addl-build-args, 'luau') && 'release-luau' || 'release' }} --locked --bin qsv -Z build-std=std --target ${{ matrix.job.target }} ${{ matrix.job.addl-build-args }},feature_capable,nightly ${{ matrix.job.default-features }}
     - name: Build qsvlite
       env:
         RUSTFLAGS: --emit=asm ${{ matrix.job.addl-rustflags }}
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        use-cross: ${{ matrix.job.use-cross }}
-        toolchain: ${{ matrix.rust }}
-        args: --release --locked --bin qsvlite -Z build-std=std --features=lite,self_update,nightly,${{ matrix.job.addl-qsvlite-features }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
+      # actions-rs/cargo is archived/Node20-deprecated (qsv #4002); invoke cargo directly.
+      # `+${{ matrix.rust }}` pins the toolchain vs a stale per-directory rustup override on self-hosted runners.
+      shell: bash
+      run: cargo +${{ matrix.rust }} build --release --locked --bin qsvlite -Z build-std=std --features=lite,self_update,nightly,${{ matrix.job.addl-qsvlite-features }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
     - name: Copy binaries to working dir
       # TODO: Add qsvdp-nightly build back in after v5.0.3, be sure to copy qsvdp binaries below
       shell: bash
@@ -94,12 +90,13 @@ jobs:
       run: |
         cargo install zipsign
     - name: Fetch zipsign private key
-      uses: mobiledevops/secret-to-file-action@v1
-      with:
-        base64-encoded-secret: ${{ secrets.QSV_ZIPSIGN_PRIV_KEY }}
-        filename: "qsvpriv.key"
-        is-executable: false
-        working-directory: "."
+      # replaces mobiledevops/secret-to-file-action (Node20-deprecated, qsv #4002):
+      # decode the base64 secret to qsvpriv.key. bash shell + `base64 -d` work on all
+      # runners (incl. Windows git-bash, macOS/BSD). Secret passed via env, not inlined.
+      shell: bash
+      env:
+        ZIPSIGN_KEY: ${{ secrets.QSV_ZIPSIGN_PRIV_KEY }}
+      run: printf '%s' "$ZIPSIGN_KEY" | base64 -d > qsvpriv.key
     - name: Download latest release zip
       uses: robinraju/release-downloader@v1.13
       with:

--- a/.github/workflows/macOS-arm64-selfhosted-publish-qsvpy.yml
+++ b/.github/workflows/macOS-arm64-selfhosted-publish-qsvpy.yml
@@ -57,12 +57,10 @@ jobs:
     - name: Build qsvpy311
       env:
         RUSTFLAGS: --emit=asm -C target-cpu=native
-      uses: actions-rs/cargo@v1
-      with:
-            command: build
-            use-cross: false
-            toolchain: ${{ matrix.rust }}
-            args: --profile ${{ contains(matrix.job.addl-build-args, 'luau') && 'release-luau' || 'release' }} --locked --bin qsv --target ${{ matrix.job.target }} ${{ matrix.job.addl-build-args }},feature_capable ${{ matrix.job.default-features }}
+      # actions-rs/cargo is archived/Node20-deprecated (qsv #4002); invoke cargo directly.
+      # `+${{ matrix.rust }}` pins the toolchain vs a stale per-directory rustup override on self-hosted runners.
+      shell: bash
+      run: cargo +${{ matrix.rust }} build --profile ${{ contains(matrix.job.addl-build-args, 'luau') && 'release-luau' || 'release' }} --locked --bin qsv --target ${{ matrix.job.target }} ${{ matrix.job.addl-build-args }},feature_capable ${{ matrix.job.default-features }}
     - name: Copy binaries to working dir
       shell: bash
       run: |
@@ -82,12 +80,10 @@ jobs:
     - name: Build qsvpy312
       env:
         RUSTFLAGS: --emit=asm -C target-cpu=native
-      uses: actions-rs/cargo@v1
-      with:
-            command: build
-            use-cross: false
-            toolchain: ${{ matrix.rust }}
-            args: --profile ${{ contains(matrix.job.addl-build-args, 'luau') && 'release-luau' || 'release' }} --locked --bin qsv --target ${{ matrix.job.target }} ${{ matrix.job.addl-build-args }},feature_capable ${{ matrix.job.default-features }}
+      # actions-rs/cargo is archived/Node20-deprecated (qsv #4002); invoke cargo directly.
+      # `+${{ matrix.rust }}` pins the toolchain vs a stale per-directory rustup override on self-hosted runners.
+      shell: bash
+      run: cargo +${{ matrix.rust }} build --profile ${{ contains(matrix.job.addl-build-args, 'luau') && 'release-luau' || 'release' }} --locked --bin qsv --target ${{ matrix.job.target }} ${{ matrix.job.addl-build-args }},feature_capable ${{ matrix.job.default-features }}
     - name: Copy binaries to working dir
       shell: bash
       run: |
@@ -106,12 +102,10 @@ jobs:
     - name: Build qsvpy313
       env:
         RUSTFLAGS: --emit=asm -C target-cpu=native
-      uses: actions-rs/cargo@v1
-      with:
-            command: build
-            use-cross: false
-            toolchain: ${{ matrix.rust }}
-            args: --profile ${{ contains(matrix.job.addl-build-args, 'luau') && 'release-luau' || 'release' }} --locked --bin qsv --target ${{ matrix.job.target }} ${{ matrix.job.addl-build-args }},feature_capable ${{ matrix.job.default-features }}
+      # actions-rs/cargo is archived/Node20-deprecated (qsv #4002); invoke cargo directly.
+      # `+${{ matrix.rust }}` pins the toolchain vs a stale per-directory rustup override on self-hosted runners.
+      shell: bash
+      run: cargo +${{ matrix.rust }} build --profile ${{ contains(matrix.job.addl-build-args, 'luau') && 'release-luau' || 'release' }} --locked --bin qsv --target ${{ matrix.job.target }} ${{ matrix.job.addl-build-args }},feature_capable ${{ matrix.job.default-features }}
     - name: Copy binaries to working dir
       shell: bash
       run: |
@@ -128,12 +122,13 @@ jobs:
       run: |
         cargo install zipsign
     - name: Fetch zipsign private key
-      uses: mobiledevops/secret-to-file-action@v1
-      with:
-          base64-encoded-secret: ${{ secrets.QSV_ZIPSIGN_PRIV_KEY }}
-          filename: "qsvpriv.key"
-          is-executable: false
-          working-directory: "."
+      # replaces mobiledevops/secret-to-file-action (Node20-deprecated, qsv #4002):
+      # decode the base64 secret to qsvpriv.key. bash shell + `base64 -d` work on all
+      # runners (incl. Windows git-bash, macOS/BSD). Secret passed via env, not inlined.
+      shell: bash
+      env:
+        ZIPSIGN_KEY: ${{ secrets.QSV_ZIPSIGN_PRIV_KEY }}
+      run: printf '%s' "$ZIPSIGN_KEY" | base64 -d > qsvpriv.key
     - name: Download latest release zip
       uses: robinraju/release-downloader@v1.13
       with:

--- a/.github/workflows/macOS-arm64-selfhosted-publish.yml
+++ b/.github/workflows/macOS-arm64-selfhosted-publish.yml
@@ -78,22 +78,18 @@ jobs:
     - name: Build qsvlite
       env:
         RUSTFLAGS: --emit=asm -C target-cpu=native
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        use-cross: ${{ matrix.job.use-cross }}
-        toolchain: ${{ matrix.rust }}
-        args: --release --locked --bin qsvlite --features=lite,self_update,${{ matrix.job.addl-qsvlite-features }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
+      # actions-rs/cargo is archived/Node20-deprecated (qsv #4002); invoke cargo directly.
+      # `+${{ matrix.rust }}` pins the toolchain vs a stale per-directory rustup override on self-hosted runners.
+      shell: bash
+      run: cargo +${{ matrix.rust }} build --release --locked --bin qsvlite --features=lite,self_update,${{ matrix.job.addl-qsvlite-features }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
     # qsvdp (datapusher_plus) is a Linux deployment helper — not built/shipped for macOS.
     - name: Build qsvmcp
       env:
         RUSTFLAGS: --emit=asm -C target-cpu=native
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        use-cross: ${{ matrix.job.use-cross }}
-        toolchain: ${{ matrix.rust }}
-        args: --release --locked --bin qsvmcp --features=qsvmcp --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
+      # actions-rs/cargo is archived/Node20-deprecated (qsv #4002); invoke cargo directly.
+      # `+${{ matrix.rust }}` pins the toolchain vs a stale per-directory rustup override on self-hosted runners.
+      shell: bash
+      run: cargo +${{ matrix.rust }} build --release --locked --bin qsvmcp --features=qsvmcp --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
     - name: Copy binaries to working dir
       shell: bash
       run: |
@@ -115,12 +111,13 @@ jobs:
       run: |
         cargo install zipsign
     - name: Fetch zipsign private key
-      uses: mobiledevops/secret-to-file-action@v1
-      with:
-        base64-encoded-secret: ${{ secrets.QSV_ZIPSIGN_PRIV_KEY }}
-        filename: "qsvpriv.key"
-        is-executable: false
-        working-directory: "."
+      # replaces mobiledevops/secret-to-file-action (Node20-deprecated, qsv #4002):
+      # decode the base64 secret to qsvpriv.key. bash shell + `base64 -d` work on all
+      # runners (incl. Windows git-bash, macOS/BSD). Secret passed via env, not inlined.
+      shell: bash
+      env:
+        ZIPSIGN_KEY: ${{ secrets.QSV_ZIPSIGN_PRIV_KEY }}
+      run: printf '%s' "$ZIPSIGN_KEY" | base64 -d > qsvpriv.key
     - name: zipsign binary
       run: |
         zipsign sign zip qsv-${{ needs.analyze-tags.outputs.previous-tag }}-${{ matrix.job.target }}.zip qsvpriv.key

--- a/.github/workflows/publish-aarch64-pc-windows-msvc.yml
+++ b/.github/workflows/publish-aarch64-pc-windows-msvc.yml
@@ -61,21 +61,17 @@ jobs:
       #   RUSTFLAGS: --emit=asm
       env:
         RUSTFLAGS: ${{ matrix.job.addl-rustflags }}
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        use-cross: ${{ matrix.job.use-cross }}
-        toolchain: ${{ matrix.rust }}
-        args: --profile ${{ contains(matrix.job.addl-build-args, 'luau') && 'release-luau' || 'release' }} --locked --bin qsv --target ${{ matrix.job.target }} ${{ matrix.job.addl-build-args }},feature_capable ${{ matrix.job.default-features }}
+      # actions-rs/cargo is archived/Node20-deprecated (qsv #4002); invoke cargo directly.
+      # `+${{ matrix.rust }}` pins the toolchain vs a stale per-directory rustup override on self-hosted runners.
+      shell: bash
+      run: cargo +${{ matrix.rust }} build --profile ${{ contains(matrix.job.addl-build-args, 'luau') && 'release-luau' || 'release' }} --locked --bin qsv --target ${{ matrix.job.target }} ${{ matrix.job.addl-build-args }},feature_capable ${{ matrix.job.default-features }}
     - name: Build qsvlite
       env:
         RUSTFLAGS: --emit=asm ${{ matrix.job.addl-rustflags }}
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        use-cross: ${{ matrix.job.use-cross }}
-        toolchain: ${{ matrix.rust }}
-        args: --release --locked --bin qsvlite --features=lite,self_update,${{ matrix.job.addl-qsvlite-features }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
+      # actions-rs/cargo is archived/Node20-deprecated (qsv #4002); invoke cargo directly.
+      # `+${{ matrix.rust }}` pins the toolchain vs a stale per-directory rustup override on self-hosted runners.
+      shell: bash
+      run: cargo +${{ matrix.rust }} build --release --locked --bin qsvlite --features=lite,self_update,${{ matrix.job.addl-qsvlite-features }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
     - name: Copy binaries to working dir
       shell: bash
       run: |
@@ -91,12 +87,13 @@ jobs:
       run: |
         cargo install zipsign
     - name: Fetch zipsign private key
-      uses: mobiledevops/secret-to-file-action@v1
-      with:
-        base64-encoded-secret: ${{ secrets.QSV_ZIPSIGN_PRIV_KEY }}
-        filename: "qsvpriv.key"
-        is-executable: false
-        working-directory: "."        
+      # replaces mobiledevops/secret-to-file-action (Node20-deprecated, qsv #4002):
+      # decode the base64 secret to qsvpriv.key. bash shell + `base64 -d` work on all
+      # runners (incl. Windows git-bash, macOS/BSD). Secret passed via env, not inlined.
+      shell: bash
+      env:
+        ZIPSIGN_KEY: ${{ secrets.QSV_ZIPSIGN_PRIV_KEY }}
+      run: printf '%s' "$ZIPSIGN_KEY" | base64 -d > qsvpriv.key
     - name: zipsign binary
       run: |
         zipsign sign zip qsv-${{ needs.analyze-tags.outputs.previous-tag }}-${{ matrix.job.target }}.zip qsvpriv.key

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -73,46 +73,34 @@ jobs:
     - uses: actions/setup-python@v6.2.0
       with:
         python-version: '3.13'
+    # actions-rs/cargo is archived/Node20-deprecated (qsv #4002), so invoke cargo directly.
+    # All targets here build with plain cargo (no use-cross: true), so the cross/cargo
+    # conditional is unneeded. `+${{ matrix.rust }}` pins the toolchain to guard against a
+    # stale per-directory rustup override on self-hosted runners.
     - name: Build qsv-nightly
       # env:
       #   RUSTFLAGS: --emit=asm
       env:
         RUSTFLAGS: ${{ matrix.job.addl-rustflags }}
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        use-cross: false
-        toolchain: ${{ matrix.rust }}
-        args: --profile ${{ contains(matrix.job.addl-build-args, 'luau') && 'release-luau' || 'release' }} --bin qsv -Z build-std=std --target ${{ matrix.job.target }} ${{ matrix.job.addl-build-args }},feature_capable,nightly ${{ matrix.job.default-features }}
+      shell: bash
+      run: cargo +${{ matrix.rust }} build --profile ${{ contains(matrix.job.addl-build-args, 'luau') && 'release-luau' || 'release' }} --bin qsv -Z build-std=std --target ${{ matrix.job.target }} ${{ matrix.job.addl-build-args }},feature_capable,nightly ${{ matrix.job.default-features }}
     - name: Build qsvlite-nightly
       env:
         RUSTFLAGS: --emit=asm ${{ matrix.job.addl-rustflags }}
-      uses: actions-rs/cargo@v1   
-      with:
-        command: build
-        use-cross: false
-        toolchain: ${{ matrix.rust }}
-        args: --release --bin qsvlite -Z build-std=std --features=lite,self_update,nightly,${{ matrix.job.addl-qsvlite-features }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
+      shell: bash
+      run: cargo +${{ matrix.rust }} build --release --bin qsvlite -Z build-std=std --features=lite,self_update,nightly,${{ matrix.job.addl-qsvlite-features }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
     - name: Build qsvmcp-nightly
       if: ${{ matrix.job.target != 'x86_64-unknown-linux-musl' }}
       env:
         RUSTFLAGS: --emit=asm ${{ matrix.job.addl-rustflags }}
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        use-cross: false
-        toolchain: ${{ matrix.rust }}
-        args: --release --bin qsvmcp -Z build-std=std ${{ matrix.job.addl-qsvlite-features != '' && format('--features=qsvmcp,nightly,{0}', matrix.job.addl-qsvlite-features) || '--features=qsvmcp,nightly' }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
+      shell: bash
+      run: cargo +${{ matrix.rust }} build --release --bin qsvmcp -Z build-std=std ${{ matrix.job.addl-qsvlite-features != '' && format('--features=qsvmcp,nightly,{0}', matrix.job.addl-qsvlite-features) || '--features=qsvmcp,nightly' }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
     # TODO: Add qsvdp-nightly build back in after v5.0.3, be sure to copy qsvdp binaries below
     # - name: Build qsvdp-nightly
     #   env:
     #     RUSTFLAGS: --emit=asm ${{ matrix.job.addl-rustflags }}
-    #   uses: actions-rs/cargo@v1
-    #   with:
-    #     command: build
-    #     use-cross: false
-    #     toolchain: ${{ matrix.rust }}
-    #     args: --release --bin qsvdp -Z build-std=std -Z unstable-options --features=datapusher_plus,nightly,${{ matrix.job.addl-qsvdp-features }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
+    #   shell: bash
+    #   run: cargo +${{ matrix.rust }} build --release --bin qsvdp -Z build-std=std -Z unstable-options --features=datapusher_plus,nightly,${{ matrix.job.addl-qsvdp-features }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
     - name: Copy binaries to working dir
       shell: bash
       run: |
@@ -138,12 +126,13 @@ jobs:
       run: |
         cargo install zipsign
     - name: Fetch zipsign private key
-      uses: mobiledevops/secret-to-file-action@v1
-      with:
-        base64-encoded-secret: ${{ secrets.QSV_ZIPSIGN_PRIV_KEY }}
-        filename: "qsvpriv.key"
-        is-executable: false
-        working-directory: "."
+      # replaces mobiledevops/secret-to-file-action (Node20-deprecated, qsv #4002):
+      # decode the base64 secret to qsvpriv.key. bash shell + `base64 -d` work on all
+      # runners (incl. Windows git-bash, macOS/BSD). Secret passed via env, not inlined.
+      shell: bash
+      env:
+        ZIPSIGN_KEY: ${{ secrets.QSV_ZIPSIGN_PRIV_KEY }}
+      run: printf '%s' "$ZIPSIGN_KEY" | base64 -d > qsvpriv.key
     - name: Download latest release zip
       uses: robinraju/release-downloader@v1.13
       with:

--- a/.github/workflows/publish-portable.yml
+++ b/.github/workflows/publish-portable.yml
@@ -157,26 +157,30 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install libwayland-dev
+    # actions-rs/cargo (archived/Node20-deprecated, qsv #4002) auto-installed `cross` when
+    # use-cross was true; invoking cargo/cross directly means we must install cross ourselves
+    # for the cross-compiled target(s) (currently aarch64-unknown-linux-gnu).
+    - name: Install cross
+      if: ${{ matrix.job.use-cross == true }}
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cross
     - name: Build qsv
       # env:
       #   RUSTFLAGS: --emit=asm
       env:
         RUSTFLAGS: ${{ matrix.job.addl-rustflags }}
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        use-cross: ${{ matrix.job.use-cross }}
-        toolchain: ${{ matrix.rust }}
-        args: --profile ${{ contains(matrix.job.addl-build-args, 'luau') && 'release-luau' || 'release' }} --locked --bin qsv --target ${{ matrix.job.target }} ${{ matrix.job.addl-build-args }},feature_capable ${{ matrix.job.default-features }}
+      # actions-rs/cargo is archived/Node20-deprecated (qsv #4002); invoke cargo/cross directly.
+      # Pick cross for use-cross targets (see Install cross above); +${{ matrix.rust }} pins the toolchain.
+      shell: bash
+      run: ${{ matrix.job.use-cross == true && 'cross' || 'cargo' }} +${{ matrix.rust }} build --profile ${{ contains(matrix.job.addl-build-args, 'luau') && 'release-luau' || 'release' }} --locked --bin qsv --target ${{ matrix.job.target }} ${{ matrix.job.addl-build-args }},feature_capable ${{ matrix.job.default-features }}
     - name: Build qsvlite
       env:
         RUSTFLAGS: --emit=asm ${{ matrix.job.addl-rustflags }}
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        use-cross: ${{ matrix.job.use-cross }}
-        toolchain: ${{ matrix.rust }}
-        args: --release --locked --bin qsvlite --features=lite,self_update,${{ matrix.job.addl-qsvlite-features }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
+      # actions-rs/cargo is archived/Node20-deprecated (qsv #4002); invoke cargo/cross directly.
+      # Pick cross for use-cross targets (see Install cross above); +${{ matrix.rust }} pins the toolchain.
+      shell: bash
+      run: ${{ matrix.job.use-cross == true && 'cross' || 'cargo' }} +${{ matrix.rust }} build --release --locked --bin qsvlite --features=lite,self_update,${{ matrix.job.addl-qsvlite-features }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
     - name: Build qsvdp
       # qsvdp (datapusher_plus) is a Linux deployment helper, so only build it for x86_64
       # Linux. Skip aarch64-unknown-linux-gnu (its Polars fat-LTO link exhausts the runner)
@@ -184,22 +188,18 @@ jobs:
       if: ${{ matrix.job.target != 'aarch64-unknown-linux-gnu' && matrix.job.os-name == 'linux' }}
       env:
         RUSTFLAGS: --emit=asm ${{ matrix.job.addl-rustflags }}
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        use-cross: ${{ matrix.job.use-cross }}
-        toolchain: ${{ matrix.rust }}
-        args: --release --locked --bin qsvdp --features=datapusher_plus,${{ matrix.job.addl-qsvdp-features }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
+      # actions-rs/cargo is archived/Node20-deprecated (qsv #4002); invoke cargo/cross directly.
+      # Pick cross for use-cross targets (see Install cross above); +${{ matrix.rust }} pins the toolchain.
+      shell: bash
+      run: ${{ matrix.job.use-cross == true && 'cross' || 'cargo' }} +${{ matrix.rust }} build --release --locked --bin qsvdp --features=datapusher_plus,${{ matrix.job.addl-qsvdp-features }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
     - name: Build qsvmcp
       if: ${{ matrix.job.target != 'x86_64-unknown-linux-musl' && matrix.job.target != 'aarch64-unknown-linux-gnu' }}
       env:
         RUSTFLAGS: ${{ matrix.job.addl-rustflags }}
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        use-cross: ${{ matrix.job.use-cross }}
-        toolchain: ${{ matrix.rust }}
-        args: --release --locked --bin qsvmcp ${{ matrix.job.addl-qsvlite-features != '' && format('--features=qsvmcp,{0}', matrix.job.addl-qsvlite-features) || '--features=qsvmcp' }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
+      # actions-rs/cargo is archived/Node20-deprecated (qsv #4002); invoke cargo/cross directly.
+      # Pick cross for use-cross targets (see Install cross above); +${{ matrix.rust }} pins the toolchain.
+      shell: bash
+      run: ${{ matrix.job.use-cross == true && 'cross' || 'cargo' }} +${{ matrix.rust }} build --release --locked --bin qsvmcp ${{ matrix.job.addl-qsvlite-features != '' && format('--features=qsvmcp,{0}', matrix.job.addl-qsvlite-features) || '--features=qsvmcp' }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
     - name: Copy binaries to working dir
       shell: bash
       run: |
@@ -225,12 +225,13 @@ jobs:
       run: |
         cargo install zipsign
     - name: Fetch zipsign private key
-      uses: mobiledevops/secret-to-file-action@v1
-      with:
-        base64-encoded-secret: ${{ secrets.QSV_ZIPSIGN_PRIV_KEY }}
-        filename: "qsvpriv.key"
-        is-executable: false
-        working-directory: "."
+      # replaces mobiledevops/secret-to-file-action (Node20-deprecated, qsv #4002):
+      # decode the base64 secret to qsvpriv.key. bash shell + `base64 -d` work on all
+      # runners (incl. Windows git-bash, macOS/BSD). Secret passed via env, not inlined.
+      shell: bash
+      env:
+        ZIPSIGN_KEY: ${{ secrets.QSV_ZIPSIGN_PRIV_KEY }}
+      run: printf '%s' "$ZIPSIGN_KEY" | base64 -d > qsvpriv.key
     - name: Download latest release zip
       uses: robinraju/release-downloader@v1.13
       with:

--- a/.github/workflows/publish-powerpc64le-unknown-linux-gnu.yml
+++ b/.github/workflows/publish-powerpc64le-unknown-linux-gnu.yml
@@ -61,27 +61,22 @@ jobs:
     - name: Build qsv
       env:
         RUSTFLAGS: --emit=asm ${{ matrix.job.addl-rustflags }} -C target-cpu=native
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        toolchain: ${{ matrix.rust }}
-        args: --profile ${{ contains(matrix.job.addl-build-args, 'luau') && 'release-luau' || 'release' }} --locked --bin qsv --target ${{ matrix.job.target }} ${{ matrix.job.addl-build-args }},feature_capable ${{ matrix.job.default-features }}
+      # actions-rs/cargo is archived/Node20-deprecated (qsv #4002); invoke cargo directly.
+      # `+${{ matrix.rust }}` pins the toolchain vs a stale per-directory rustup override on self-hosted runners.
+      shell: bash
+      run: cargo +${{ matrix.rust }} build --profile ${{ contains(matrix.job.addl-build-args, 'luau') && 'release-luau' || 'release' }} --locked --bin qsv --target ${{ matrix.job.target }} ${{ matrix.job.addl-build-args }},feature_capable ${{ matrix.job.default-features }}
     - name: Build qsvlite
       env:
         RUSTFLAGS: --emit=asm ${{ matrix.job.addl-rustflags }} -C target-cpu=native
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        toolchain: ${{ matrix.rust }}
-        args: --release --locked --bin qsvlite --features=lite,self_update,${{ matrix.job.addl-qsvlite-features }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
+      # actions-rs/cargo is archived/Node20-deprecated (qsv #4002); invoke cargo directly.
+      # `+${{ matrix.rust }}` pins the toolchain vs a stale per-directory rustup override on self-hosted runners.
+      shell: bash
+      run: cargo +${{ matrix.rust }} build --release --locked --bin qsvlite --features=lite,self_update,${{ matrix.job.addl-qsvlite-features }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
     # - name: Build qsvdp
     #   env:
     #     RUSTFLAGS: --emit=asm ${{ matrix.job.addl-rustflags }} -C target-cpu=native
-    #   uses: actions-rs/cargo@v1
-    #   with:
-    #     command: build
-    #     toolchain: ${{ matrix.rust }}
-    #     args: --release --locked --bin qsvdp --features=datapusher_plus,${{ matrix.job.addl-qsvdp-features }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
+    #   shell: bash
+    #   run: cargo +${{ matrix.rust }} build --release --locked --bin qsvdp --features=datapusher_plus,${{ matrix.job.addl-qsvdp-features }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
     - name: Copy binaries to working dir
       shell: bash
       run: |
@@ -101,12 +96,13 @@ jobs:
       run: |
         cargo install zipsign
     - name: Fetch zipsign private key
-      uses: mobiledevops/secret-to-file-action@v1
-      with:
-        base64-encoded-secret: ${{ secrets.QSV_ZIPSIGN_PRIV_KEY }}
-        filename: "qsvpriv.key"
-        is-executable: false
-        working-directory: "."        
+      # replaces mobiledevops/secret-to-file-action (Node20-deprecated, qsv #4002):
+      # decode the base64 secret to qsvpriv.key. bash shell + `base64 -d` work on all
+      # runners (incl. Windows git-bash, macOS/BSD). Secret passed via env, not inlined.
+      shell: bash
+      env:
+        ZIPSIGN_KEY: ${{ secrets.QSV_ZIPSIGN_PRIV_KEY }}
+      run: printf '%s' "$ZIPSIGN_KEY" | base64 -d > qsvpriv.key
     - name: zipsign binary
       run: |
         zipsign sign zip qsv-${{ needs.analyze-tags.outputs.previous-tag }}-${{ matrix.job.target }}.zip qsvpriv.key

--- a/.github/workflows/publish-qsvpy.yml
+++ b/.github/workflows/publish-qsvpy.yml
@@ -98,12 +98,10 @@ jobs:
         #   RUSTFLAGS: --emit=asm
       env:
         RUSTFLAGS: ${{ matrix.job.addl-rustflags }}
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        use-cross: false
-        toolchain: ${{ matrix.rust }}
-        args: --profile ${{ contains(matrix.job.addl-build-args, 'luau') && 'release-luau' || 'release' }} --locked --bin qsv --target ${{ matrix.job.target }} ${{ matrix.job.addl-build-args }},feature_capable ${{ matrix.job.default-features }}
+      # actions-rs/cargo is archived/Node20-deprecated (qsv #4002); invoke cargo directly.
+      # `+${{ matrix.rust }}` pins the toolchain vs a stale per-directory rustup override on self-hosted runners.
+      shell: bash
+      run: cargo +${{ matrix.rust }} build --profile ${{ contains(matrix.job.addl-build-args, 'luau') && 'release-luau' || 'release' }} --locked --bin qsv --target ${{ matrix.job.target }} ${{ matrix.job.addl-build-args }},feature_capable ${{ matrix.job.default-features }}
     - name: Copy binaries to working dir
       shell: bash
       run: |
@@ -129,12 +127,10 @@ jobs:
         #   RUSTFLAGS: --emit=asm
       env:
         RUSTFLAGS: ${{ matrix.job.addl-rustflags }}
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        use-cross: false
-        toolchain: ${{ matrix.rust }}
-        args: --profile ${{ contains(matrix.job.addl-build-args, 'luau') && 'release-luau' || 'release' }} --locked --bin qsv --target ${{ matrix.job.target }} ${{ matrix.job.addl-build-args }},feature_capable ${{ matrix.job.default-features }}
+      # actions-rs/cargo is archived/Node20-deprecated (qsv #4002); invoke cargo directly.
+      # `+${{ matrix.rust }}` pins the toolchain vs a stale per-directory rustup override on self-hosted runners.
+      shell: bash
+      run: cargo +${{ matrix.rust }} build --profile ${{ contains(matrix.job.addl-build-args, 'luau') && 'release-luau' || 'release' }} --locked --bin qsv --target ${{ matrix.job.target }} ${{ matrix.job.addl-build-args }},feature_capable ${{ matrix.job.default-features }}
     - name: Copy binaries to working dir
       shell: bash
       run: |
@@ -160,12 +156,10 @@ jobs:
         #   RUSTFLAGS: --emit=asm
       env:
         RUSTFLAGS: ${{ matrix.job.addl-rustflags }}
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        use-cross: false
-        toolchain: ${{ matrix.rust }}
-        args: --profile ${{ contains(matrix.job.addl-build-args, 'luau') && 'release-luau' || 'release' }} --locked --bin qsv --target ${{ matrix.job.target }} ${{ matrix.job.addl-build-args }},feature_capable ${{ matrix.job.default-features }}
+      # actions-rs/cargo is archived/Node20-deprecated (qsv #4002); invoke cargo directly.
+      # `+${{ matrix.rust }}` pins the toolchain vs a stale per-directory rustup override on self-hosted runners.
+      shell: bash
+      run: cargo +${{ matrix.rust }} build --profile ${{ contains(matrix.job.addl-build-args, 'luau') && 'release-luau' || 'release' }} --locked --bin qsv --target ${{ matrix.job.target }} ${{ matrix.job.addl-build-args }},feature_capable ${{ matrix.job.default-features }}
     - name: Copy binaries to working dir
       shell: bash
       run: |
@@ -187,12 +181,13 @@ jobs:
       run: |
         cargo install zipsign
     - name: Fetch zipsign private key
-      uses: mobiledevops/secret-to-file-action@v1
-      with:
-        base64-encoded-secret: ${{ secrets.QSV_ZIPSIGN_PRIV_KEY }}
-        filename: "qsvpriv.key"
-        is-executable: false
-        working-directory: "."
+      # replaces mobiledevops/secret-to-file-action (Node20-deprecated, qsv #4002):
+      # decode the base64 secret to qsvpriv.key. bash shell + `base64 -d` work on all
+      # runners (incl. Windows git-bash, macOS/BSD). Secret passed via env, not inlined.
+      shell: bash
+      env:
+        ZIPSIGN_KEY: ${{ secrets.QSV_ZIPSIGN_PRIV_KEY }}
+      run: printf '%s' "$ZIPSIGN_KEY" | base64 -d > qsvpriv.key
     - name: Download latest release zip
       uses: robinraju/release-downloader@v1.13
       with:

--- a/.github/workflows/publish-s390x-unknown-linux-gnu.yml
+++ b/.github/workflows/publish-s390x-unknown-linux-gnu.yml
@@ -70,27 +70,22 @@ jobs:
     - name: Build qsv
       env:
         RUSTFLAGS: --emit=asm ${{ matrix.job.addl-rustflags }} -C target-cpu=native
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        toolchain: ${{ matrix.rust }}
-        args: --profile ${{ contains(matrix.job.addl-build-args, 'luau') && 'release-luau' || 'release' }} --locked --bin qsv --target ${{ matrix.job.target }} ${{ matrix.job.addl-build-args }},feature_capable ${{ matrix.job.default-features }}
+      # actions-rs/cargo is archived/Node20-deprecated (qsv #4002); invoke cargo directly.
+      # `+${{ matrix.rust }}` pins the toolchain vs a stale per-directory rustup override on self-hosted runners.
+      shell: bash
+      run: cargo +${{ matrix.rust }} build --profile ${{ contains(matrix.job.addl-build-args, 'luau') && 'release-luau' || 'release' }} --locked --bin qsv --target ${{ matrix.job.target }} ${{ matrix.job.addl-build-args }},feature_capable ${{ matrix.job.default-features }}
     - name: Build qsvlite
       env:
         RUSTFLAGS: --emit=asm ${{ matrix.job.addl-rustflags }} -C target-cpu=native
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        toolchain: ${{ matrix.rust }}
-        args: --release --locked --bin qsvlite --features=lite,self_update,${{ matrix.job.addl-qsvlite-features }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
+      # actions-rs/cargo is archived/Node20-deprecated (qsv #4002); invoke cargo directly.
+      # `+${{ matrix.rust }}` pins the toolchain vs a stale per-directory rustup override on self-hosted runners.
+      shell: bash
+      run: cargo +${{ matrix.rust }} build --release --locked --bin qsvlite --features=lite,self_update,${{ matrix.job.addl-qsvlite-features }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
     # - name: Build qsvdp
     #   env:
     #     RUSTFLAGS: --emit=asm ${{ matrix.job.addl-rustflags }} -C target-cpu=native
-    #   uses: actions-rs/cargo@v1
-    #   with:
-    #     command: build
-    #     toolchain: ${{ matrix.rust }}
-    #     args: --release --locked --bin qsvdp --features=datapusher_plus,${{ matrix.job.addl-qsvdp-features }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
+    #   shell: bash
+    #   run: cargo +${{ matrix.rust }} build --release --locked --bin qsvdp --features=datapusher_plus,${{ matrix.job.addl-qsvdp-features }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
     - name: Copy binaries to working dir
       shell: bash
       run: |
@@ -110,12 +105,13 @@ jobs:
       run: |
         cargo install zipsign
     - name: Fetch zipsign private key
-      uses: mobiledevops/secret-to-file-action@v1
-      with:
-        base64-encoded-secret: ${{ secrets.QSV_ZIPSIGN_PRIV_KEY }}
-        filename: "qsvpriv.key"
-        is-executable: false
-        working-directory: "."        
+      # replaces mobiledevops/secret-to-file-action (Node20-deprecated, qsv #4002):
+      # decode the base64 secret to qsvpriv.key. bash shell + `base64 -d` work on all
+      # runners (incl. Windows git-bash, macOS/BSD). Secret passed via env, not inlined.
+      shell: bash
+      env:
+        ZIPSIGN_KEY: ${{ secrets.QSV_ZIPSIGN_PRIV_KEY }}
+      run: printf '%s' "$ZIPSIGN_KEY" | base64 -d > qsvpriv.key
     - name: zipsign binary
       run: |
         zipsign sign zip qsv-${{ needs.analyze-tags.outputs.previous-tag }}-${{ matrix.job.target }}.zip qsvpriv.key

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -231,27 +231,23 @@ jobs:
         export QSV_FEATURES="${ADDL_BUILD_ARGS#--features=}"
         chmod +x scripts/build-pgo.sh scripts/pgo-train.sh
         ./scripts/build-pgo.sh
+    # actions-rs/cargo is archived/Node20-deprecated (qsv #4002), so invoke cargo directly.
+    # All active targets in this workflow build with plain cargo (no use-cross: true), so the
+    # cross/cargo conditional is unneeded here. `+${{ matrix.rust }}` pins the toolchain to
+    # guard against a stale per-directory rustup override on self-hosted runners (see note above).
     - name: Build qsv (normal)
       if: ${{ !matrix.job.pgo }}
       # env:
       #   RUSTFLAGS: --emit=asm
       env:
         RUSTFLAGS: ${{ matrix.job.addl-rustflags }}
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        use-cross: ${{ matrix.job.use-cross }}
-        toolchain: ${{ matrix.rust }}
-        args: --profile ${{ contains(matrix.job.addl-build-args, 'luau') && 'release-luau' || 'release' }} --locked --bin qsv --target ${{ matrix.job.target }} ${{ matrix.job.addl-build-args }},feature_capable ${{ matrix.job.default-features }}
+      shell: bash
+      run: cargo +${{ matrix.rust }} build --profile ${{ contains(matrix.job.addl-build-args, 'luau') && 'release-luau' || 'release' }} --locked --bin qsv --target ${{ matrix.job.target }} ${{ matrix.job.addl-build-args }},feature_capable ${{ matrix.job.default-features }}
     - name: Build qsvlite
       env:
         RUSTFLAGS: --emit=asm ${{ matrix.job.addl-rustflags }}
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        use-cross: ${{ matrix.job.use-cross }}
-        toolchain: ${{ matrix.rust }}
-        args: --release --locked --bin qsvlite --features=lite,self_update,${{ matrix.job.addl-qsvlite-features }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
+      shell: bash
+      run: cargo +${{ matrix.rust }} build --release --locked --bin qsvlite --features=lite,self_update,${{ matrix.job.addl-qsvlite-features }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
     - name: Build qsvdp
       # qsvdp (datapusher_plus) is a Linux deployment helper, so only build it for x86_64
       # Linux. Skip aarch64-unknown-linux-gnu (its Polars fat-LTO link OOM-kills the hosted
@@ -259,22 +255,14 @@ jobs:
       if: ${{ matrix.job.target != 'aarch64-unknown-linux-gnu' && matrix.job.os-name == 'linux' }}
       env:
         RUSTFLAGS: --emit=asm ${{ matrix.job.addl-rustflags }}
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        use-cross: ${{ matrix.job.use-cross }}
-        toolchain: ${{ matrix.rust }}
-        args: --release --locked --bin qsvdp --features=datapusher_plus,${{ matrix.job.addl-qsvdp-features }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
+      shell: bash
+      run: cargo +${{ matrix.rust }} build --release --locked --bin qsvdp --features=datapusher_plus,${{ matrix.job.addl-qsvdp-features }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
     - name: Build qsvmcp
       if: ${{ matrix.job.target != 'x86_64-unknown-linux-musl' && matrix.job.target != 'aarch64-unknown-linux-gnu' }}
       env:
         RUSTFLAGS: --emit=asm ${{ matrix.job.addl-rustflags }}
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        use-cross: ${{ matrix.job.use-cross }}
-        toolchain: ${{ matrix.rust }}
-        args: --release --locked --bin qsvmcp ${{ matrix.job.addl-qsvlite-features != '' && format('--features=qsvmcp,{0}', matrix.job.addl-qsvlite-features) || '--features=qsvmcp' }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
+      shell: bash
+      run: cargo +${{ matrix.rust }} build --release --locked --bin qsvmcp ${{ matrix.job.addl-qsvlite-features != '' && format('--features=qsvmcp,{0}', matrix.job.addl-qsvlite-features) || '--features=qsvmcp' }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
     - name: Copy binaries to working dir
       shell: bash
       run: |
@@ -294,12 +282,13 @@ jobs:
       run: |
         cargo install zipsign
     - name: Fetch zipsign private key
-      uses: mobiledevops/secret-to-file-action@v1
-      with:
-        base64-encoded-secret: ${{ secrets.QSV_ZIPSIGN_PRIV_KEY }}
-        filename: "qsvpriv.key"
-        is-executable: false
-        working-directory: "."        
+      # replaces mobiledevops/secret-to-file-action (Node20-deprecated, qsv #4002):
+      # decode the base64 secret to qsvpriv.key. bash shell + `base64 -d` work on all
+      # runners (incl. Windows git-bash, macOS/BSD). Secret passed via env, not inlined.
+      shell: bash
+      env:
+        ZIPSIGN_KEY: ${{ secrets.QSV_ZIPSIGN_PRIV_KEY }}
+      run: printf '%s' "$ZIPSIGN_KEY" | base64 -d > qsvpriv.key
     - name: zipsign binary
       run: |
         zipsign sign zip qsv-${{ needs.analyze-tags.outputs.previous-tag }}-${{ matrix.job.target }}.zip qsvpriv.key

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -26,10 +26,6 @@ jobs:
         rustup default nightly
         rustup component add rustfmt
         rustup update
+    # actions-rs/cargo is archived/Node20-deprecated (qsv #4002), so invoke cargo directly.
     - name: Check formatting
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        toolchain: nightly
-        use-cross: false
-        args: -- --check
+      run: cargo +nightly fmt -- --check

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -11,6 +11,8 @@ jobs:
       - uses: actions/checkout@v6
       - name: Update Rust
         run: rustup update 
-      - uses: actions-rs/audit-check@v1
+      # actions-rs/audit-check is archived/Node20-deprecated (qsv #4002);
+      # rustsec/audit-check@v2 is the maintained Node24 successor.
+      - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-publish-nightly.yml
+++ b/.github/workflows/test-publish-nightly.yml
@@ -77,30 +77,24 @@ jobs:
     - name: Build qsv-nightly
       env:
         RUSTFLAGS: --emit=asm
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        use-cross: false
-        toolchain: ${{ matrix.rust }}
-        args: --profile ${{ contains(matrix.job.addl-build-args, 'luau') && 'release-luau' || 'release' }} --bin qsv -Z build-std=std --target ${{ matrix.job.target }} ${{ matrix.job.addl-build-args }},feature_capable ${{ matrix.job.default-features }}
+      # actions-rs/cargo is archived/Node20-deprecated (qsv #4002); invoke cargo directly.
+      # `+${{ matrix.rust }}` pins the toolchain vs a stale per-directory rustup override on self-hosted runners.
+      shell: bash
+      run: cargo +${{ matrix.rust }} build --profile ${{ contains(matrix.job.addl-build-args, 'luau') && 'release-luau' || 'release' }} --bin qsv -Z build-std=std --target ${{ matrix.job.target }} ${{ matrix.job.addl-build-args }},feature_capable ${{ matrix.job.default-features }}
     - name: Build qsvlite-nightly
       env:
         RUSTFLAGS: --emit=asm
-      uses: actions-rs/cargo@v1   
-      with:
-        command: build
-        use-cross: false
-        toolchain: ${{ matrix.rust }}
-        args: --release --bin qsvlite -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort ${{ matrix.job.addl-qsvlite-features != '' && format('--features=lite,self_update,{0}', matrix.job.addl-qsvlite-features) || '--features=lite,self_update' }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
+      # actions-rs/cargo is archived/Node20-deprecated (qsv #4002); invoke cargo directly.
+      # `+${{ matrix.rust }}` pins the toolchain vs a stale per-directory rustup override on self-hosted runners.
+      shell: bash
+      run: cargo +${{ matrix.rust }} build --release --bin qsvlite -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort ${{ matrix.job.addl-qsvlite-features != '' && format('--features=lite,self_update,{0}', matrix.job.addl-qsvlite-features) || '--features=lite,self_update' }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
     - name: Build qsvdp-nightly
       env:
         RUSTFLAGS: --emit=asm
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        use-cross: false
-        toolchain: ${{ matrix.rust }}
-        args: --release --bin qsvdp -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --features=datapusher_plus,${{ matrix.job.addl-qsvdp-features }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
+      # actions-rs/cargo is archived/Node20-deprecated (qsv #4002); invoke cargo directly.
+      # `+${{ matrix.rust }}` pins the toolchain vs a stale per-directory rustup override on self-hosted runners.
+      shell: bash
+      run: cargo +${{ matrix.rust }} build --release --bin qsvdp -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --features=datapusher_plus,${{ matrix.job.addl-qsvdp-features }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
     - name: Copy binaries to working dir
       shell: bash
       run: |

--- a/.github/workflows/test-publish-nightly.yml
+++ b/.github/workflows/test-publish-nightly.yml
@@ -60,11 +60,8 @@ jobs:
       uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust }}
-        profile: minimal
         components: rust-src
         target: ${{ matrix.job.target }}
-        override: true
-        default: true
     - name: Checkout repository
       uses: actions/checkout@v6
       with:

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -123,9 +123,7 @@ jobs:
       uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust }}
-        profile: minimal
         target: ${{ matrix.job.target }}
-        override: true
     - name: Checkout repository
       uses: actions/checkout@v6
       with:

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -141,30 +141,24 @@ jobs:
       #   RUSTFLAGS: --emit=asm
       env:
         RUSTFLAGS: ${{ matrix.job.addl-rustflags }}
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        use-cross: ${{ matrix.job.use-cross }}
-        toolchain: ${{ matrix.rust }}
-        args: --profile ${{ contains(matrix.job.addl-build-args, 'luau') && 'release-luau' || 'release' }} --locked --bin qsv --target ${{ matrix.job.target }} ${{ matrix.job.addl-build-args }},feature_capable ${{ matrix.job.default-features }}
+      # actions-rs/cargo is archived/Node20-deprecated (qsv #4002); invoke cargo directly.
+      # `+${{ matrix.rust }}` pins the toolchain vs a stale per-directory rustup override on self-hosted runners.
+      shell: bash
+      run: cargo +${{ matrix.rust }} build --profile ${{ contains(matrix.job.addl-build-args, 'luau') && 'release-luau' || 'release' }} --locked --bin qsv --target ${{ matrix.job.target }} ${{ matrix.job.addl-build-args }},feature_capable ${{ matrix.job.default-features }}
     - name: Build qsvlite
       env:
         RUSTFLAGS: --emit=asm
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        use-cross: ${{ matrix.job.use-cross }}
-        toolchain: ${{ matrix.rust }}
-        args: --release --locked --bin qsvlite --features=lite,self_update --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
+      # actions-rs/cargo is archived/Node20-deprecated (qsv #4002); invoke cargo directly.
+      # `+${{ matrix.rust }}` pins the toolchain vs a stale per-directory rustup override on self-hosted runners.
+      shell: bash
+      run: cargo +${{ matrix.rust }} build --release --locked --bin qsvlite --features=lite,self_update --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
     - name: Build qsvdp
       env:
         RUSTFLAGS: --emit=asm
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        use-cross: ${{ matrix.job.use-cross }}
-        toolchain: ${{ matrix.rust }}
-        args: --release --locked --bin qsvdp --features=datapusher_plus,${{ matrix.job.addl-qsvdp-features }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
+      # actions-rs/cargo is archived/Node20-deprecated (qsv #4002); invoke cargo directly.
+      # `+${{ matrix.rust }}` pins the toolchain vs a stale per-directory rustup override on self-hosted runners.
+      shell: bash
+      run: cargo +${{ matrix.rust }} build --release --locked --bin qsvdp --features=datapusher_plus,${{ matrix.job.addl-qsvdp-features }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
     - name: Copy binaries to working dir
       shell: bash
       run: |


### PR DESCRIPTION
Closes #4002.

GitHub Actions forces Node 20 actions to Node 24 on **2026-06-16** and removes Node 20 from runners on **2026-09-16**. Two of the three offenders (`actions-rs/*`) are archived and will never get a Node 24 update. This migrates all publish/CI workflows off them.

## Changes

- **`actions-rs/cargo@v1` → direct `run:` steps.** `cargo +${{ matrix.rust }} build …` — the `+toolchain` is load-bearing: it guards against a stale per-directory `rustup override` beating dtolnay's *default* toolchain on self-hosted runners.
  - `publish-portable.yml` keeps the `${{ matrix.job.use-cross == true && 'cross' || 'cargo' }}` conditional for its `aarch64-unknown-linux-gnu` cross target and gains an explicit **`Install cross`** step (`taiki-e/install-action@v2`), since `actions-rs/cargo` previously auto-installed `cross`.
  - `rustfmt.yml` → `cargo +nightly fmt -- --check`.
- **`mobiledevops/secret-to-file-action@v1` → inline base64 decode** of the zipsign key (secret passed via `env`, `shell: bash` for cross-runner portability).
- **`actions-rs/audit-check@v1` → `rustsec/audit-check@v2`** (maintained Node 24 successor).
- Commented-out `qsvdp` build blocks were converted too, so re-enabling them won't reintroduce the deprecated action.
- **Drop invalid `dtolnay/rust-toolchain` inputs.** `test-publish.yml` and `test-publish-nightly.yml` still passed `profile`/`override` (and `default` in the nightly) — leftovers from the old `actions-rs/toolchain` — which dtolnay ignores while emitting an `Unexpected input(s) … valid inputs are ['toolchain', 'targets', 'target', 'components']` warning. Removed them; dtolnay already makes the installed toolchain the default and we pin per-invocation with `cargo +${{ matrix.rust }}`.

`publish.yml` was migrated first as the reviewable template (commit e389f087d); this PR includes that plus the 13-file sweep.

## Verification

- No live or commented `uses: actions-rs/` / `uses: mobiledevops/` references remain anywhere in `.github/workflows/`.
- Full `uses:` inventory confirms only maintained Node 24 actions remain (plus new `rustsec/audit-check@v2` and `taiki-e/install-action@v2`).
- Every workflow YAML parses clean (`yaml.safe_load`).
- `test-publish.yml` dispatched against this branch built successfully with **zero** "Node.js 20 actions are deprecated" warnings.

### Not yet exercised by a live run
The new `Install cross` step + `cross` build and the inline zipsign decode in `publish-portable.yml` (and the other `publish-*` workflows) weren't run live, because those workflows resolve to the **latest existing release tag**, download its published asset, and re-upload with `overwrite: true` — i.e. dispatching them would mutate the real release, not act as a test. These changes are mechanical (`taiki-e/install-action@v2 tool: cross` is the standard cross installer; the zipsign step is a plain `base64 -d`) and are best validated by review, locally (`cross build` + a `zipsign` round-trip), or via a throwaway scratch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)