### PR TITLE
ci(viz): bump Pages deploy actions off deprecated Node 20

### DIFF
--- a/.github/workflows/viz-gallery-pages.yml
+++ b/.github/workflows/viz-gallery-pages.yml
@@ -30,12 +30,12 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/checkout@v7
+      - uses: actions/configure-pages@v6
+      - uses: actions/upload-pages-artifact@v5
         with:
           # serve the gallery directory as the site root, so the gallery's
           # relative iframe srcs (smart_*.html) and dataset links resolve
           path: examples/viz
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Why
The merge-triggered "Deploy viz gallery to Pages" run ([28108909987](https://github.com/dathere/qsv/actions/runs/28108909987)) succeeded but annotated:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/configure-pages@v5, actions/upload-pages-artifact@v4, actions/deploy-pages@v4, actions/upload-artifact@v4.

The forced-Node-24 shim is transitional. Bumping the actions to releases that natively target Node 24 clears the warning.

## Change
`.github/workflows/viz-gallery-pages.yml` was the lone outlier still on stale majors (the rest of the repo already standardized on `checkout@v7` etc.). Bumped to current latest majors:

- `actions/checkout@v4` → `@v7`
- `actions/configure-pages@v5` → `@v6`
- `actions/upload-pages-artifact@v3` → `@v5` (bundles a Node-24 `upload-artifact`, the source of the transitive warning)
- `actions/deploy-pages@v4` → `@v5`

No application code; no test/gallery regeneration. YAML validated with `yaml.safe_load`.

## Verify
After merge, trigger a no-op deploy and confirm the Node 20 annotation is gone and the deploy still succeeds (site idempotent: https://dathere.github.io/qsv/gallery.html):
\`\`\`bash
gh workflow run viz-gallery-pages.yml --ref master
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)