### PR TITLE
fix(viz): explicit --theme wins over saved toggle pref in smart dashboards

### DIFF
--- a/examples/viz/smart_dict_sunburst.html
+++ b/examples/viz/smart_dict_sunburst.html
@@ -154,13 +154,18 @@
   var DARK = { paper: "#111111", plot: "#111111", font: "#f2f5fa", grid: "#283442", line: "#506784", zero: "#283442", bg: "#111111", land: "#2a3138", water: "#16202b", mapbox: "carto-darkmatter" };
   var LIGHT = { paper: "#FFFFFF", plot: "#FFFFFF", font: "#2A3F5F", grid: "#ECECEC", line: "#BCC4CE", zero: "#ECECEC", bg: "#FFFFFF", land: "#d3d3d3", water: "#add8e6", mapbox: "carto-positron" };
   function isDark() {
+    // An explicit --theme is authoritative: it wins over a stale cross-dashboard
+    // saved preference (the localStorage key is shared across all qsv viz pages,
+    // so a "light" toggle on one dashboard must not override --theme plotly_dark
+    // on another).
+    if (themeDefaultMode === "dark") return true;
+    if (themeDefaultMode === "light") return false;
+    // No --theme: defer to the viewer's saved choice, then OS preference.
     try {
       var saved = localStorage.getItem("qsv-viz-theme");
       if (saved === "dark") return true;
       if (saved === "light") return false;
     } catch (e) {}
-    if (themeDefaultMode === "dark") return true;
-    if (themeDefaultMode === "light") return false;
     return window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
   }
   function buildUpdate(gd, p) {

--- a/examples/viz/smart_dict_treemap.html
+++ b/examples/viz/smart_dict_treemap.html
@@ -74,13 +74,18 @@
   var DARK = { paper: "#111111", plot: "#111111", font: "#f2f5fa", grid: "#283442", line: "#506784", zero: "#283442", bg: "#111111", land: "#2a3138", water: "#16202b", mapbox: "carto-darkmatter" };
   var LIGHT = { paper: "#FFFFFF", plot: "#FFFFFF", font: "#2A3F5F", grid: "#ECECEC", line: "#BCC4CE", zero: "#ECECEC", bg: "#FFFFFF", land: "#d3d3d3", water: "#add8e6", mapbox: "carto-positron" };
   function isDark() {
+    // An explicit --theme is authoritative: it wins over a stale cross-dashboard
+    // saved preference (the localStorage key is shared across all qsv viz pages,
+    // so a "light" toggle on one dashboard must not override --theme plotly_dark
+    // on another).
+    if (themeDefaultMode === "dark") return true;
+    if (themeDefaultMode === "light") return false;
+    // No --theme: defer to the viewer's saved choice, then OS preference.
     try {
       var saved = localStorage.getItem("qsv-viz-theme");
       if (saved === "dark") return true;
       if (saved === "light") return false;
     } catch (e) {}
-    if (themeDefaultMode === "dark") return true;
-    if (themeDefaultMode === "light") return false;
     return window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
   }
   function buildUpdate(gd, p) {

--- a/examples/viz/smart_geo_outliers.html
+++ b/examples/viz/smart_geo_outliers.html
@@ -131,13 +131,18 @@
   var DARK = { paper: "#111111", plot: "#111111", font: "#f2f5fa", grid: "#283442", line: "#506784", zero: "#283442", bg: "#111111", land: "#2a3138", water: "#16202b", mapbox: "carto-darkmatter" };
   var LIGHT = { paper: "#FFFFFF", plot: "#FFFFFF", font: "#2A3F5F", grid: "#ECECEC", line: "#BCC4CE", zero: "#ECECEC", bg: "#FFFFFF", land: "#d3d3d3", water: "#add8e6", mapbox: "carto-positron" };
   function isDark() {
+    // An explicit --theme is authoritative: it wins over a stale cross-dashboard
+    // saved preference (the localStorage key is shared across all qsv viz pages,
+    // so a "light" toggle on one dashboard must not override --theme plotly_dark
+    // on another).
+    if (themeDefaultMode === "dark") return true;
+    if (themeDefaultMode === "light") return false;
+    // No --theme: defer to the viewer's saved choice, then OS preference.
     try {
       var saved = localStorage.getItem("qsv-viz-theme");
       if (saved === "dark") return true;
       if (saved === "light") return false;
     } catch (e) {}
-    if (themeDefaultMode === "dark") return true;
-    if (themeDefaultMode === "light") return false;
     return window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
   }
   function buildUpdate(gd, p) {

--- a/examples/viz/smart_geospatial.html
+++ b/examples/viz/smart_geospatial.html
@@ -131,13 +131,18 @@
   var DARK = { paper: "#111111", plot: "#111111", font: "#f2f5fa", grid: "#283442", line: "#506784", zero: "#283442", bg: "#111111", land: "#2a3138", water: "#16202b", mapbox: "carto-darkmatter" };
   var LIGHT = { paper: "#FFFFFF", plot: "#FFFFFF", font: "#2A3F5F", grid: "#ECECEC", line: "#BCC4CE", zero: "#ECECEC", bg: "#FFFFFF", land: "#d3d3d3", water: "#add8e6", mapbox: "carto-positron" };
   function isDark() {
+    // An explicit --theme is authoritative: it wins over a stale cross-dashboard
+    // saved preference (the localStorage key is shared across all qsv viz pages,
+    // so a "light" toggle on one dashboard must not override --theme plotly_dark
+    // on another).
+    if (themeDefaultMode === "dark") return true;
+    if (themeDefaultMode === "light") return false;
+    // No --theme: defer to the viewer's saved choice, then OS preference.
     try {
       var saved = localStorage.getItem("qsv-viz-theme");
       if (saved === "dark") return true;
       if (saved === "light") return false;
     } catch (e) {}
-    if (themeDefaultMode === "dark") return true;
-    if (themeDefaultMode === "light") return false;
     return window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
   }
   function buildUpdate(gd, p) {

--- a/examples/viz/smart_nyc311.html
+++ b/examples/viz/smart_nyc311.html
@@ -347,13 +347,18 @@
   var DARK = { paper: "#111111", plot: "#111111", font: "#f2f5fa", grid: "#283442", line: "#506784", zero: "#283442", bg: "#111111", land: "#2a3138", water: "#16202b", mapbox: "carto-darkmatter" };
   var LIGHT = { paper: "#FFFFFF", plot: "#FFFFFF", font: "#2A3F5F", grid: "#ECECEC", line: "#BCC4CE", zero: "#ECECEC", bg: "#FFFFFF", land: "#d3d3d3", water: "#add8e6", mapbox: "carto-positron" };
   function isDark() {
+    // An explicit --theme is authoritative: it wins over a stale cross-dashboard
+    // saved preference (the localStorage key is shared across all qsv viz pages,
+    // so a "light" toggle on one dashboard must not override --theme plotly_dark
+    // on another).
+    if (themeDefaultMode === "dark") return true;
+    if (themeDefaultMode === "light") return false;
+    // No --theme: defer to the viewer's saved choice, then OS preference.
     try {
       var saved = localStorage.getItem("qsv-viz-theme");
       if (saved === "dark") return true;
       if (saved === "light") return false;
     } catch (e) {}
-    if (themeDefaultMode === "dark") return true;
-    if (themeDefaultMode === "light") return false;
     return window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
   }
   function buildUpdate(gd, p) {

--- a/examples/viz/smart_sales.html
+++ b/examples/viz/smart_sales.html
@@ -106,13 +106,18 @@
   var DARK = { paper: "#111111", plot: "#111111", font: "#f2f5fa", grid: "#283442", line: "#506784", zero: "#283442", bg: "#111111", land: "#2a3138", water: "#16202b", mapbox: "carto-darkmatter" };
   var LIGHT = { paper: "#FFFFFF", plot: "#FFFFFF", font: "#2A3F5F", grid: "#ECECEC", line: "#BCC4CE", zero: "#ECECEC", bg: "#FFFFFF", land: "#d3d3d3", water: "#add8e6", mapbox: "carto-positron" };
   function isDark() {
+    // An explicit --theme is authoritative: it wins over a stale cross-dashboard
+    // saved preference (the localStorage key is shared across all qsv viz pages,
+    // so a "light" toggle on one dashboard must not override --theme plotly_dark
+    // on another).
+    if (themeDefaultMode === "dark") return true;
+    if (themeDefaultMode === "light") return false;
+    // No --theme: defer to the viewer's saved choice, then OS preference.
     try {
       var saved = localStorage.getItem("qsv-viz-theme");
       if (saved === "dark") return true;
       if (saved === "light") return false;
     } catch (e) {}
-    if (themeDefaultMode === "dark") return true;
-    if (themeDefaultMode === "light") return false;
     return window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
   }
   function buildUpdate(gd, p) {

--- a/examples/viz/smart_smarter.html
+++ b/examples/viz/smart_smarter.html
@@ -82,13 +82,18 @@
   var DARK = { paper: "#111111", plot: "#111111", font: "#f2f5fa", grid: "#283442", line: "#506784", zero: "#283442", bg: "#111111", land: "#2a3138", water: "#16202b", mapbox: "carto-darkmatter" };
   var LIGHT = { paper: "#FFFFFF", plot: "#FFFFFF", font: "#2A3F5F", grid: "#ECECEC", line: "#BCC4CE", zero: "#ECECEC", bg: "#FFFFFF", land: "#d3d3d3", water: "#add8e6", mapbox: "carto-positron" };
   function isDark() {
+    // An explicit --theme is authoritative: it wins over a stale cross-dashboard
+    // saved preference (the localStorage key is shared across all qsv viz pages,
+    // so a "light" toggle on one dashboard must not override --theme plotly_dark
+    // on another).
+    if (themeDefaultMode === "dark") return true;
+    if (themeDefaultMode === "light") return false;
+    // No --theme: defer to the viewer's saved choice, then OS preference.
     try {
       var saved = localStorage.getItem("qsv-viz-theme");
       if (saved === "dark") return true;
       if (saved === "light") return false;
     } catch (e) {}
-    if (themeDefaultMode === "dark") return true;
-    if (themeDefaultMode === "light") return false;
     return window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
   }
   function buildUpdate(gd, p) {

--- a/examples/viz/smart_timeseries.html
+++ b/examples/viz/smart_timeseries.html
@@ -46,13 +46,18 @@
   var DARK = { paper: "#111111", plot: "#111111", font: "#f2f5fa", grid: "#283442", line: "#506784", zero: "#283442", bg: "#111111", land: "#2a3138", water: "#16202b", mapbox: "carto-darkmatter" };
   var LIGHT = { paper: "#FFFFFF", plot: "#FFFFFF", font: "#2A3F5F", grid: "#ECECEC", line: "#BCC4CE", zero: "#ECECEC", bg: "#FFFFFF", land: "#d3d3d3", water: "#add8e6", mapbox: "carto-positron" };
   function isDark() {
+    // An explicit --theme is authoritative: it wins over a stale cross-dashboard
+    // saved preference (the localStorage key is shared across all qsv viz pages,
+    // so a "light" toggle on one dashboard must not override --theme plotly_dark
+    // on another).
+    if (themeDefaultMode === "dark") return true;
+    if (themeDefaultMode === "light") return false;
+    // No --theme: defer to the viewer's saved choice, then OS preference.
     try {
       var saved = localStorage.getItem("qsv-viz-theme");
       if (saved === "dark") return true;
       if (saved === "light") return false;
     } catch (e) {}
-    if (themeDefaultMode === "dark") return true;
-    if (themeDefaultMode === "light") return false;
     return window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
   }
   function buildUpdate(gd, p) {

--- a/examples/viz/smart_us_choropleth.html
+++ b/examples/viz/smart_us_choropleth.html
@@ -91,13 +91,18 @@
   var DARK = { paper: "#111111", plot: "#111111", font: "#f2f5fa", grid: "#283442", line: "#506784", zero: "#283442", bg: "#111111", land: "#2a3138", water: "#16202b", mapbox: "carto-darkmatter" };
   var LIGHT = { paper: "#FFFFFF", plot: "#FFFFFF", font: "#2A3F5F", grid: "#ECECEC", line: "#BCC4CE", zero: "#ECECEC", bg: "#FFFFFF", land: "#d3d3d3", water: "#add8e6", mapbox: "carto-positron" };
   function isDark() {
+    // An explicit --theme is authoritative: it wins over a stale cross-dashboard
+    // saved preference (the localStorage key is shared across all qsv viz pages,
+    // so a "light" toggle on one dashboard must not override --theme plotly_dark
+    // on another).
+    if (themeDefaultMode === "dark") return true;
+    if (themeDefaultMode === "light") return false;
+    // No --theme: defer to the viewer's saved choice, then OS preference.
     try {
       var saved = localStorage.getItem("qsv-viz-theme");
       if (saved === "dark") return true;
       if (saved === "light") return false;
     } catch (e) {}
-    if (themeDefaultMode === "dark") return true;
-    if (themeDefaultMode === "light") return false;
     return window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
   }
   function buildUpdate(gd, p) {

--- a/examples/viz/smart_world_choropleth.html
+++ b/examples/viz/smart_world_choropleth.html
@@ -114,13 +114,18 @@
   var DARK = { paper: "#111111", plot: "#111111", font: "#f2f5fa", grid: "#283442", line: "#506784", zero: "#283442", bg: "#111111", land: "#2a3138", water: "#16202b", mapbox: "carto-darkmatter" };
   var LIGHT = { paper: "#FFFFFF", plot: "#FFFFFF", font: "#2A3F5F", grid: "#ECECEC", line: "#BCC4CE", zero: "#ECECEC", bg: "#FFFFFF", land: "#d3d3d3", water: "#add8e6", mapbox: "carto-positron" };
   function isDark() {
+    // An explicit --theme is authoritative: it wins over a stale cross-dashboard
+    // saved preference (the localStorage key is shared across all qsv viz pages,
+    // so a "light" toggle on one dashboard must not override --theme plotly_dark
+    // on another).
+    if (themeDefaultMode === "dark") return true;
+    if (themeDefaultMode === "light") return false;
+    // No --theme: defer to the viewer's saved choice, then OS preference.
     try {
       var saved = localStorage.getItem("qsv-viz-theme");
       if (saved === "dark") return true;
       if (saved === "light") return false;
     } catch (e) {}
-    if (themeDefaultMode === "dark") return true;
-    if (themeDefaultMode === "light") return false;
     return window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
   }
   function buildUpdate(gd, p) {

--- a/src/cmd/viz.rs
+++ b/src/cmd/viz.rs
@@ -4721,6 +4721,28 @@ fn light_chart_palette(
     }
 }
 
+/// The chart colors `(paper, font, grid, line, zero)` the toggle's runtime DARK palette applies.
+/// Symmetric to `light_chart_palette`: a dark theme drives its own template colors so the dark
+/// view (and the dark toggle target) honors that theme's actual shade — e.g. `seaborn_dark`'s
+/// `#222222` rather than collapsing to the generic `#111111`. `plotly_dark`, the light themes,
+/// and no theme keep the generic fixed-dark set (which equals `plotly_dark`'s own colors), so
+/// those dashboards render byte-identically. Mirrors the fork's `layout::themes` values.
+fn dark_chart_palette(
+    theme: Option<BuiltinTheme>,
+) -> (
+    &'static str,
+    &'static str,
+    &'static str,
+    &'static str,
+    &'static str,
+) {
+    match theme {
+        Some(BuiltinTheme::SeabornDark) => ("#222222", "#eaeaf2", "#444444", "#888888", "#444444"),
+        // plotly_dark, the light themes, and no theme use the generic fixed-dark set.
+        _ => ("#111111", "#f2f5fa", "#283442", "#506784", "#283442"),
+    }
+}
+
 /// The CSS, button markup, and re-theming `<script>` for the `viz smart` light/dark toggle,
 /// shared by both HTML render paths (the inline-div grid and the single typed-`Plot` grid).
 /// Page chrome is driven by CSS variables (`--qsv-page-bg`/`--qsv-page-ink`/`--qsv-geo-meta`)
@@ -4754,24 +4776,30 @@ fn toggle_chrome(theme: Option<BuiltinTheme>) -> ToggleChrome {
         Some(_) => "light",
     };
 
+    // The light/dark chart palettes the runtime toggle relayouts to. Each mirrors the selected
+    // theme's own template colors for that mode (so the page chrome and the charts agree), else
+    // qsv's built-in light look / the generic fixed-dark set. The dark page chrome reuses the dark
+    // chart paper/font (geo-meta stays a fixed light gray, readable on any dark page).
+    let (light_paper, light_font, light_grid, light_line, light_zero) = light_chart_palette(theme);
+    let (dark_paper, dark_font, dark_grid, dark_line, dark_zero) = dark_chart_palette(theme);
+
     // Raw-string templates with token placeholders, so the brace-heavy JS needs no `{{`/`}}`
     // escaping and rustfmt's `format_strings` (regular-string-only) won't reflow/mangle them.
     let style = STYLE_TEMPLATE
         .replace("__LIGHT_BG__", light_bg)
         .replace("__LIGHT_INK__", light_ink)
         .replace("__LIGHT_GEO_META__", light_geo_meta)
+        .replace("__DARK_BG__", dark_paper)
+        .replace("__DARK_INK__", dark_font)
+        .replace("__DARK_GEO_META__", "#9aa4b2")
         .replace("__FONT_FAMILY__", FONT_FAMILY);
 
     let button = "<button id=\"qsv-theme-toggle\" type=\"button\" aria-label=\"Toggle light/dark \
                   mode\">\u{1F313} Theme</button>"
         .to_string();
 
-    // The light palette mirrors the selected theme's own template colors for light non-default
-    // themes (so the relayout keeps charts consistent with the themed page), else qsv's built-in
-    // look; the dark palette is a fixed dark set. `buildUpdate` only sets keys present on a given
-    // graph's layout, so axis-less plots (pie) and arbitrary subplot counts both work without
-    // knowing div ids.
-    let (light_paper, light_font, light_grid, light_line, light_zero) = light_chart_palette(theme);
+    // `buildUpdate` only sets keys present on a given graph's layout, so axis-less plots (pie) and
+    // arbitrary subplot counts both work without knowing div ids.
     let script = SCRIPT_TEMPLATE
         .replace("__DEFAULT_MODE__", default_mode)
         .replace("__LIGHT_PAPER__", light_paper)
@@ -4779,6 +4807,11 @@ fn toggle_chrome(theme: Option<BuiltinTheme>) -> ToggleChrome {
         .replace("__LIGHT_GRID__", light_grid)
         .replace("__LIGHT_LINE__", light_line)
         .replace("__LIGHT_ZERO__", light_zero)
+        .replace("__DARK_PAPER__", dark_paper)
+        .replace("__DARK_FONT__", dark_font)
+        .replace("__DARK_GRID__", dark_grid)
+        .replace("__DARK_LINE__", dark_line)
+        .replace("__DARK_ZERO__", dark_zero)
         .replace("__GEO_LAND_LIGHT__", GEO_LAND_LIGHT)
         .replace("__GEO_WATER_LIGHT__", GEO_WATER_LIGHT)
         .replace("__GEO_LAND_DARK__", GEO_LAND_DARK)
@@ -4808,7 +4841,7 @@ fn logo_markup() -> String {
 /// CSS variables + toggle-button rule for `toggle_chrome`. Token placeholders are substituted at
 /// runtime; kept as a raw string so the literal CSS braces stay intact.
 const STYLE_TEMPLATE: &str = r#"  :root { --qsv-page-bg: __LIGHT_BG__; --qsv-page-ink: __LIGHT_INK__; --qsv-geo-meta: __LIGHT_GEO_META__; }
-  body.qsv-dark { --qsv-page-bg: #111111; --qsv-page-ink: #f2f5fa; --qsv-geo-meta: #9aa4b2; }
+  body.qsv-dark { --qsv-page-bg: __DARK_BG__; --qsv-page-ink: __DARK_INK__; --qsv-geo-meta: __DARK_GEO_META__; }
   #qsv-theme-toggle { position: fixed; top: 12px; right: 12px; z-index: 1000; font: 13px __FONT_FAMILY__; padding: 6px 12px; border-radius: 6px; border: 1px solid var(--qsv-page-ink); background: var(--qsv-page-bg); color: var(--qsv-page-ink); cursor: pointer; opacity: 0.85; }
   #qsv-theme-toggle:hover { opacity: 1; }"#;
 
@@ -4817,7 +4850,7 @@ const STYLE_TEMPLATE: &str = r#"  :root { --qsv-page-bg: __LIGHT_BG__; --qsv-pag
 const SCRIPT_TEMPLATE: &str = r##"<script>
 (function () {
   var themeDefaultMode = "__DEFAULT_MODE__";
-  var DARK = { paper: "#111111", plot: "#111111", font: "#f2f5fa", grid: "#283442", line: "#506784", zero: "#283442", bg: "#111111", land: "__GEO_LAND_DARK__", water: "__GEO_WATER_DARK__", mapbox: "carto-darkmatter" };
+  var DARK = { paper: "__DARK_PAPER__", plot: "__DARK_PAPER__", font: "__DARK_FONT__", grid: "__DARK_GRID__", line: "__DARK_LINE__", zero: "__DARK_ZERO__", bg: "__DARK_PAPER__", land: "__GEO_LAND_DARK__", water: "__GEO_WATER_DARK__", mapbox: "carto-darkmatter" };
   var LIGHT = { paper: "__LIGHT_PAPER__", plot: "__LIGHT_PAPER__", font: "__LIGHT_FONT__", grid: "__LIGHT_GRID__", line: "__LIGHT_LINE__", zero: "__LIGHT_ZERO__", bg: "__LIGHT_PAPER__", land: "__GEO_LAND_LIGHT__", water: "__GEO_WATER_LIGHT__", mapbox: "carto-positron" };
   function isDark() {
     // An explicit --theme is authoritative: it wins over a stale cross-dashboard

--- a/src/cmd/viz.rs
+++ b/src/cmd/viz.rs
@@ -4693,9 +4693,11 @@ fn theme_page_chrome(theme: Option<BuiltinTheme>) -> (&'static str, &'static str
 /// shared by both HTML render paths (the inline-div grid and the single typed-`Plot` grid).
 /// Page chrome is driven by CSS variables (`--qsv-page-bg`/`--qsv-page-ink`/`--qsv-geo-meta`)
 /// so flipping `body.qsv-dark` recolors the page instantly, while the script calls
-/// `Plotly.relayout` on every live graph div to recolor the plots themselves. `theme` only
-/// decides the *default* mode when the viewer has no saved/OS preference (dark built-in themes
-/// open dark). Known limitation: geo/scene/polar/pie panels flip their background, font, and
+/// `Plotly.relayout` on every live graph div to recolor the plots themselves. An explicit
+/// `theme` is authoritative — it sets the initial mode and wins over any saved/OS preference
+/// (so `--theme plotly_dark` always opens dark); only an unthemed dashboard (`theme == None`)
+/// defers to the viewer's saved choice then OS preference. Known limitation: geo/scene/polar/pie
+/// panels flip their background, font, and
 /// container color, but basemap fills, mapbox tiles, and trace marker colors do NOT re-theme
 /// (that would need a trace-type-aware `Plotly.restyle`, which is out of scope here).
 struct ToggleChrome {
@@ -4709,10 +4711,11 @@ struct ToggleChrome {
 
 fn toggle_chrome(theme: Option<BuiltinTheme>) -> ToggleChrome {
     let (light_bg, light_ink, light_geo_meta) = theme_page_chrome(theme);
-    // Three-state initial mode (overridable by a saved localStorage choice). An EXPLICIT
-    // `--theme` opens in that theme's implied mode — dark for the dark built-ins, light for every
-    // other (light) built-in — so e.g. `--theme plotly_white` is NOT overridden by a dark-mode OS.
-    // Only with no `--theme` at all do we defer to the viewer's `prefers-color-scheme`.
+    // Three-state initial mode. An EXPLICIT `--theme` is authoritative: it opens in that theme's
+    // implied mode — dark for the dark built-ins, light for every other (light) built-in — and is
+    // NOT overridden by a saved localStorage choice or a dark-mode OS (see `isDark()`). Only with
+    // no `--theme` at all (`"system"`) do we defer to the saved choice, then
+    // `prefers-color-scheme`.
     let default_mode = match theme {
         None => "system",
         Some(BuiltinTheme::PlotlyDark | BuiltinTheme::SeabornDark) => "dark",
@@ -4781,13 +4784,18 @@ const SCRIPT_TEMPLATE: &str = r##"<script>
   var DARK = { paper: "#111111", plot: "#111111", font: "#f2f5fa", grid: "#283442", line: "#506784", zero: "#283442", bg: "#111111", land: "__GEO_LAND_DARK__", water: "__GEO_WATER_DARK__", mapbox: "carto-darkmatter" };
   var LIGHT = { paper: "__PAPER_BG__", plot: "__PAPER_BG__", font: "__INK__", grid: "__GRID_COLOR__", line: "__AXIS_LINE__", zero: "__GRID_COLOR__", bg: "__PAPER_BG__", land: "__GEO_LAND_LIGHT__", water: "__GEO_WATER_LIGHT__", mapbox: "carto-positron" };
   function isDark() {
+    // An explicit --theme is authoritative: it wins over a stale cross-dashboard
+    // saved preference (the localStorage key is shared across all qsv viz pages,
+    // so a "light" toggle on one dashboard must not override --theme plotly_dark
+    // on another).
+    if (themeDefaultMode === "dark") return true;
+    if (themeDefaultMode === "light") return false;
+    // No --theme: defer to the viewer's saved choice, then OS preference.
     try {
       var saved = localStorage.getItem("qsv-viz-theme");
       if (saved === "dark") return true;
       if (saved === "light") return false;
     } catch (e) {}
-    if (themeDefaultMode === "dark") return true;
-    if (themeDefaultMode === "light") return false;
     return window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
   }
   function buildUpdate(gd, p) {

--- a/src/cmd/viz.rs
+++ b/src/cmd/viz.rs
@@ -4689,6 +4689,38 @@ fn theme_page_chrome(theme: Option<BuiltinTheme>) -> (&'static str, &'static str
     }
 }
 
+/// The chart colors `(paper, font, grid, line, zero)` the toggle's runtime LIGHT palette applies
+/// on load. For a light *non-default* theme (seaborn/seaborn_whitegrid/matplotlib/plotnine) this
+/// mirrors that theme's own template colors, so the on-load `Plotly.relayout` keeps the panel
+/// backgrounds consistent with the themed page chrome (`theme_page_chrome`) instead of resetting
+/// them to qsv's generic light look — which left e.g. a `#EAEAF2` seaborn page wrapping `#FFFFFF`
+/// charts. Every other case (no theme, the white `default`/`plotly_white`, or a dark theme whose
+/// LIGHT palette is only the toggle's light *complement*) keeps qsv's built-in light look, so
+/// unthemed and dark-theme dashboards render byte-identically. Mirrors the fork's
+/// `layout::themes` values. Trace colors come from the baked template (the relayout never touches
+/// `colorway`/marker colors), so they are already theme-correct and out of scope here.
+fn light_chart_palette(
+    theme: Option<BuiltinTheme>,
+) -> (
+    &'static str,
+    &'static str,
+    &'static str,
+    &'static str,
+    &'static str,
+) {
+    match theme {
+        Some(BuiltinTheme::Seaborn) => ("#EAEAF2", "#333333", "#D3D3D3", "#CCCCCC", "#D3D3D3"),
+        Some(BuiltinTheme::SeabornWhitegrid) => {
+            ("#FFFFFF", "#333333", "#E5E5E5", "#CCCCCC", "#E5E5E5")
+        },
+        Some(BuiltinTheme::Matplotlib) => ("#FFFFFF", "black", "#e5e5e5", "black", "#e5e5e5"),
+        Some(BuiltinTheme::Plotnine) => ("#EBEBEB", "#525252", "#FFFFFF", "#CCCCCC", "#FFFFFF"),
+        // No theme, the white default themes, and dark themes (whose light palette is just the
+        // toggle's light complement) all keep qsv's built-in light look.
+        _ => (PAPER_BG, INK, GRID_COLOR, AXIS_LINE, GRID_COLOR),
+    }
+}
+
 /// The CSS, button markup, and re-theming `<script>` for the `viz smart` light/dark toggle,
 /// shared by both HTML render paths (the inline-div grid and the single typed-`Plot` grid).
 /// Page chrome is driven by CSS variables (`--qsv-page-bg`/`--qsv-page-ink`/`--qsv-geo-meta`)
@@ -4734,15 +4766,19 @@ fn toggle_chrome(theme: Option<BuiltinTheme>) -> ToggleChrome {
                   mode\">\u{1F313} Theme</button>"
         .to_string();
 
-    // The light palette mirrors qsv's built-in look (INK/PAPER_BG/GRID_COLOR/AXIS_LINE); the dark
-    // palette is a fixed dark set. `buildUpdate` only sets keys present on a given graph's layout,
-    // so axis-less plots (pie) and arbitrary subplot counts both work without knowing div ids.
+    // The light palette mirrors the selected theme's own template colors for light non-default
+    // themes (so the relayout keeps charts consistent with the themed page), else qsv's built-in
+    // look; the dark palette is a fixed dark set. `buildUpdate` only sets keys present on a given
+    // graph's layout, so axis-less plots (pie) and arbitrary subplot counts both work without
+    // knowing div ids.
+    let (light_paper, light_font, light_grid, light_line, light_zero) = light_chart_palette(theme);
     let script = SCRIPT_TEMPLATE
         .replace("__DEFAULT_MODE__", default_mode)
-        .replace("__PAPER_BG__", PAPER_BG)
-        .replace("__INK__", INK)
-        .replace("__GRID_COLOR__", GRID_COLOR)
-        .replace("__AXIS_LINE__", AXIS_LINE)
+        .replace("__LIGHT_PAPER__", light_paper)
+        .replace("__LIGHT_FONT__", light_font)
+        .replace("__LIGHT_GRID__", light_grid)
+        .replace("__LIGHT_LINE__", light_line)
+        .replace("__LIGHT_ZERO__", light_zero)
         .replace("__GEO_LAND_LIGHT__", GEO_LAND_LIGHT)
         .replace("__GEO_WATER_LIGHT__", GEO_WATER_LIGHT)
         .replace("__GEO_LAND_DARK__", GEO_LAND_DARK)
@@ -4782,7 +4818,7 @@ const SCRIPT_TEMPLATE: &str = r##"<script>
 (function () {
   var themeDefaultMode = "__DEFAULT_MODE__";
   var DARK = { paper: "#111111", plot: "#111111", font: "#f2f5fa", grid: "#283442", line: "#506784", zero: "#283442", bg: "#111111", land: "__GEO_LAND_DARK__", water: "__GEO_WATER_DARK__", mapbox: "carto-darkmatter" };
-  var LIGHT = { paper: "__PAPER_BG__", plot: "__PAPER_BG__", font: "__INK__", grid: "__GRID_COLOR__", line: "__AXIS_LINE__", zero: "__GRID_COLOR__", bg: "__PAPER_BG__", land: "__GEO_LAND_LIGHT__", water: "__GEO_WATER_LIGHT__", mapbox: "carto-positron" };
+  var LIGHT = { paper: "__LIGHT_PAPER__", plot: "__LIGHT_PAPER__", font: "__LIGHT_FONT__", grid: "__LIGHT_GRID__", line: "__LIGHT_LINE__", zero: "__LIGHT_ZERO__", bg: "__LIGHT_PAPER__", land: "__GEO_LAND_LIGHT__", water: "__GEO_WATER_LIGHT__", mapbox: "carto-positron" };
   function isDark() {
     // An explicit --theme is authoritative: it wins over a stale cross-dashboard
     // saved preference (the localStorage key is shared across all qsv viz pages,

--- a/tests/test_viz.rs
+++ b/tests/test_viz.rs
@@ -3724,6 +3724,20 @@ fn viz_smart_inline_theme_drives_page_chrome() {
     assert!(html.contains(r#"var themeDefaultMode = "dark""#));
     // and the panels themselves carry the dark template
     assert!(html.contains(r#""template":{"layout""#));
+    // regression: an explicit --theme is authoritative. isDark() must consult themeDefaultMode
+    // BEFORE the saved localStorage value, so a stale cross-dashboard "light" preference (the
+    // key is shared across all qsv viz pages) can't override --theme plotly_dark and leave a
+    // dark page with light charts.
+    let theme_check = html
+        .find(r#"if (themeDefaultMode === "dark") return true;"#)
+        .expect("isDark() should check themeDefaultMode");
+    let saved_check = html
+        .find(r#"localStorage.getItem("qsv-viz-theme")"#)
+        .expect("isDark() should read the saved preference");
+    assert!(
+        theme_check < saved_check,
+        "isDark() must check themeDefaultMode before localStorage so an explicit --theme wins"
+    );
 }
 
 #[test]

--- a/tests/test_viz.rs
+++ b/tests/test_viz.rs
@@ -3741,6 +3741,39 @@ fn viz_smart_inline_theme_drives_page_chrome() {
 }
 
 #[test]
+fn viz_smart_light_theme_palette_matches_chrome() {
+    // a light non-default theme (seaborn) must drive the runtime LIGHT palette so the on-load
+    // relayout keeps the panels consistent with the themed page chrome, instead of resetting them
+    // to qsv's generic light look (which left a #EAEAF2 seaborn page wrapping #FFFFFF charts).
+    let wrk = Workdir::new("viz_smart_light_theme_palette_matches_chrome");
+    let mut rows = String::from("id,age,city,active\n");
+    for i in 1..=100 {
+        let city = match i % 3 {
+            0 => "NYC",
+            1 => "LA",
+            _ => "SF",
+        };
+        let active = if i % 2 == 0 { "true" } else { "false" };
+        rows.push_str(&format!("{i},{},{city},{active}\n", 20 + i % 50));
+    }
+    wrk.create_from_string("people.csv", &rows);
+
+    let out_html = wrk.path("dash.html").to_string_lossy().to_string();
+    let mut cmd = wrk.command("viz");
+    cmd.args(["smart", "people.csv", "--theme", "seaborn", "-o", &out_html]);
+    wrk.assert_success(&mut cmd);
+
+    let html = wrk.read_to_string("dash.html").unwrap();
+    // the runtime LIGHT palette carries seaborn's own paper/font colors ...
+    assert!(html.contains(r##"var LIGHT = { paper: "#EAEAF2", plot: "#EAEAF2", font: "#333333""##));
+    // ... matching the seaborn page chrome (so page and charts agree), and it opens in light mode.
+    assert!(html.contains("--qsv-page-bg: #EAEAF2"));
+    assert!(html.contains(r#"var themeDefaultMode = "light""#));
+    // the dark complement (toggle target) stays the generic fixed-dark set.
+    assert!(html.contains(r##"var DARK = { paper: "#111111""##));
+}
+
+#[test]
 fn viz_smart_grid_has_theme_toggle() {
     // the common ≤8-panel case: the single typed-Plot grid is now wrapped in qsv's own HTML
     // page so it carries the always-on light/dark toggle (plotly's to_html() has no hook).

--- a/tests/test_viz.rs
+++ b/tests/test_viz.rs
@@ -3774,6 +3774,44 @@ fn viz_smart_light_theme_palette_matches_chrome() {
 }
 
 #[test]
+fn viz_smart_seaborn_dark_palette_matches_chrome() {
+    // seaborn_dark is a dark theme whose own shade is #222222, not the generic #111111. Its dark
+    // chart palette and dark page chrome must both carry #222222 so the default (dark) view honors
+    // the theme instead of collapsing to a plotly_dark look.
+    let wrk = Workdir::new("viz_smart_seaborn_dark_palette_matches_chrome");
+    let mut rows = String::from("id,age,city,active\n");
+    for i in 1..=100 {
+        let city = match i % 3 {
+            0 => "NYC",
+            1 => "LA",
+            _ => "SF",
+        };
+        let active = if i % 2 == 0 { "true" } else { "false" };
+        rows.push_str(&format!("{i},{},{city},{active}\n", 20 + i % 50));
+    }
+    wrk.create_from_string("people.csv", &rows);
+
+    let out_html = wrk.path("dash.html").to_string_lossy().to_string();
+    let mut cmd = wrk.command("viz");
+    cmd.args([
+        "smart",
+        "people.csv",
+        "--theme",
+        "seaborn_dark",
+        "-o",
+        &out_html,
+    ]);
+    wrk.assert_success(&mut cmd);
+
+    let html = wrk.read_to_string("dash.html").unwrap();
+    // the runtime DARK palette carries seaborn_dark's own paper/font ...
+    assert!(html.contains(r##"var DARK = { paper: "#222222", plot: "#222222", font: "#eaeaf2""##));
+    // ... and the dark page chrome matches it, opening in dark mode.
+    assert!(html.contains("body.qsv-dark { --qsv-page-bg: #222222;"));
+    assert!(html.contains(r#"var themeDefaultMode = "dark""#));
+}
+
+#[test]
 fn viz_smart_grid_has_theme_toggle() {
     // the common ≤8-panel case: the single typed-Plot grid is now wrapped in qsv's own HTML
     // page so it carries the always-on light/dark toggle (plotly's to_html() has no hook).


### PR DESCRIPTION
## Problem

On the [Japan earthquakes gallery example](https://dathere.github.io/qsv/gallery.html) generated with `--theme plotly_dark`, the **page chrome renders dark but the charts render light**.

**Root cause:** `viz smart` HTML dashboards inject a runtime light/dark toggle (`SCRIPT_TEMPLATE` in `src/cmd/viz.rs`). Its `isDark()` consulted `localStorage["qsv-viz-theme"]` **before** the explicit `--theme` (`themeDefaultMode`). That localStorage key is **shared across all qsv viz dashboards on an origin**, so toggling *any* prior dashboard to light leaves a stale `"light"` that silently overrides a freshly-generated `--theme plotly_dark` dashboard — the charts relayout to the qsv-light palette (`paper_bgcolor` `#FFFFFF`) while `theme_page_chrome` keeps the page dark. Hence "dark page, light charts." On a brand-new browser (no saved pref) it already renders dark, which is why the bug looked intermittent.

## Fix

Reorder `isDark()` so an explicit `--theme` is **authoritative** and wins over the saved/OS preference. The saved preference (and OS `prefers-color-scheme`) now applies only to un-themed (`"system"`) dashboards.

```js
function isDark() {
  // explicit --theme is authoritative
  if (themeDefaultMode === "dark") return true;
  if (themeDefaultMode === "light") return false;
  // no --theme: defer to saved choice, then OS preference
  try { var saved = localStorage.getItem("qsv-viz-theme");
        if (saved === "dark") return true;
        if (saved === "light") return false; } catch (e) {}
  return window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
}
```

**Intended side effect:** on a themed dashboard the in-page toggle still works for the session but no longer *persists* across reloads — reload reverts to the authored theme. Persistence still works for un-themed dashboards.

## Gallery artifacts

The `examples/viz/smart_*.html` dashboards are **CDN-ified artifacts** (committed files reference plotly.js via CDN; raw `qsv viz smart` output embeds the full ~4000-line bundle). Regenerating would swap CDN→embedded and cause massive unrelated churn, so the 10 dashboards are **patched with the identical `isDark()` block pulled from current-build output** — keeping each diff isolated to the fix. `gallery.html` embeds no toggle script (iframes only), so it needs no change.

> Note: the live site won't reflect this until the gallery is rebuilt/redeployed from the merged branch.

## Tests

- Added a regression assertion in `tests/test_viz.rs` that `themeDefaultMode` is checked before `localStorage.getItem` in the generated HTML (fails on the old ordering).
- `cargo t viz -F all_features` → 161 passed; clippy clean; `cargo +nightly fmt` applied.
- Verified end-to-end in a browser: with `localStorage["qsv-viz-theme"]="light"` set, the patched seismic dashboard now renders fully dark (basemap, choropleth, time-series).

## Follow-up commits (theme consistency)

Subsequent commits on this branch extend the fix so the toggle's chart palettes are theme-derived, resolving the page-vs-chart inconsistency for the other themes:
- **Light non-default themes** (`seaborn`/`seaborn_whitegrid`/`matplotlib`/`plotnine`): the `LIGHT` palette now mirrors each theme's own template colors (e.g. a `#EAEAF2` seaborn page now wraps `#EAEAF2` charts instead of `#FFFFFF`).
- **Dark themes**: the `DARK` palette and the `body.qsv-dark` page chrome are theme-derived, so `seaborn_dark` renders in its own `#222222` rather than collapsing to plotly_dark's `#111111`.

Unthemed and `plotly_dark` dashboards (incl. the committed example HTML) render byte-identically — zero artifact churn. Trace colorway already comes from the baked template, so it's unaffected.

## Out of scope (tracked follow-up)

A dark theme toggled **to light** still leaves the page dark, because `:root` stays pinned to the theme's dark color to avoid a load flash; fixing it needs the chrome state model reworked. Tracked in #4102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
