### PR TITLE
fix(frequency): classify duplicate-named columns by position, not name

### DIFF
--- a/src/cmd/frequency.rs
+++ b/src/cmd/frequency.rs
@@ -3439,7 +3439,9 @@ impl Args {
     /// * `col_type_by_pos` - Column types indexed by ORIGINAL CSV column position
     ///
     /// # Returns
-    /// A vector of indices (into the selected headers) of Float columns to skip.
+    /// A vector of ORIGINAL CSV column indices of Float columns to skip. Original indices
+    /// (not selected positions) are stable when an earlier filter removes columns, so this
+    /// composes correctly with --stats-filter.
     /// Columns listed in the --no-float exception list are NOT included in the skip list.
     fn compute_float_columns_to_skip(
         &self,
@@ -3472,8 +3474,10 @@ impl Args {
 
         // Look up the type by ORIGINAL column position (sel[i]) — not by header name — so
         // duplicate-named columns are each evaluated on their own type. The exception list
-        // still matches by name (it's a user-supplied list of column names).
-        for (i, (header, &orig_idx)) in headers.iter().zip(sel.iter()).enumerate() {
+        // still matches by name (it's a user-supplied list of column names). We record the
+        // ORIGINAL column index (orig_idx), which stays valid even if another filter later
+        // removes columns ahead of it.
+        for (header, &orig_idx) in headers.iter().zip(sel.iter()) {
             if let Some(col_type) = col_type_by_pos.get(orig_idx)
                 && col_type == "Float"
             {
@@ -3481,7 +3485,7 @@ impl Args {
                     .unwrap_or(NON_UTF8_ERR)
                     .to_lowercase();
                 if !exception_cols.contains(&header_str) {
-                    float_columns_to_skip.push(i);
+                    float_columns_to_skip.push(orig_idx);
                 }
             }
         }
@@ -3499,8 +3503,10 @@ impl Args {
     /// * `filter_expression` - The Luau expression to evaluate for each column
     ///
     /// # Returns
-    /// A vector of indices (into the selected headers) of columns where the filter
-    /// expression evaluated to `true` (meaning they should be excluded).
+    /// A vector of ORIGINAL CSV column indices of columns where the filter expression
+    /// evaluated to `true` (meaning they should be excluded). Original indices (not selected
+    /// positions) stay valid even if --no-float removed columns first, so the two filters
+    /// compose correctly.
     #[allow(clippy::unused_self)]
     #[cfg(feature = "luau")]
     fn compute_stats_filter_columns_to_skip(
@@ -3520,8 +3526,10 @@ impl Args {
         let mut columns_to_skip = Vec::new();
 
         // Look up the stats record by ORIGINAL column position (sel[i]) — not by header
-        // name — so duplicate-named columns are each evaluated against their own stats.
-        for (i, (header, &orig_idx)) in headers.iter().zip(sel.iter()).enumerate() {
+        // name — so duplicate-named columns are each evaluated against their own stats. We
+        // record the ORIGINAL column index (orig_idx), which stays valid even if --no-float
+        // removed columns ahead of it.
+        for (header, &orig_idx) in headers.iter().zip(sel.iter()) {
             let Some(stats_data) = stats_by_pos.get(orig_idx) else {
                 // No stats available for this column - skip filtering for it
                 log::debug!(
@@ -3537,7 +3545,7 @@ impl Args {
                     if should_exclude {
                         let header_str = simdutf8::basic::from_utf8(header).unwrap_or(NON_UTF8_ERR);
                         log::debug!("Column '{header_str}' excluded by --stats-filter expression");
-                        columns_to_skip.push(i);
+                        columns_to_skip.push(orig_idx);
                     }
                 },
                 Err(e) => {
@@ -4074,14 +4082,14 @@ impl Args {
                 if float_cols_to_skip.is_empty() {
                     (sel, selected_headers)
                 } else {
-                    // Filter selection to exclude Float columns
-                    // float_cols_to_skip contains indices into selected_headers
+                    // Filter selection to exclude Float columns.
+                    // float_cols_to_skip contains ORIGINAL CSV column indices, and sel
+                    // yields original column indices, so filter by the index value (stable
+                    // regardless of position).
                     let sel_vec: Vec<usize> = sel
                         .iter()
                         .copied()
-                        .enumerate()
-                        .filter(|(i, _)| !float_cols_to_skip.contains(i))
-                        .map(|(_, idx)| idx)
+                        .filter(|orig_idx| !float_cols_to_skip.contains(orig_idx))
                         .collect();
 
                     if sel_vec.is_empty() {
@@ -4115,14 +4123,14 @@ impl Args {
                 if stats_filter_cols_to_skip.is_empty() {
                     (final_sel, final_headers)
                 } else {
-                    // Filter selection to exclude stats-filtered columns
-                    // stats_filter_cols_to_skip contains indices into selected_headers
+                    // Filter selection to exclude stats-filtered columns.
+                    // stats_filter_cols_to_skip contains ORIGINAL CSV column indices; since
+                    // final_sel yields original column indices, this stays correct even when
+                    // --no-float already dropped earlier columns (positions would have shifted).
                     let sel_vec: Vec<usize> = final_sel
                         .iter()
                         .copied()
-                        .enumerate()
-                        .filter(|(i, _)| !stats_filter_cols_to_skip.contains(i))
-                        .map(|(_, idx)| idx)
+                        .filter(|orig_idx| !stats_filter_cols_to_skip.contains(orig_idx))
                         .collect();
 
                     if sel_vec.is_empty() {

--- a/src/cmd/frequency.rs
+++ b/src/cmd/frequency.rs
@@ -3432,8 +3432,11 @@ impl Args {
     /// Compute indices of Float columns that should be skipped from frequency analysis.
     ///
     /// # Arguments
-    /// * `headers` - The selected CSV headers
-    /// * `col_type_map` - Map of column names to their data types from stats cache
+    /// * `headers` - The selected CSV headers (used for the --no-float exception list, which
+    ///   matches by user-supplied column name)
+    /// * `sel` - The selection; `sel[i]` is the ORIGINAL CSV column position of selected column
+    ///   `i`, used to look up the column type positionally
+    /// * `col_type_by_pos` - Column types indexed by ORIGINAL CSV column position
     ///
     /// # Returns
     /// A vector of indices (into the selected headers) of Float columns to skip.
@@ -3441,7 +3444,8 @@ impl Args {
     fn compute_float_columns_to_skip(
         &self,
         headers: &Headers,
-        col_type_map: &HashMap<String, String>,
+        sel: &Selection,
+        col_type_by_pos: &[String],
     ) -> Vec<usize> {
         // Parse exception columns from flag value
         // If value is "*", exclude ALL Float columns (empty exception list)
@@ -3466,17 +3470,19 @@ impl Args {
 
         let mut float_columns_to_skip = Vec::new();
 
-        for (i, header) in headers.iter().enumerate() {
-            let header_str = simdutf8::basic::from_utf8(header)
-                .unwrap_or(NON_UTF8_ERR)
-                .to_string();
-
-            // Check if column is Float type and not in exception list
-            if let Some(col_type) = col_type_map.get(&header_str)
+        // Look up the type by ORIGINAL column position (sel[i]) — not by header name — so
+        // duplicate-named columns are each evaluated on their own type. The exception list
+        // still matches by name (it's a user-supplied list of column names).
+        for (i, (header, &orig_idx)) in headers.iter().zip(sel.iter()).enumerate() {
+            if let Some(col_type) = col_type_by_pos.get(orig_idx)
                 && col_type == "Float"
-                && !exception_cols.contains(&header_str.to_lowercase())
             {
-                float_columns_to_skip.push(i);
+                let header_str = simdutf8::basic::from_utf8(header)
+                    .unwrap_or(NON_UTF8_ERR)
+                    .to_lowercase();
+                if !exception_cols.contains(&header_str) {
+                    float_columns_to_skip.push(i);
+                }
             }
         }
 
@@ -3486,8 +3492,10 @@ impl Args {
     /// Compute indices of columns that should be skipped based on the --stats-filter expression.
     ///
     /// # Arguments
-    /// * `headers` - The selected CSV headers
-    /// * `stats_records` - Map of column names to their stats data from stats cache
+    /// * `headers` - The selected CSV headers (used only for log/error messages)
+    /// * `sel` - The selection; `sel[i]` is the ORIGINAL CSV column position of selected column
+    ///   `i`, used to look up the stats record positionally
+    /// * `stats_by_pos` - Stats records indexed by ORIGINAL CSV column position
     /// * `filter_expression` - The Luau expression to evaluate for each column
     ///
     /// # Returns
@@ -3498,7 +3506,8 @@ impl Args {
     fn compute_stats_filter_columns_to_skip(
         &self,
         headers: &Headers,
-        stats_records: &HashMap<String, StatsData>,
+        sel: &Selection,
+        stats_by_pos: &[StatsData],
         filter_expression: &str,
     ) -> CliResult<Vec<usize>> {
         use mlua::Lua;
@@ -3510,36 +3519,33 @@ impl Args {
 
         let mut columns_to_skip = Vec::new();
 
-        for (i, header) in headers.iter().enumerate() {
-            let header_str = simdutf8::basic::from_utf8(header)
-                .unwrap_or(NON_UTF8_ERR)
-                .to_string();
-
-            // Look up the stats record for this column
-            if let Some(stats_data) = stats_records.get(&header_str) {
-                // Evaluate the filter expression against this column's stats
-                match evaluate_stats_filter(&lua, stats_data, filter_expression) {
-                    Ok(should_exclude) => {
-                        if should_exclude {
-                            log::debug!(
-                                "Column '{header_str}' excluded by --stats-filter expression"
-                            );
-                            columns_to_skip.push(i);
-                        }
-                    },
-                    Err(e) => {
-                        return fail_clierror!(
-                            "Error evaluating --stats-filter expression for column \
-                             '{header_str}': {e}"
-                        );
-                    },
-                }
-            } else {
+        // Look up the stats record by ORIGINAL column position (sel[i]) — not by header
+        // name — so duplicate-named columns are each evaluated against their own stats.
+        for (i, (header, &orig_idx)) in headers.iter().zip(sel.iter()).enumerate() {
+            let Some(stats_data) = stats_by_pos.get(orig_idx) else {
                 // No stats available for this column - skip filtering for it
                 log::debug!(
-                    "No stats available for column '{header_str}', skipping --stats-filter \
+                    "No stats available for column index {orig_idx}, skipping --stats-filter \
                      evaluation"
                 );
+                continue;
+            };
+
+            // Evaluate the filter expression against this column's stats
+            match evaluate_stats_filter(&lua, stats_data, filter_expression) {
+                Ok(should_exclude) => {
+                    if should_exclude {
+                        let header_str = simdutf8::basic::from_utf8(header).unwrap_or(NON_UTF8_ERR);
+                        log::debug!("Column '{header_str}' excluded by --stats-filter expression");
+                        columns_to_skip.push(i);
+                    }
+                },
+                Err(e) => {
+                    let header_str = simdutf8::basic::from_utf8(header).unwrap_or(NON_UTF8_ERR);
+                    return fail_clierror!(
+                        "Error evaluating --stats-filter expression for column '{header_str}': {e}"
+                    );
+                },
             }
         }
 
@@ -3585,20 +3591,21 @@ impl Args {
             flag_output:          None,
         };
         let is_json = self.flag_json || self.flag_pretty_json || self.flag_toon;
-        // The name-keyed hashmap is needed ONLY for the two consumers that address a
-        // column by its user-specified name:
-        //   - --stats-filter evaluation (reads the local hashmap), and
-        //   - the --weight tolerance lookup (reads STATS_RECORDS, weighted JSON mode only).
-        // Per-output-column JSON stats now come from STATS_RECORDS_BY_POS (positional), so
-        // plain (non-weighted) JSON output no longer builds this hashmap at all.
-        #[cfg(feature = "luau")]
-        let needs_stats_records =
-            self.flag_stats_filter.is_some() || (is_json && self.flag_weight.is_some());
-        #[cfg(not(feature = "luau"))]
-        let needs_stats_records = is_json && self.flag_weight.is_some();
 
-        // initialize the stats records hashmap
-        let mut stats_records_hashmap = if needs_stats_records {
+        // What positional/name-keyed structures each feature needs, so we only pay for
+        // what's requested. ALL per-column lookups are positional (indexed by ORIGINAL CSV
+        // column position) so duplicate-named columns are each classified on their own data
+        // — the lone exception is the name-keyed hashmap below, which exists solely for the
+        // --weight tolerance lookup (it addresses ONE column by the user-supplied name).
+        let needs_weight_records = is_json && self.flag_weight.is_some();
+        let needs_float_types = self.flag_no_float.is_some();
+        #[cfg(feature = "luau")]
+        let needs_stats_by_pos = is_json || self.flag_stats_filter.is_some();
+        #[cfg(not(feature = "luau"))]
+        let needs_stats_by_pos = is_json;
+
+        // initialize the name-keyed stats records hashmap (used only by --weight tolerance)
+        let mut stats_records_hashmap = if needs_weight_records {
             HashMap::with_capacity(headers.len())
         } else {
             HashMap::new()
@@ -3614,37 +3621,42 @@ impl Args {
             return Ok((Vec::new(), Vec::new(), Vec::new()));
         }
 
-        // Build a column name -> type map (for Float detection) and a cardinality
-        // vector indexed by ORIGINAL CSV column position. csv_stats/csv_fields have one
-        // entry per column in original order, so the index IS the original column
-        // position — duplicate-named columns each keep their own cardinality (a
+        // Positional vectors indexed by ORIGINAL CSV column position. csv_stats/csv_fields
+        // have one entry per column in original order, so the index IS the original column
+        // position — duplicate-named columns each keep their own cardinality/type/stats (a
         // name-keyed lookup would collapse them onto the first match).
-        let mut col_type_map: HashMap<String, String> = HashMap::with_capacity(csv_stats.len());
         let mut col_cardinality_by_pos: Vec<u64> = Vec::with_capacity(csv_stats.len());
-        // Positional stats for JSON/TOON output, aligned to ORIGINAL columns. Built only
-        // for JSON output; the caller (sel_headers) remaps it to the final selected order.
-        let mut stats_by_pos: Vec<StatsData> = if is_json {
+        // Per-column types for --no-float detection (built only when needed).
+        let mut col_type_by_pos: Vec<String> = if needs_float_types {
+            Vec::with_capacity(csv_stats.len())
+        } else {
+            Vec::new()
+        };
+        // Per-column stats for JSON/TOON output and --stats-filter, aligned to ORIGINAL
+        // columns. For JSON, the caller (sel_headers) remaps it to the final selected order.
+        let mut stats_by_pos: Vec<StatsData> = if needs_stats_by_pos {
             Vec::with_capacity(csv_stats.len())
         } else {
             Vec::new()
         };
 
         for (i, stats_record) in csv_stats.iter().enumerate() {
-            // safety: we know that csv_fields and csv_stats have the same length
-            let col_name = csv_fields.get(i).unwrap();
-            let col_name_str = simdutf8::basic::from_utf8(col_name)
-                .unwrap_or(NON_UTF8_ERR)
-                .to_string();
-            if needs_stats_records {
-                // Name-keyed records for the --weight tolerance lookup and --stats-filter
-                // (both legitimately address columns by user-specified name)
-                stats_records_hashmap.insert(col_name_str.clone(), stats_record.clone());
+            if needs_weight_records {
+                // Name-keyed record for the --weight tolerance lookup (addresses the weight
+                // column by user-supplied name). safety: csv_fields and csv_stats are equal
+                // length, so index i is valid for csv_fields.
+                let col_name = csv_fields.get(i).unwrap();
+                let col_name_str = simdutf8::basic::from_utf8(col_name)
+                    .unwrap_or(NON_UTF8_ERR)
+                    .to_string();
+                stats_records_hashmap.insert(col_name_str, stats_record.clone());
             }
-            if is_json {
+            if needs_float_types {
+                col_type_by_pos.push(stats_record.r#type.clone());
+            }
+            if needs_stats_by_pos {
                 stats_by_pos.push(stats_record.clone());
             }
-            // Store type info for Float column detection
-            col_type_map.insert(col_name_str, stats_record.r#type.clone());
             col_cardinality_by_pos.push(stats_record.cardinality);
         }
 
@@ -3668,7 +3680,8 @@ impl Args {
 
         // Compute Float columns to skip if --no-float is specified
         if self.flag_no_float.is_some() {
-            let float_columns_to_skip = self.compute_float_columns_to_skip(headers, &col_type_map);
+            let float_columns_to_skip =
+                self.compute_float_columns_to_skip(headers, sel, &col_type_by_pos);
             if FLOAT_COLUMNS_TO_SKIP.set(float_columns_to_skip).is_err() {
                 log::warn!("FLOAT_COLUMNS_TO_SKIP already set — stale float columns may be used");
             }
@@ -3677,7 +3690,7 @@ impl Args {
         // Compute stats filter columns to skip if --stats-filter is specified
         #[cfg(feature = "luau")]
         if let Some(ref filter_expression) = self.flag_stats_filter {
-            if stats_records_hashmap.is_empty() {
+            if stats_by_pos.is_empty() {
                 log::warn!(
                     "Stats cache unavailable. Cannot apply --stats-filter. Run 'qsv stats \
                      --cardinality --stats-jsonl' first."
@@ -3685,7 +3698,8 @@ impl Args {
             } else {
                 let stats_filter_columns_to_skip = self.compute_stats_filter_columns_to_skip(
                     headers,
-                    &stats_records_hashmap,
+                    sel,
+                    &stats_by_pos,
                     filter_expression,
                 )?;
                 if STATS_FILTER_COLUMNS_TO_SKIP
@@ -4169,7 +4183,10 @@ impl Args {
         // (positional), so duplicate-named columns each report their own stats. orig_idx
         // values come from a valid selection over the original columns, so every lookup
         // resolves; the length guard skips the set if any unexpectedly does not.
-        if !stats_by_pos.is_empty() {
+        // Only for JSON output: stats_by_pos may also be populated for --stats-filter in
+        // non-JSON mode, where STATS_RECORDS_BY_POS is never read.
+        let is_json = self.flag_json || self.flag_pretty_json || self.flag_toon;
+        if is_json && !stats_by_pos.is_empty() {
             let final_stats: Vec<StatsData> = final_sel
                 .iter()
                 .filter_map(|&orig_idx| stats_by_pos.get(orig_idx).cloned())

--- a/src/cmd/frequency.rs
+++ b/src/cmd/frequency.rs
@@ -381,15 +381,26 @@ pub struct Args {
 
 const NON_UTF8_ERR: &str = "<Non-UTF8 ERROR>";
 
+// Name-keyed stats records. Retained ONLY for lookups that legitimately address a
+// column by its user-specified name: the `--weight` column's tolerance scale and
+// `--stats-filter`. NOT used for per-output-column JSON stats (see STATS_RECORDS_BY_POS),
+// which must be positional so duplicate-named columns don't collapse onto one record.
 static STATS_RECORDS: OnceLock<HashMap<String, StatsData>> = OnceLock::new();
+// Per-output-column stats for JSON/TOON output, aligned positionally to the FINAL
+// selected columns (index = output column position). Positional — not name-keyed — so
+// duplicate-named columns each report their own stats.
+static STATS_RECORDS_BY_POS: OnceLock<Vec<StatsData>> = OnceLock::new();
 static NULL_VAL: OnceLock<Vec<u8>> = OnceLock::new();
 static UNIQUE_COLUMNS_VEC: OnceLock<Vec<usize>> = OnceLock::new();
-static COL_CARDINALITY_VEC: OnceLock<Vec<(String, u64)>> = OnceLock::new();
+// Cardinalities aligned positionally to the FINAL selected columns (NOT keyed by
+// name). Name-keying collapsed duplicate-named columns onto the first match; using
+// position lets each duplicate keep its own cardinality.
+static COL_CARDINALITY_VEC: OnceLock<Vec<u64>> = OnceLock::new();
 static FREQ_ROW_COUNT: OnceLock<u64> = OnceLock::new();
 static FLOAT_COLUMNS_TO_SKIP: OnceLock<Vec<usize>> = OnceLock::new();
 #[cfg(feature = "luau")]
 static STATS_FILTER_COLUMNS_TO_SKIP: OnceLock<Vec<usize>> = OnceLock::new();
-static EMPTY_VEC: Vec<(String, u64)> = Vec::new();
+static EMPTY_VEC: Vec<u64> = Vec::new();
 static EMPTY_USIZE_VEC: Vec<usize> = Vec::new();
 static ALL_UNIQUE_TEXT: OnceLock<Vec<u8>> = OnceLock::new();
 // Partial frequency cache: when some columns are cached but others need computation,
@@ -1846,10 +1857,10 @@ impl Args {
                 util::bytes_to_cow_str(header).into_owned()
             };
 
-            let cardinality = col_cardinality
-                .iter()
-                .find(|(name, _)| name == &field_name)
-                .map_or(0, |(_, card)| *card);
+            // col_cardinality is aligned positionally to the selected columns, so index
+            // by position (i) — not by name — so duplicate-named columns each get their
+            // own cardinality.
+            let cardinality = col_cardinality.get(i).copied().unwrap_or(0);
 
             let is_high_cardinality =
                 !unique_headers.contains(&i) && cardinality > effective_threshold;
@@ -3156,11 +3167,11 @@ impl Args {
                     let capacity = if nchunks == 1 {
                         col_cardinality_vec
                             .get(i)
-                            .map_or(1000, |(_, cardinality)| *cardinality as usize)
+                            .map_or(1000, |&cardinality| cardinality as usize)
                     } else {
                         let cardinality = col_cardinality_vec
                             .get(i)
-                            .map_or(1000, |(_, cardinality)| *cardinality as usize);
+                            .map_or(1000, |&cardinality| cardinality as usize);
                         cardinality / nchunks
                     };
                     HashMap::with_capacity(capacity)
@@ -3322,12 +3333,12 @@ impl Args {
                     } else if nchunks == 1 {
                         col_cardinality_vec
                             .get(i)
-                            .map_or(1000, |(_, cardinality)| *cardinality as usize)
+                            .map_or(1000, |&cardinality| cardinality as usize)
                     } else {
                         // use cardinality and number of jobs to set the capacity
                         let cardinality = col_cardinality_vec
                             .get(i)
-                            .map_or(1000, |(_, cardinality)| *cardinality as usize);
+                            .map_or(1000, |&cardinality| cardinality as usize);
                         cardinality / nchunks
                     };
                     Frequencies::with_capacity(capacity)
@@ -3535,10 +3546,24 @@ impl Args {
         Ok(columns_to_skip)
     }
 
-    /// return the names of headers/columns that are unique identifiers
-    /// (i.e. where cardinality == rowcount)
+    /// Return the all-unique columns (cardinality == rowcount) as ORIGINAL CSV
+    /// column indices, together with a cardinality vector indexed by ORIGINAL CSV
+    /// column position (aligned to the stats cache, which has one record per
+    /// column regardless of duplicate names).
+    ///
+    /// Both are keyed by position — NOT by header name — so duplicate-named columns
+    /// are each classified on their own data. `sel` maps each selected column to its
+    /// original CSV column position. An empty cardinality vector signals "no stats
+    /// cache available" (compute frequencies for all columns).
+    ///
     /// Also stores the stats records in a hashmap for use when producing JSON output
-    fn get_unique_headers(&self, headers: &Headers) -> CliResult<Vec<usize>> {
+    /// and computes the Float / `--stats-filter` skip lists (both still name-keyed,
+    /// as those features index by selected-header name).
+    fn get_unique_headers(
+        &self,
+        sel: &Selection,
+        headers: &Headers,
+    ) -> CliResult<(Vec<usize>, Vec<u64>, Vec<StatsData>)> {
         // get the stats records for the entire CSV
         let schema_args = util::SchemaArgs {
             flag_enum_threshold:  0,
@@ -3560,12 +3585,17 @@ impl Args {
             flag_output:          None,
         };
         let is_json = self.flag_json || self.flag_pretty_json || self.flag_toon;
-        // Check if we need to populate stats_records_hashmap
-        // We need it for JSON output and for --stats-filter
+        // The name-keyed hashmap is needed ONLY for the two consumers that address a
+        // column by its user-specified name:
+        //   - --stats-filter evaluation (reads the local hashmap), and
+        //   - the --weight tolerance lookup (reads STATS_RECORDS, weighted JSON mode only).
+        // Per-output-column JSON stats now come from STATS_RECORDS_BY_POS (positional), so
+        // plain (non-weighted) JSON output no longer builds this hashmap at all.
         #[cfg(feature = "luau")]
-        let needs_stats_records = is_json || self.flag_stats_filter.is_some();
+        let needs_stats_records =
+            self.flag_stats_filter.is_some() || (is_json && self.flag_weight.is_some());
         #[cfg(not(feature = "luau"))]
-        let needs_stats_records = is_json;
+        let needs_stats_records = is_json && self.flag_weight.is_some();
 
         // initialize the stats records hashmap
         let mut stats_records_hashmap = if needs_stats_records {
@@ -3578,55 +3608,61 @@ impl Args {
 
         if csv_fields.is_empty() || csv_stats.len() != csv_fields.len() {
             // the stats cache does not exist or the number of fields & stats records
-            // do not match. Just return an empty vector.
+            // do not match. Just return empty vectors.
             // we're not going to be able to get the cardinalities, so
             // this signals that we just compute frequencies for all columns
-            return Ok(Vec::new());
+            return Ok((Vec::new(), Vec::new(), Vec::new()));
         }
 
-        // Build column name -> (cardinality, type) map for matching by name
+        // Build a column name -> type map (for Float detection) and a cardinality
+        // vector indexed by ORIGINAL CSV column position. csv_stats/csv_fields have one
+        // entry per column in original order, so the index IS the original column
+        // position — duplicate-named columns each keep their own cardinality (a
+        // name-keyed lookup would collapse them onto the first match).
         let mut col_type_map: HashMap<String, String> = HashMap::with_capacity(csv_stats.len());
+        let mut col_cardinality_by_pos: Vec<u64> = Vec::with_capacity(csv_stats.len());
+        // Positional stats for JSON/TOON output, aligned to ORIGINAL columns. Built only
+        // for JSON output; the caller (sel_headers) remaps it to the final selected order.
+        let mut stats_by_pos: Vec<StatsData> = if is_json {
+            Vec::with_capacity(csv_stats.len())
+        } else {
+            Vec::new()
+        };
 
-        let col_cardinality_vec: Vec<(String, u64)> = csv_stats
-            .iter()
-            .enumerate()
-            .map(|(i, stats_record)| {
-                // get the column name and stats record
-                // safety: we know that csv_fields and csv_stats have the same length
-                let col_name = csv_fields.get(i).unwrap();
-                let col_name_str = simdutf8::basic::from_utf8(col_name)
-                    .unwrap_or(NON_UTF8_ERR)
-                    .to_string();
-                if needs_stats_records {
-                    // Store the stats records hashmap for later use when producing JSON output
-                    // or for --stats-filter evaluation
-                    stats_records_hashmap.insert(col_name_str.clone(), stats_record.clone());
-                }
-                // Store type info for Float column detection
-                col_type_map.insert(col_name_str.clone(), stats_record.r#type.clone());
-                (col_name_str, stats_record.cardinality)
-            })
-            .collect();
+        for (i, stats_record) in csv_stats.iter().enumerate() {
+            // safety: we know that csv_fields and csv_stats have the same length
+            let col_name = csv_fields.get(i).unwrap();
+            let col_name_str = simdutf8::basic::from_utf8(col_name)
+                .unwrap_or(NON_UTF8_ERR)
+                .to_string();
+            if needs_stats_records {
+                // Name-keyed records for the --weight tolerance lookup and --stats-filter
+                // (both legitimately address columns by user-specified name)
+                stats_records_hashmap.insert(col_name_str.clone(), stats_record.clone());
+            }
+            if is_json {
+                stats_by_pos.push(stats_record.clone());
+            }
+            // Store type info for Float column detection
+            col_type_map.insert(col_name_str, stats_record.r#type.clone());
+            col_cardinality_by_pos.push(stats_record.cardinality);
+        }
 
         // now, get the unique headers, where cardinality == rowcount
         let row_count = util::count_rows(&self.rconfig()).unwrap_or_default();
         FREQ_ROW_COUNT.set(row_count).unwrap();
 
-        // Most datasets have relatively few columns with all unique values (e.g. ID columns)
-        // so pre-allocate space for 5 as a reasonable default capacity
+        // Determine all-unique columns by ORIGINAL column position via the selection,
+        // not by header name, so duplicate-named columns are each classified on their
+        // own cardinality. `sel` yields the original CSV column index of each selected
+        // column. Returns original indices (the caller remaps them to selected positions).
+        // Most datasets have relatively few all-unique columns (e.g. ID columns), so
+        // pre-allocate space for 5 as a reasonable default capacity.
         let mut all_unique_headers_vec: Vec<usize> = Vec::with_capacity(5);
-        for (i, header) in headers.iter().enumerate() {
-            // Look up cardinality by column name, not index, since headers may be a
-            // user-selected subset in a different order than the original CSV columns
-            let cardinality = col_cardinality_vec
-                .iter()
-                .find(|(name, _)| {
-                    name == simdutf8::basic::from_utf8(header).unwrap_or(NON_UTF8_ERR)
-                })
-                .map_or(0, |(_, card)| *card);
-
+        for &orig_idx in sel.iter() {
+            let cardinality = col_cardinality_by_pos.get(orig_idx).copied().unwrap_or(0);
             if cardinality == row_count {
-                all_unique_headers_vec.push(i);
+                all_unique_headers_vec.push(orig_idx);
             }
         }
 
@@ -3664,14 +3700,17 @@ impl Args {
             }
         }
 
-        COL_CARDINALITY_VEC.get_or_init(|| col_cardinality_vec);
-
-        if is_json {
-            // Store the stats records hashmap for later use when producing JSON output
+        if is_json && self.flag_weight.is_some() {
+            // Only the weighted-JSON tolerance path reads STATS_RECORDS; set it just for
+            // that case (addresses the weight column by name). Non-weighted JSON never
+            // populated the hashmap above, so there is nothing to store.
             STATS_RECORDS.set(stats_records_hashmap).unwrap();
         }
 
-        Ok(all_unique_headers_vec)
+        // COL_CARDINALITY_VEC and STATS_RECORDS_BY_POS are set by the caller (sel_headers)
+        // once the FINAL selection is known, so they can be aligned positionally to the
+        // final columns.
+        Ok((all_unique_headers_vec, col_cardinality_by_pos, stats_by_pos))
     }
 
     #[allow(clippy::cast_precision_loss)]
@@ -3697,6 +3736,7 @@ impl Args {
 
         // Helper function to build a frequency field for JSON output
         let build_frequency_field = |field_name: String,
+                                     field_pos: usize,
                                      cardinality: u64,
                                      processed_frequencies: &mut Vec<ProcessedFrequency>,
                                      field_stats: &mut Vec<FieldStats>,
@@ -3715,10 +3755,11 @@ impl Args {
                 }
             }
 
-            // Get stats record for this field
-            let stats_record = STATS_RECORDS
+            // Get stats record for this field by output-column POSITION (not name), so
+            // duplicate-named columns each get their own stats.
+            let stats_record = STATS_RECORDS_BY_POS
                 .get()
-                .and_then(|records| records.get(&field_name));
+                .and_then(|records| records.get(field_pos));
 
             // Get data type and nullcount from stats record
             let dtype = stats_record.map_or(String::new(), |sr| sr.r#type.clone());
@@ -3832,6 +3873,7 @@ impl Args {
 
                 fields.push(build_frequency_field(
                     field_name,
+                    i,
                     cardinality,
                     &mut processed_frequencies,
                     &mut field_stats,
@@ -3868,6 +3910,7 @@ impl Args {
 
                 fields.push(build_frequency_field(
                     field_name,
+                    i,
                     cardinality,
                     &mut processed_frequencies,
                     &mut field_stats,
@@ -4008,7 +4051,8 @@ impl Args {
         let (weight_col_idx, mut sel, selected_headers) =
             self.process_headers_with_weight_exclusion(&full_headers)?;
 
-        let all_unique_headers_vec = self.get_unique_headers(&selected_headers)?;
+        let (all_unique_headers_vec, col_cardinality_by_pos, stats_by_pos) =
+            self.get_unique_headers(&sel, &selected_headers)?;
 
         // Filter out Float columns if --no-float is specified
         let (final_sel, final_headers) = if self.flag_no_float.is_some() {
@@ -4105,6 +4149,37 @@ impl Args {
         UNIQUE_COLUMNS_VEC
             .set(mapped_unique_headers)
             .map_err(|_| "Cannot set UNIQUE_COLUMNS")?;
+
+        // Build the cardinality vector aligned positionally to the FINAL selected
+        // columns (after --no-float / --stats-filter dropping), so downstream
+        // consumers (cache cardinality, capacity hints) can index by position.
+        // Skip when the stats cache is unavailable (empty), leaving COL_CARDINALITY_VEC
+        // unset so consumers fall back to default capacities.
+        if !col_cardinality_by_pos.is_empty() {
+            let final_cardinalities: Vec<u64> = final_sel
+                .iter()
+                .map(|&orig_idx| col_cardinality_by_pos.get(orig_idx).copied().unwrap_or(0))
+                .collect();
+            if COL_CARDINALITY_VEC.set(final_cardinalities).is_err() {
+                log::warn!("COL_CARDINALITY_VEC already set — stale cardinalities may be used");
+            }
+        }
+
+        // Likewise, align the per-output-column JSON stats to the FINAL selected columns
+        // (positional), so duplicate-named columns each report their own stats. orig_idx
+        // values come from a valid selection over the original columns, so every lookup
+        // resolves; the length guard skips the set if any unexpectedly does not.
+        if !stats_by_pos.is_empty() {
+            let final_stats: Vec<StatsData> = final_sel
+                .iter()
+                .filter_map(|&orig_idx| stats_by_pos.get(orig_idx).cloned())
+                .collect();
+            if final_stats.len() == final_sel.len()
+                && STATS_RECORDS_BY_POS.set(final_stats).is_err()
+            {
+                log::warn!("STATS_RECORDS_BY_POS already set — stale stats may be used");
+            }
+        }
 
         Ok((final_headers, final_sel, weight_col_idx))
     }

--- a/src/cmd/schema.rs
+++ b/src/cmd/schema.rs
@@ -304,6 +304,22 @@ pub fn infer_schema_from_stats(
     // invoke cmd::stats
     let (csv_fields, csv_stats) = util::get_stats_records(args, StatsMode::Schema)?;
 
+    // Name-keyed outputs (this command's JSON Schema `properties`, and tojsonl's JSON
+    // objects — both reach here) cannot represent two columns sharing a name: the
+    // duplicates silently collapse onto a single key. Warn so the result isn't trusted
+    // blindly. Only meaningful when headers are in use (with --no-headers the "names"
+    // are the first data row).
+    if !quiet && !args.flag_no_headers {
+        let dupes = util::duplicate_headers(&csv_fields);
+        if !dupes.is_empty() {
+            wwarn!(
+                "Duplicate column name(s) detected ({}). Name-keyed output collapses them onto a \
+                 single key, so the result is unreliable for these columns.",
+                dupes.join(", ")
+            );
+        }
+    }
+
     // amortize memory allocation
     let mut low_cardinality_column_indices: Vec<u64> =
         Vec::with_capacity(args.flag_enum_threshold as usize);

--- a/src/cmd/schema.rs
+++ b/src/cmd/schema.rs
@@ -305,12 +305,21 @@ pub fn infer_schema_from_stats(
     let (csv_fields, csv_stats) = util::get_stats_records(args, StatsMode::Schema)?;
 
     // Name-keyed outputs (this command's JSON Schema `properties`, and tojsonl's JSON
-    // objects — both reach here) cannot represent two columns sharing a name: the
-    // duplicates silently collapse onto a single key. Warn so the result isn't trusted
-    // blindly. Only meaningful when headers are in use (with --no-headers the "names"
-    // are the first data row).
+    // objects — both reach here via this shared fn) cannot represent two columns sharing a
+    // name: the duplicates silently collapse onto a single key. Warn (once per duplicated
+    // name) so the result isn't trusted blindly. Only meaningful when headers are in use
+    // (with --no-headers the "names" are the first data row).
     if !quiet && !args.flag_no_headers {
-        let dupes = util::duplicate_headers(&csv_fields);
+        let mut seen: HashSet<&[u8]> = HashSet::default();
+        let mut dupes: Vec<String> = Vec::new();
+        for field in &csv_fields {
+            if !seen.insert(field) {
+                let name = String::from_utf8_lossy(field).into_owned();
+                if !dupes.contains(&name) {
+                    dupes.push(name);
+                }
+            }
+        }
         if !dupes.is_empty() {
             wwarn!(
                 "Duplicate column name(s) detected ({}). Name-keyed output collapses them onto a \

--- a/src/util.rs
+++ b/src/util.rs
@@ -833,29 +833,6 @@ pub fn show_env_vars() {
     }
 }
 
-/// Return the header names that occur more than once, each listed once in
-/// first-seen order (empty when all headers are unique).
-///
-/// Output formats that key by column name — JSON objects (`tojsonl`), JSON Schema
-/// `properties` (`schema`) — cannot represent two columns sharing a name distinctly,
-/// so the duplicates silently collapse. Callers should warn the user when this
-/// returns a non-empty list.
-#[must_use]
-pub fn duplicate_headers(headers: &ByteRecord) -> Vec<String> {
-    use std::collections::HashSet;
-
-    let mut seen: HashSet<&[u8]> = HashSet::with_capacity(headers.len());
-    let mut reported: HashSet<&[u8]> = HashSet::new();
-    let mut dupes: Vec<String> = Vec::new();
-    for field in headers {
-        if !seen.insert(field) && reported.insert(field) {
-            // first repeat of this name → record it once
-            dupes.push(String::from_utf8_lossy(field).into_owned());
-        }
-    }
-    dupes
-}
-
 #[inline]
 pub fn count_rows(conf: &Config) -> Result<u64, CliError> {
     // Check if ROW_COUNT is already initialized to avoid redundant counting

--- a/src/util.rs
+++ b/src/util.rs
@@ -833,6 +833,29 @@ pub fn show_env_vars() {
     }
 }
 
+/// Return the header names that occur more than once, each listed once in
+/// first-seen order (empty when all headers are unique).
+///
+/// Output formats that key by column name — JSON objects (`tojsonl`), JSON Schema
+/// `properties` (`schema`) — cannot represent two columns sharing a name distinctly,
+/// so the duplicates silently collapse. Callers should warn the user when this
+/// returns a non-empty list.
+#[must_use]
+pub fn duplicate_headers(headers: &ByteRecord) -> Vec<String> {
+    use std::collections::HashSet;
+
+    let mut seen: HashSet<&[u8]> = HashSet::with_capacity(headers.len());
+    let mut reported: HashSet<&[u8]> = HashSet::new();
+    let mut dupes: Vec<String> = Vec::new();
+    for field in headers {
+        if !seen.insert(field) && reported.insert(field) {
+            // first repeat of this name → record it once
+            dupes.push(String::from_utf8_lossy(field).into_owned());
+        }
+    }
+    dupes
+}
+
 #[inline]
 pub fn count_rows(conf: &Config) -> Result<u64, CliError> {
     // Check if ROW_COUNT is already initialized to avoid redundant counting

--- a/tests/test_frequency.rs
+++ b/tests/test_frequency.rs
@@ -711,6 +711,138 @@ fn frequency_all_unique_with_stats_cache() {
     assert_eq!(got, expected);
 }
 
+// Regression tests for duplicate-named columns. Per-column cardinality used to be
+// looked up by header NAME, so every duplicate inherited the FIRST duplicate's
+// stats (all classified identically). The fix keys cardinality/all-unique by
+// column POSITION, so each duplicate is classified on its own data.
+#[test]
+fn frequency_duplicate_headers_distinct_data() {
+    let wrk = Workdir::new("frequency_duplicate_headers_distinct_data");
+    // both columns are named "id": col 1 is all-unique, col 2 is red=3/blue=1
+    let rows = vec![
+        svec!["id", "id"],
+        svec!["a", "red"],
+        svec!["b", "red"],
+        svec!["c", "blue"],
+        svec!["d", "red"],
+    ];
+    wrk.create("in.csv", rows);
+
+    // create stats cache so cardinalities are available
+    let mut stats_cmd = wrk.command("stats");
+    stats_cmd
+        .arg("in.csv")
+        .arg("--cardinality")
+        .arg("--stats-jsonl");
+    wrk.assert_success(&mut stats_cmd);
+
+    let mut cmd = wrk.command("frequency");
+    cmd.arg("in.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["field", "value", "count", "percentage", "rank"],
+        // col 1 (a,b,c,d) is genuinely all-unique
+        svec!["id", "<ALL_UNIQUE>", "4", "100", "0"],
+        // col 2 (red,red,blue,red) must report its OWN distribution, NOT all-unique
+        svec!["id", "red", "3", "75", "1"],
+        svec!["id", "blue", "1", "25", "2"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn frequency_duplicate_headers_jsonl_cache() {
+    let wrk = Workdir::new("frequency_duplicate_headers_jsonl_cache");
+    let rows = vec![
+        svec!["id", "id"],
+        svec!["a", "red"],
+        svec!["b", "red"],
+        svec!["c", "blue"],
+        svec!["d", "red"],
+    ];
+    wrk.create("in.csv", rows);
+
+    let mut stats_cmd = wrk.command("stats");
+    stats_cmd
+        .arg("in.csv")
+        .arg("--cardinality")
+        .arg("--stats-jsonl");
+    wrk.assert_success(&mut stats_cmd);
+
+    let mut cmd = wrk.command("frequency");
+    cmd.arg("in.csv").arg("--frequency-jsonl");
+    wrk.assert_success(&mut cmd);
+
+    let cache_path = wrk.path("in.freq.csv.data.jsonl");
+    assert!(cache_path.exists(), "Frequency cache file should exist");
+
+    let fields = decode_cache_fields(&cache_path);
+    assert_eq!(fields.len(), 2, "Should have one entry per column");
+
+    // First "id" column: genuinely all-unique, cardinality 4
+    assert_eq!(fields[0]["field"], "id");
+    assert_eq!(fields[0]["cardinality"], 4);
+    let freqs0 = fields[0]["frequencies"].as_array().unwrap();
+    assert_eq!(freqs0.len(), 1);
+    assert_eq!(freqs0[0]["value"], "<ALL_UNIQUE>");
+
+    // Second "id" column: cardinality 2, holds its OWN distribution (red=3, blue=1)
+    assert_eq!(fields[1]["field"], "id");
+    assert_eq!(fields[1]["cardinality"], 2);
+    let freqs1 = fields[1]["frequencies"].as_array().unwrap();
+    assert_eq!(freqs1.len(), 2);
+    assert_eq!(freqs1[0]["value"], "red");
+    assert_eq!(freqs1[0]["count"], 3);
+    assert_eq!(freqs1[1]["value"], "blue");
+    assert_eq!(freqs1[1]["count"], 1);
+}
+
+#[test]
+fn frequency_duplicate_headers_jsonl_high_cardinality() {
+    let wrk = Workdir::new("frequency_duplicate_headers_jsonl_high_cardinality");
+    // both columns are named "x": col 1 is all-unique (card 6), col 2 is card 3
+    let rows = vec![
+        svec!["x", "x"],
+        svec!["1", "a"],
+        svec!["2", "a"],
+        svec!["3", "b"],
+        svec!["4", "a"],
+        svec!["5", "b"],
+        svec!["6", "c"],
+    ];
+    wrk.create("in.csv", rows);
+
+    let mut stats_cmd = wrk.command("stats");
+    stats_cmd
+        .arg("in.csv")
+        .arg("--cardinality")
+        .arg("--stats-jsonl");
+    wrk.assert_success(&mut stats_cmd);
+
+    let mut cmd = wrk.command("frequency");
+    // threshold 2: col 2 (cardinality 3 > 2) is HIGH_CARDINALITY; col 1 is ALL_UNIQUE
+    cmd.arg("in.csv")
+        .args(["--high-card-threshold", "2"])
+        .arg("--frequency-jsonl");
+    wrk.assert_success(&mut cmd);
+
+    let cache_path = wrk.path("in.freq.csv.data.jsonl");
+    let fields = decode_cache_fields(&cache_path);
+    assert_eq!(fields.len(), 2);
+
+    // col 1: all-unique on its OWN cardinality (6)
+    assert_eq!(fields[0]["cardinality"], 6);
+    let freqs0 = fields[0]["frequencies"].as_array().unwrap();
+    assert_eq!(freqs0[0]["value"], "<ALL_UNIQUE>");
+
+    // col 2: classified high-cardinality on its OWN cardinality (3), NOT all-unique
+    assert_eq!(fields[1]["cardinality"], 3);
+    let freqs1 = fields[1]["frequencies"].as_array().unwrap();
+    assert_eq!(freqs1.len(), 1);
+    assert_eq!(freqs1[0]["value"], "<HIGH_CARDINALITY>");
+}
+
 #[test]
 fn frequency_custom_null_text() {
     let wrk = Workdir::new("frequency_custom_null_text");
@@ -1222,6 +1354,47 @@ fn frequency_json() {
 }
 
 #[test]
+fn frequency_json_duplicate_headers() {
+    // Regression: JSON per-field stats were looked up by header NAME, so two columns
+    // named "id" both got the SAME stats record. They must each report their own.
+    let wrk = Workdir::new("frequency_json_duplicate_headers");
+    let rows = vec![
+        svec!["id", "id"],
+        svec!["10", "red"],
+        svec!["20", "red"],
+        svec!["30", "blue"],
+        svec!["40", "red"],
+    ];
+    wrk.create("in.csv", rows);
+
+    // stats cache is required for the per-field stats (type, cardinality, ...)
+    let mut stats_cmd = wrk.command("stats");
+    stats_cmd
+        .arg("in.csv")
+        .arg("--cardinality")
+        .arg("--stats-jsonl");
+    wrk.assert_success(&mut stats_cmd);
+
+    let mut cmd = wrk.command("frequency");
+    cmd.arg("in.csv").arg("--json");
+    let got: String = wrk.stdout(&mut cmd);
+    let v: Value = serde_json::from_str(&got).unwrap();
+
+    let fields = v["fields"].as_array().unwrap();
+    assert_eq!(fields.len(), 2);
+
+    // col 1: numeric, all-unique — its OWN type/cardinality
+    assert_eq!(fields[0]["field"], "id");
+    assert_eq!(fields[0]["type"], "Integer");
+    assert_eq!(fields[0]["cardinality"], 4);
+
+    // col 2: String red/blue — must NOT inherit col 1's record
+    assert_eq!(fields[1]["field"], "id");
+    assert_eq!(fields[1]["type"], "String");
+    assert_eq!(fields[1]["cardinality"], 2);
+}
+
+#[test]
 fn frequency_json_no_headers() {
     let (wrk, mut cmd) = setup("frequency_json_no_headers");
     cmd.args(["--limit", "0"])
@@ -1446,11 +1619,22 @@ rowcount: 8
 fieldcount: 1
 fields[1]:
   - field: "1"
-    type: ""
+    type: String
     cardinality: 5
-    nullcount: 0
-    sparsity: 0
+    nullcount: 1
+    sparsity: 0.125
     uniqueness_ratio: 0.625
+    stats[10]{name,value}:
+      min,(NULL)
+      max,h1
+      sort_order,Unsorted
+      min_length,0
+      max_length,6
+      sum_length,13
+      avg_length,1.625
+      stddev_length,1.7275
+      variance_length,2.9844
+      cv_length,1.0631
     frequencies[5]{value,count,percentage,rank}:
       a,4,50,1
       b,1,12.5,2

--- a/tests/test_frequency.rs
+++ b/tests/test_frequency.rs
@@ -3588,6 +3588,43 @@ fn frequency_no_float_basic() {
 }
 
 #[test]
+fn frequency_no_float_duplicate_headers() {
+    // Regression: column types were looked up by header NAME, so two columns named "x"
+    // both inherited the first's type — --no-float would drop or keep BOTH. The fix keys
+    // type by position: only the genuinely-Float column is dropped.
+    let wrk = Workdir::new("frequency_no_float_duplicate_headers");
+    // col 1 "x" = Float, col 2 "x" = String
+    wrk.create(
+        "in.csv",
+        vec![
+            svec!["x", "x"],
+            svec!["1.5", "a"],
+            svec!["2.5", "a"],
+            svec!["3.5", "b"],
+        ],
+    );
+
+    let mut stats_cmd = wrk.command("stats");
+    stats_cmd
+        .arg("in.csv")
+        .arg("--cardinality")
+        .arg("--stats-jsonl");
+    wrk.assert_success(&mut stats_cmd);
+
+    let mut cmd = wrk.command("frequency");
+    cmd.arg("in.csv").args(["--no-float", "*"]);
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    // Only the String column (col 2: a,a,b) survives; the Float column (col 1) is dropped.
+    let expected = vec![
+        svec!["field", "value", "count", "percentage", "rank"],
+        svec!["x", "a", "2", "66.66667", "1"],
+        svec!["x", "b", "1", "33.33333", "2"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
 fn frequency_no_float_with_exceptions() {
     let wrk = Workdir::new("frequency_no_float_with_exceptions");
 
@@ -3932,6 +3969,45 @@ fn frequency_stats_filter_nullcount() {
     for h in headers.iter() {
         assert_eq!(*h, "name", "Only 'name' column should appear, got '{h}'");
     }
+}
+
+#[test]
+#[cfg(feature = "luau")]
+fn frequency_stats_filter_duplicate_headers() {
+    // Regression: stats records were looked up by header NAME, so two columns named "y"
+    // both evaluated against the first's stats. The fix keys stats by position: only the
+    // genuinely-Integer column is excluded by `type == "Integer"`.
+    let wrk = Workdir::new("frequency_stats_filter_duplicate_headers");
+    // col 1 "y" = Integer, col 2 "y" = String
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["y", "y"],
+            svec!["1", "a"],
+            svec!["2", "a"],
+            svec!["3", "b"],
+        ],
+    );
+
+    let mut stats_cmd = wrk.command("stats");
+    stats_cmd
+        .arg("data.csv")
+        .arg("--cardinality")
+        .arg("--stats-jsonl");
+    wrk.assert_success(&mut stats_cmd);
+
+    let mut cmd = wrk.command("frequency");
+    cmd.arg("data.csv")
+        .args(["--stats-filter", r#"type == "Integer""#]);
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    // Only the String column (col 2: a,a,b) survives; the Integer column (col 1) is excluded.
+    let expected = vec![
+        svec!["field", "value", "count", "percentage", "rank"],
+        svec!["y", "a", "2", "66.66667", "1"],
+        svec!["y", "b", "1", "33.33333", "2"],
+    ];
+    assert_eq!(got, expected);
 }
 
 #[test]

--- a/tests/test_frequency.rs
+++ b/tests/test_frequency.rs
@@ -4012,6 +4012,47 @@ fn frequency_stats_filter_duplicate_headers() {
 
 #[test]
 #[cfg(feature = "luau")]
+fn frequency_no_float_and_stats_filter_compose() {
+    // Regression (roborev #3082): --no-float and --stats-filter compose. The stats-filter
+    // skip set must stay valid after --no-float removes an EARLIER column. Here A=Float is
+    // dropped by --no-float and B=Integer is excluded by --stats-filter, so only C=String
+    // survives. With position-based skip indices, the stats filter would have dropped the
+    // wrong (shifted) column.
+    let wrk = Workdir::new("frequency_no_float_and_stats_filter_compose");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["A", "B", "C"],
+            svec!["1.5", "10", "x"],
+            svec!["2.5", "20", "y"],
+            svec!["3.5", "20", "y"],
+        ],
+    );
+
+    let mut stats_cmd = wrk.command("stats");
+    stats_cmd
+        .arg("data.csv")
+        .arg("--cardinality")
+        .arg("--stats-jsonl");
+    wrk.assert_success(&mut stats_cmd);
+
+    let mut cmd = wrk.command("frequency");
+    cmd.arg("data.csv")
+        .args(["--no-float", "*"])
+        .args(["--stats-filter", r#"type == "Integer""#]);
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    // A (Float) dropped by --no-float; B (Integer) excluded by --stats-filter; only C remains.
+    let expected = vec![
+        svec!["field", "value", "count", "percentage", "rank"],
+        svec!["C", "y", "2", "66.66667", "1"],
+        svec!["C", "x", "1", "33.33333", "2"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+#[cfg(feature = "luau")]
 fn frequency_stats_filter_type() {
     // Test filtering columns by type
     let wrk = Workdir::new("frequency_stats_filter_type");

--- a/tests/test_tojsonl.rs
+++ b/tests/test_tojsonl.rs
@@ -634,3 +634,35 @@ fn tojsonl_number_nan_infinity_literal_is_null() {
 {"id":5,"score":2.5}"#;
     assert_eq!(got, expected);
 }
+
+#[test]
+#[serial]
+fn tojsonl_duplicate_headers_warns() {
+    // Duplicate column names collapse into a single JSON key; warn the user.
+    let wrk = Workdir::new("tojsonl_duplicate_headers_warns");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec!["id", "id", "name"],
+            svec!["1", "red", "bob"],
+            svec!["2", "blue", "sue"],
+        ],
+    );
+
+    let mut cmd = wrk.command("tojsonl");
+    cmd.arg("in.csv");
+    let stderr = wrk.output_stderr(&mut cmd);
+    assert!(
+        stderr.contains("Duplicate column name(s) detected (id)"),
+        "expected duplicate-header warning, got stderr: {stderr}"
+    );
+
+    // --quiet suppresses the warning
+    let mut quiet_cmd = wrk.command("tojsonl");
+    quiet_cmd.arg("--quiet").arg("in.csv");
+    let quiet_stderr = wrk.output_stderr(&mut quiet_cmd);
+    assert!(
+        !quiet_stderr.contains("Duplicate column name"),
+        "--quiet should suppress the warning, got stderr: {quiet_stderr}"
+    );
+}


### PR DESCRIPTION
## Problem

When a CSV has two or more columns sharing a header name, `qsv frequency` gave **every** duplicate the **first** duplicate's cardinality/uniqueness, so all of them were classified identically (all `<ALL_UNIQUE>`, all `<HIGH_CARDINALITY>`, or all "normal") regardless of their real per-column data. This was a **user-facing correctness bug in normal output**, not just a cache artifact.

```console
$ printf 'id,id\na,red\nb,red\nc,blue\nd,red\n' > dup.csv
$ qsv frequency dup.csv
# BEFORE (wrong — 2nd `id` is red=3/blue=1, not all-unique):
field,value,count,percentage,rank
id,<ALL_UNIQUE>,4,100,0
id,<ALL_UNIQUE>,4,100,0

# AFTER:
id,<ALL_UNIQUE>,4,100,0
id,red,3,75,1
id,blue,1,25,2
```

**Root cause:** per-column stats were looked up **by column name** with `Vec::find`, which returns the first match for duplicate names. The stats cache itself preserves per-position data (one record per column), so the fix threads the **column index** through instead of the name.

## Changes

### Root-cause fix (Option A — index-addressed stats)
- `COL_CARDINALITY_VEC` is now `Vec<u64>` aligned positionally to the **final selected columns** (was `Vec<(String, u64)>`).
- `get_unique_headers` takes the `Selection` and computes all-unique columns by **original column position**; `sel_headers` builds the final-order cardinality vector once the selection is known.
- Cache-write cardinality / `HIGH_CARDINALITY` decision and the capacity hints now index by position (the latter also fixes slightly-wrong pre-sizing under `--select`).

### Tier 1 — `frequency` JSON/TOON output
- Added positional `STATS_RECORDS_BY_POS` so duplicate-named columns each report their **own** `type`/`cardinality`/stats in JSON/TOON.
- Kept name-keyed `STATS_RECORDS` only for the `--weight` tolerance lookup (built only when `is_json && --weight`).
- Also fixes a **latent bug**: under `--no-headers`, the synthetic field name never matched the name-keyed map, so JSON/TOON silently emitted `type: ""` and dropped per-field stats. Now populated correctly.

### `--no-float` and `--stats-filter` made positional (roborev #3081)
- The float and stats-filter skip lists also keyed column type/stats by name, so duplicate-named columns collapsed (e.g. `x,x` with one Float + one String dropped/kept both). Now both compute positionally from the selection's original column indices (`col_type_by_pos` / `stats_by_pos`).

### `--no-float` + `--stats-filter` compose correctly (roborev #3082)
- The stats-filter skip set stored original-selection positions but was applied to the post-`--no-float` selection, so the indices shifted and the wrong column was dropped. Both skip sets now store **original CSV column indices** (stable across prior filtering) and the filter blocks key on the index value.

### Tier 2 — `schema` & `tojsonl`
- Added `util::duplicate_headers` and emit a warning (at the shared `infer_schema_from_stats` chokepoint, gated by `!quiet && !no_headers`) that name-keyed output collapses duplicate-named columns onto a single key. Their output formats (JSON Schema `properties`, JSONL row objects) **cannot represent** two same-named columns, so a clear warning — not a positional refactor — is the honest fix.

`pivotp` is intentionally left as-is: polars normalizes duplicate column names at load, so pivots aren't silently wrong.

## Performance
No per-row hot-loop changes anywhere. Setup goes from O(columns²) name-search loops to O(columns) positional indexing (eliminates per-column UTF-8 decode + string compare); `COL_CARDINALITY_VEC` drops a `String` per column. Net neutral-to-faster with lower memory.

## Tests
- `frequency` (**186 passed**): duplicate-header regressions for normal output, `--frequency-jsonl` cache, `HIGH_CARDINALITY`, `--json`, `--no-float`, `--stats-filter`, and `--no-float`+`--stats-filter` composition; updated `frequency_toon_no_headers` for the corrected (no-longer-empty) stats.
- `tojsonl` (**26 passed**): `tojsonl_duplicate_headers_warns` (warning present; `--quiet` suppresses).
- `schema` (**59 passed**).
- clippy clean; `qsvlite` builds; `cargo +nightly fmt` applied.

## Review
All three roborev review jobs on this branch (#3081, #3082) addressed and closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)