### PR TITLE
fix(viz): switch choroplethmap basemap with the theme toggle

### DIFF
--- a/examples/viz/smart_dict_sunburst.html
+++ b/examples/viz/smart_dict_sunburst.html
@@ -352,11 +352,7 @@
         u[k + ".oceancolor"] = p.water;
         u[k + ".lakecolor"] = p.water;
       } else if (/^mapbox\d*$/.test(k) || /^map\d*$/.test(k)) {
-        // A choroplethmap (MapLibre) can't take a `.style` relayout in our pinned plotly fork: it
-        // throws "setData of undefined" and blanks the polygons. Skip the basemap restyle for it
-        // (its data + the page's paper/font still theme); other map types still switch basemap.
-        var hasChoro = (gd.data || []).some(function (t) { return t.type === "choroplethmap"; });
-        if (!hasChoro) u[k + ".style"] = p.mapbox;
+        u[k + ".style"] = p.mapbox;
       } else if (/^polar\d*$/.test(k) || /^scene\d*$/.test(k)) {
         u[k + ".bgcolor"] = p.bg;
       }
@@ -364,11 +360,40 @@
     if (hasAxis) u["plot_bgcolor"] = p.plot;
     return u;
   }
+  function hasChoropleth(gd) {
+    return (gd.data || []).some(function (t) { return t.type === "choroplethmap"; });
+  }
+  // Apply a flat dotted-key update (buildUpdate's shape) onto a nested layout, in place — so the
+  // same update can feed Plotly.newPlot (which wants nested layout) instead of relayout.
+  function setPath(obj, path, val) {
+    var parts = path.split("."), o = obj;
+    for (var i = 0; i < parts.length - 1; i++) {
+      if (o[parts[i]] == null || typeof o[parts[i]] !== "object") o[parts[i]] = {};
+      o = o[parts[i]];
+    }
+    o[parts[parts.length - 1]] = val;
+  }
   function apply(dark) {
     document.body.classList.toggle("qsv-dark", dark);
     var p = dark ? DARK : LIGHT;
     document.querySelectorAll(".js-plotly-plot").forEach(function (gd) {
-      try { Plotly.relayout(gd, buildUpdate(gd, p)); } catch (e) {}
+      var u = buildUpdate(gd, p);
+      try {
+        if (hasChoropleth(gd)) {
+          // A choroplethmap (MapLibre) throws "setData of undefined" on a relayout/react in our
+          // pinned plotly fork, so fold the theme update (incl. the basemap `.style`) into a full
+          // Plotly.newPlot — the only primitive that safely restyles a choroplethmap without
+          // blanking its polygons. Preserve the injected fullscreen modebar button via the div's
+          // existing config.
+          Object.keys(u).forEach(function (k) { setPath(gd.layout, k, u[k]); });
+          var cfg = { responsive: true };
+          var add = gd._context && gd._context.modeBarButtonsToAdd;
+          if (add && add.length) cfg.modeBarButtonsToAdd = add;
+          Plotly.newPlot(gd, gd.data, gd.layout, cfg);
+        } else {
+          Plotly.relayout(gd, u);
+        }
+      } catch (e) {}
     });
   }
   function init() {

--- a/examples/viz/smart_dict_treemap.html
+++ b/examples/viz/smart_dict_treemap.html
@@ -272,11 +272,7 @@
         u[k + ".oceancolor"] = p.water;
         u[k + ".lakecolor"] = p.water;
       } else if (/^mapbox\d*$/.test(k) || /^map\d*$/.test(k)) {
-        // A choroplethmap (MapLibre) can't take a `.style` relayout in our pinned plotly fork: it
-        // throws "setData of undefined" and blanks the polygons. Skip the basemap restyle for it
-        // (its data + the page's paper/font still theme); other map types still switch basemap.
-        var hasChoro = (gd.data || []).some(function (t) { return t.type === "choroplethmap"; });
-        if (!hasChoro) u[k + ".style"] = p.mapbox;
+        u[k + ".style"] = p.mapbox;
       } else if (/^polar\d*$/.test(k) || /^scene\d*$/.test(k)) {
         u[k + ".bgcolor"] = p.bg;
       }
@@ -284,11 +280,40 @@
     if (hasAxis) u["plot_bgcolor"] = p.plot;
     return u;
   }
+  function hasChoropleth(gd) {
+    return (gd.data || []).some(function (t) { return t.type === "choroplethmap"; });
+  }
+  // Apply a flat dotted-key update (buildUpdate's shape) onto a nested layout, in place — so the
+  // same update can feed Plotly.newPlot (which wants nested layout) instead of relayout.
+  function setPath(obj, path, val) {
+    var parts = path.split("."), o = obj;
+    for (var i = 0; i < parts.length - 1; i++) {
+      if (o[parts[i]] == null || typeof o[parts[i]] !== "object") o[parts[i]] = {};
+      o = o[parts[i]];
+    }
+    o[parts[parts.length - 1]] = val;
+  }
   function apply(dark) {
     document.body.classList.toggle("qsv-dark", dark);
     var p = dark ? DARK : LIGHT;
     document.querySelectorAll(".js-plotly-plot").forEach(function (gd) {
-      try { Plotly.relayout(gd, buildUpdate(gd, p)); } catch (e) {}
+      var u = buildUpdate(gd, p);
+      try {
+        if (hasChoropleth(gd)) {
+          // A choroplethmap (MapLibre) throws "setData of undefined" on a relayout/react in our
+          // pinned plotly fork, so fold the theme update (incl. the basemap `.style`) into a full
+          // Plotly.newPlot — the only primitive that safely restyles a choroplethmap without
+          // blanking its polygons. Preserve the injected fullscreen modebar button via the div's
+          // existing config.
+          Object.keys(u).forEach(function (k) { setPath(gd.layout, k, u[k]); });
+          var cfg = { responsive: true };
+          var add = gd._context && gd._context.modeBarButtonsToAdd;
+          if (add && add.length) cfg.modeBarButtonsToAdd = add;
+          Plotly.newPlot(gd, gd.data, gd.layout, cfg);
+        } else {
+          Plotly.relayout(gd, u);
+        }
+      } catch (e) {}
     });
   }
   function init() {

--- a/examples/viz/smart_geo_outliers.html
+++ b/examples/viz/smart_geo_outliers.html
@@ -329,11 +329,7 @@
         u[k + ".oceancolor"] = p.water;
         u[k + ".lakecolor"] = p.water;
       } else if (/^mapbox\d*$/.test(k) || /^map\d*$/.test(k)) {
-        // A choroplethmap (MapLibre) can't take a `.style` relayout in our pinned plotly fork: it
-        // throws "setData of undefined" and blanks the polygons. Skip the basemap restyle for it
-        // (its data + the page's paper/font still theme); other map types still switch basemap.
-        var hasChoro = (gd.data || []).some(function (t) { return t.type === "choroplethmap"; });
-        if (!hasChoro) u[k + ".style"] = p.mapbox;
+        u[k + ".style"] = p.mapbox;
       } else if (/^polar\d*$/.test(k) || /^scene\d*$/.test(k)) {
         u[k + ".bgcolor"] = p.bg;
       }
@@ -341,11 +337,40 @@
     if (hasAxis) u["plot_bgcolor"] = p.plot;
     return u;
   }
+  function hasChoropleth(gd) {
+    return (gd.data || []).some(function (t) { return t.type === "choroplethmap"; });
+  }
+  // Apply a flat dotted-key update (buildUpdate's shape) onto a nested layout, in place — so the
+  // same update can feed Plotly.newPlot (which wants nested layout) instead of relayout.
+  function setPath(obj, path, val) {
+    var parts = path.split("."), o = obj;
+    for (var i = 0; i < parts.length - 1; i++) {
+      if (o[parts[i]] == null || typeof o[parts[i]] !== "object") o[parts[i]] = {};
+      o = o[parts[i]];
+    }
+    o[parts[parts.length - 1]] = val;
+  }
   function apply(dark) {
     document.body.classList.toggle("qsv-dark", dark);
     var p = dark ? DARK : LIGHT;
     document.querySelectorAll(".js-plotly-plot").forEach(function (gd) {
-      try { Plotly.relayout(gd, buildUpdate(gd, p)); } catch (e) {}
+      var u = buildUpdate(gd, p);
+      try {
+        if (hasChoropleth(gd)) {
+          // A choroplethmap (MapLibre) throws "setData of undefined" on a relayout/react in our
+          // pinned plotly fork, so fold the theme update (incl. the basemap `.style`) into a full
+          // Plotly.newPlot — the only primitive that safely restyles a choroplethmap without
+          // blanking its polygons. Preserve the injected fullscreen modebar button via the div's
+          // existing config.
+          Object.keys(u).forEach(function (k) { setPath(gd.layout, k, u[k]); });
+          var cfg = { responsive: true };
+          var add = gd._context && gd._context.modeBarButtonsToAdd;
+          if (add && add.length) cfg.modeBarButtonsToAdd = add;
+          Plotly.newPlot(gd, gd.data, gd.layout, cfg);
+        } else {
+          Plotly.relayout(gd, u);
+        }
+      } catch (e) {}
     });
   }
   function init() {

--- a/examples/viz/smart_geospatial.html
+++ b/examples/viz/smart_geospatial.html
@@ -329,11 +329,7 @@
         u[k + ".oceancolor"] = p.water;
         u[k + ".lakecolor"] = p.water;
       } else if (/^mapbox\d*$/.test(k) || /^map\d*$/.test(k)) {
-        // A choroplethmap (MapLibre) can't take a `.style` relayout in our pinned plotly fork: it
-        // throws "setData of undefined" and blanks the polygons. Skip the basemap restyle for it
-        // (its data + the page's paper/font still theme); other map types still switch basemap.
-        var hasChoro = (gd.data || []).some(function (t) { return t.type === "choroplethmap"; });
-        if (!hasChoro) u[k + ".style"] = p.mapbox;
+        u[k + ".style"] = p.mapbox;
       } else if (/^polar\d*$/.test(k) || /^scene\d*$/.test(k)) {
         u[k + ".bgcolor"] = p.bg;
       }
@@ -341,11 +337,40 @@
     if (hasAxis) u["plot_bgcolor"] = p.plot;
     return u;
   }
+  function hasChoropleth(gd) {
+    return (gd.data || []).some(function (t) { return t.type === "choroplethmap"; });
+  }
+  // Apply a flat dotted-key update (buildUpdate's shape) onto a nested layout, in place — so the
+  // same update can feed Plotly.newPlot (which wants nested layout) instead of relayout.
+  function setPath(obj, path, val) {
+    var parts = path.split("."), o = obj;
+    for (var i = 0; i < parts.length - 1; i++) {
+      if (o[parts[i]] == null || typeof o[parts[i]] !== "object") o[parts[i]] = {};
+      o = o[parts[i]];
+    }
+    o[parts[parts.length - 1]] = val;
+  }
   function apply(dark) {
     document.body.classList.toggle("qsv-dark", dark);
     var p = dark ? DARK : LIGHT;
     document.querySelectorAll(".js-plotly-plot").forEach(function (gd) {
-      try { Plotly.relayout(gd, buildUpdate(gd, p)); } catch (e) {}
+      var u = buildUpdate(gd, p);
+      try {
+        if (hasChoropleth(gd)) {
+          // A choroplethmap (MapLibre) throws "setData of undefined" on a relayout/react in our
+          // pinned plotly fork, so fold the theme update (incl. the basemap `.style`) into a full
+          // Plotly.newPlot — the only primitive that safely restyles a choroplethmap without
+          // blanking its polygons. Preserve the injected fullscreen modebar button via the div's
+          // existing config.
+          Object.keys(u).forEach(function (k) { setPath(gd.layout, k, u[k]); });
+          var cfg = { responsive: true };
+          var add = gd._context && gd._context.modeBarButtonsToAdd;
+          if (add && add.length) cfg.modeBarButtonsToAdd = add;
+          Plotly.newPlot(gd, gd.data, gd.layout, cfg);
+        } else {
+          Plotly.relayout(gd, u);
+        }
+      } catch (e) {}
     });
   }
   function init() {

--- a/examples/viz/smart_nyc311.html
+++ b/examples/viz/smart_nyc311.html
@@ -545,11 +545,7 @@
         u[k + ".oceancolor"] = p.water;
         u[k + ".lakecolor"] = p.water;
       } else if (/^mapbox\d*$/.test(k) || /^map\d*$/.test(k)) {
-        // A choroplethmap (MapLibre) can't take a `.style` relayout in our pinned plotly fork: it
-        // throws "setData of undefined" and blanks the polygons. Skip the basemap restyle for it
-        // (its data + the page's paper/font still theme); other map types still switch basemap.
-        var hasChoro = (gd.data || []).some(function (t) { return t.type === "choroplethmap"; });
-        if (!hasChoro) u[k + ".style"] = p.mapbox;
+        u[k + ".style"] = p.mapbox;
       } else if (/^polar\d*$/.test(k) || /^scene\d*$/.test(k)) {
         u[k + ".bgcolor"] = p.bg;
       }
@@ -557,11 +553,40 @@
     if (hasAxis) u["plot_bgcolor"] = p.plot;
     return u;
   }
+  function hasChoropleth(gd) {
+    return (gd.data || []).some(function (t) { return t.type === "choroplethmap"; });
+  }
+  // Apply a flat dotted-key update (buildUpdate's shape) onto a nested layout, in place — so the
+  // same update can feed Plotly.newPlot (which wants nested layout) instead of relayout.
+  function setPath(obj, path, val) {
+    var parts = path.split("."), o = obj;
+    for (var i = 0; i < parts.length - 1; i++) {
+      if (o[parts[i]] == null || typeof o[parts[i]] !== "object") o[parts[i]] = {};
+      o = o[parts[i]];
+    }
+    o[parts[parts.length - 1]] = val;
+  }
   function apply(dark) {
     document.body.classList.toggle("qsv-dark", dark);
     var p = dark ? DARK : LIGHT;
     document.querySelectorAll(".js-plotly-plot").forEach(function (gd) {
-      try { Plotly.relayout(gd, buildUpdate(gd, p)); } catch (e) {}
+      var u = buildUpdate(gd, p);
+      try {
+        if (hasChoropleth(gd)) {
+          // A choroplethmap (MapLibre) throws "setData of undefined" on a relayout/react in our
+          // pinned plotly fork, so fold the theme update (incl. the basemap `.style`) into a full
+          // Plotly.newPlot — the only primitive that safely restyles a choroplethmap without
+          // blanking its polygons. Preserve the injected fullscreen modebar button via the div's
+          // existing config.
+          Object.keys(u).forEach(function (k) { setPath(gd.layout, k, u[k]); });
+          var cfg = { responsive: true };
+          var add = gd._context && gd._context.modeBarButtonsToAdd;
+          if (add && add.length) cfg.modeBarButtonsToAdd = add;
+          Plotly.newPlot(gd, gd.data, gd.layout, cfg);
+        } else {
+          Plotly.relayout(gd, u);
+        }
+      } catch (e) {}
     });
   }
   function init() {

--- a/examples/viz/smart_sales.html
+++ b/examples/viz/smart_sales.html
@@ -304,11 +304,7 @@
         u[k + ".oceancolor"] = p.water;
         u[k + ".lakecolor"] = p.water;
       } else if (/^mapbox\d*$/.test(k) || /^map\d*$/.test(k)) {
-        // A choroplethmap (MapLibre) can't take a `.style` relayout in our pinned plotly fork: it
-        // throws "setData of undefined" and blanks the polygons. Skip the basemap restyle for it
-        // (its data + the page's paper/font still theme); other map types still switch basemap.
-        var hasChoro = (gd.data || []).some(function (t) { return t.type === "choroplethmap"; });
-        if (!hasChoro) u[k + ".style"] = p.mapbox;
+        u[k + ".style"] = p.mapbox;
       } else if (/^polar\d*$/.test(k) || /^scene\d*$/.test(k)) {
         u[k + ".bgcolor"] = p.bg;
       }
@@ -316,11 +312,40 @@
     if (hasAxis) u["plot_bgcolor"] = p.plot;
     return u;
   }
+  function hasChoropleth(gd) {
+    return (gd.data || []).some(function (t) { return t.type === "choroplethmap"; });
+  }
+  // Apply a flat dotted-key update (buildUpdate's shape) onto a nested layout, in place — so the
+  // same update can feed Plotly.newPlot (which wants nested layout) instead of relayout.
+  function setPath(obj, path, val) {
+    var parts = path.split("."), o = obj;
+    for (var i = 0; i < parts.length - 1; i++) {
+      if (o[parts[i]] == null || typeof o[parts[i]] !== "object") o[parts[i]] = {};
+      o = o[parts[i]];
+    }
+    o[parts[parts.length - 1]] = val;
+  }
   function apply(dark) {
     document.body.classList.toggle("qsv-dark", dark);
     var p = dark ? DARK : LIGHT;
     document.querySelectorAll(".js-plotly-plot").forEach(function (gd) {
-      try { Plotly.relayout(gd, buildUpdate(gd, p)); } catch (e) {}
+      var u = buildUpdate(gd, p);
+      try {
+        if (hasChoropleth(gd)) {
+          // A choroplethmap (MapLibre) throws "setData of undefined" on a relayout/react in our
+          // pinned plotly fork, so fold the theme update (incl. the basemap `.style`) into a full
+          // Plotly.newPlot — the only primitive that safely restyles a choroplethmap without
+          // blanking its polygons. Preserve the injected fullscreen modebar button via the div's
+          // existing config.
+          Object.keys(u).forEach(function (k) { setPath(gd.layout, k, u[k]); });
+          var cfg = { responsive: true };
+          var add = gd._context && gd._context.modeBarButtonsToAdd;
+          if (add && add.length) cfg.modeBarButtonsToAdd = add;
+          Plotly.newPlot(gd, gd.data, gd.layout, cfg);
+        } else {
+          Plotly.relayout(gd, u);
+        }
+      } catch (e) {}
     });
   }
   function init() {

--- a/examples/viz/smart_smarter.html
+++ b/examples/viz/smart_smarter.html
@@ -280,11 +280,7 @@
         u[k + ".oceancolor"] = p.water;
         u[k + ".lakecolor"] = p.water;
       } else if (/^mapbox\d*$/.test(k) || /^map\d*$/.test(k)) {
-        // A choroplethmap (MapLibre) can't take a `.style` relayout in our pinned plotly fork: it
-        // throws "setData of undefined" and blanks the polygons. Skip the basemap restyle for it
-        // (its data + the page's paper/font still theme); other map types still switch basemap.
-        var hasChoro = (gd.data || []).some(function (t) { return t.type === "choroplethmap"; });
-        if (!hasChoro) u[k + ".style"] = p.mapbox;
+        u[k + ".style"] = p.mapbox;
       } else if (/^polar\d*$/.test(k) || /^scene\d*$/.test(k)) {
         u[k + ".bgcolor"] = p.bg;
       }
@@ -292,11 +288,40 @@
     if (hasAxis) u["plot_bgcolor"] = p.plot;
     return u;
   }
+  function hasChoropleth(gd) {
+    return (gd.data || []).some(function (t) { return t.type === "choroplethmap"; });
+  }
+  // Apply a flat dotted-key update (buildUpdate's shape) onto a nested layout, in place — so the
+  // same update can feed Plotly.newPlot (which wants nested layout) instead of relayout.
+  function setPath(obj, path, val) {
+    var parts = path.split("."), o = obj;
+    for (var i = 0; i < parts.length - 1; i++) {
+      if (o[parts[i]] == null || typeof o[parts[i]] !== "object") o[parts[i]] = {};
+      o = o[parts[i]];
+    }
+    o[parts[parts.length - 1]] = val;
+  }
   function apply(dark) {
     document.body.classList.toggle("qsv-dark", dark);
     var p = dark ? DARK : LIGHT;
     document.querySelectorAll(".js-plotly-plot").forEach(function (gd) {
-      try { Plotly.relayout(gd, buildUpdate(gd, p)); } catch (e) {}
+      var u = buildUpdate(gd, p);
+      try {
+        if (hasChoropleth(gd)) {
+          // A choroplethmap (MapLibre) throws "setData of undefined" on a relayout/react in our
+          // pinned plotly fork, so fold the theme update (incl. the basemap `.style`) into a full
+          // Plotly.newPlot — the only primitive that safely restyles a choroplethmap without
+          // blanking its polygons. Preserve the injected fullscreen modebar button via the div's
+          // existing config.
+          Object.keys(u).forEach(function (k) { setPath(gd.layout, k, u[k]); });
+          var cfg = { responsive: true };
+          var add = gd._context && gd._context.modeBarButtonsToAdd;
+          if (add && add.length) cfg.modeBarButtonsToAdd = add;
+          Plotly.newPlot(gd, gd.data, gd.layout, cfg);
+        } else {
+          Plotly.relayout(gd, u);
+        }
+      } catch (e) {}
     });
   }
   function init() {

--- a/examples/viz/smart_timeseries.html
+++ b/examples/viz/smart_timeseries.html
@@ -244,11 +244,7 @@
         u[k + ".oceancolor"] = p.water;
         u[k + ".lakecolor"] = p.water;
       } else if (/^mapbox\d*$/.test(k) || /^map\d*$/.test(k)) {
-        // A choroplethmap (MapLibre) can't take a `.style` relayout in our pinned plotly fork: it
-        // throws "setData of undefined" and blanks the polygons. Skip the basemap restyle for it
-        // (its data + the page's paper/font still theme); other map types still switch basemap.
-        var hasChoro = (gd.data || []).some(function (t) { return t.type === "choroplethmap"; });
-        if (!hasChoro) u[k + ".style"] = p.mapbox;
+        u[k + ".style"] = p.mapbox;
       } else if (/^polar\d*$/.test(k) || /^scene\d*$/.test(k)) {
         u[k + ".bgcolor"] = p.bg;
       }
@@ -256,11 +252,40 @@
     if (hasAxis) u["plot_bgcolor"] = p.plot;
     return u;
   }
+  function hasChoropleth(gd) {
+    return (gd.data || []).some(function (t) { return t.type === "choroplethmap"; });
+  }
+  // Apply a flat dotted-key update (buildUpdate's shape) onto a nested layout, in place — so the
+  // same update can feed Plotly.newPlot (which wants nested layout) instead of relayout.
+  function setPath(obj, path, val) {
+    var parts = path.split("."), o = obj;
+    for (var i = 0; i < parts.length - 1; i++) {
+      if (o[parts[i]] == null || typeof o[parts[i]] !== "object") o[parts[i]] = {};
+      o = o[parts[i]];
+    }
+    o[parts[parts.length - 1]] = val;
+  }
   function apply(dark) {
     document.body.classList.toggle("qsv-dark", dark);
     var p = dark ? DARK : LIGHT;
     document.querySelectorAll(".js-plotly-plot").forEach(function (gd) {
-      try { Plotly.relayout(gd, buildUpdate(gd, p)); } catch (e) {}
+      var u = buildUpdate(gd, p);
+      try {
+        if (hasChoropleth(gd)) {
+          // A choroplethmap (MapLibre) throws "setData of undefined" on a relayout/react in our
+          // pinned plotly fork, so fold the theme update (incl. the basemap `.style`) into a full
+          // Plotly.newPlot — the only primitive that safely restyles a choroplethmap without
+          // blanking its polygons. Preserve the injected fullscreen modebar button via the div's
+          // existing config.
+          Object.keys(u).forEach(function (k) { setPath(gd.layout, k, u[k]); });
+          var cfg = { responsive: true };
+          var add = gd._context && gd._context.modeBarButtonsToAdd;
+          if (add && add.length) cfg.modeBarButtonsToAdd = add;
+          Plotly.newPlot(gd, gd.data, gd.layout, cfg);
+        } else {
+          Plotly.relayout(gd, u);
+        }
+      } catch (e) {}
     });
   }
   function init() {

--- a/examples/viz/smart_us_choropleth.html
+++ b/examples/viz/smart_us_choropleth.html
@@ -289,11 +289,7 @@
         u[k + ".oceancolor"] = p.water;
         u[k + ".lakecolor"] = p.water;
       } else if (/^mapbox\d*$/.test(k) || /^map\d*$/.test(k)) {
-        // A choroplethmap (MapLibre) can't take a `.style` relayout in our pinned plotly fork: it
-        // throws "setData of undefined" and blanks the polygons. Skip the basemap restyle for it
-        // (its data + the page's paper/font still theme); other map types still switch basemap.
-        var hasChoro = (gd.data || []).some(function (t) { return t.type === "choroplethmap"; });
-        if (!hasChoro) u[k + ".style"] = p.mapbox;
+        u[k + ".style"] = p.mapbox;
       } else if (/^polar\d*$/.test(k) || /^scene\d*$/.test(k)) {
         u[k + ".bgcolor"] = p.bg;
       }
@@ -301,11 +297,40 @@
     if (hasAxis) u["plot_bgcolor"] = p.plot;
     return u;
   }
+  function hasChoropleth(gd) {
+    return (gd.data || []).some(function (t) { return t.type === "choroplethmap"; });
+  }
+  // Apply a flat dotted-key update (buildUpdate's shape) onto a nested layout, in place — so the
+  // same update can feed Plotly.newPlot (which wants nested layout) instead of relayout.
+  function setPath(obj, path, val) {
+    var parts = path.split("."), o = obj;
+    for (var i = 0; i < parts.length - 1; i++) {
+      if (o[parts[i]] == null || typeof o[parts[i]] !== "object") o[parts[i]] = {};
+      o = o[parts[i]];
+    }
+    o[parts[parts.length - 1]] = val;
+  }
   function apply(dark) {
     document.body.classList.toggle("qsv-dark", dark);
     var p = dark ? DARK : LIGHT;
     document.querySelectorAll(".js-plotly-plot").forEach(function (gd) {
-      try { Plotly.relayout(gd, buildUpdate(gd, p)); } catch (e) {}
+      var u = buildUpdate(gd, p);
+      try {
+        if (hasChoropleth(gd)) {
+          // A choroplethmap (MapLibre) throws "setData of undefined" on a relayout/react in our
+          // pinned plotly fork, so fold the theme update (incl. the basemap `.style`) into a full
+          // Plotly.newPlot — the only primitive that safely restyles a choroplethmap without
+          // blanking its polygons. Preserve the injected fullscreen modebar button via the div's
+          // existing config.
+          Object.keys(u).forEach(function (k) { setPath(gd.layout, k, u[k]); });
+          var cfg = { responsive: true };
+          var add = gd._context && gd._context.modeBarButtonsToAdd;
+          if (add && add.length) cfg.modeBarButtonsToAdd = add;
+          Plotly.newPlot(gd, gd.data, gd.layout, cfg);
+        } else {
+          Plotly.relayout(gd, u);
+        }
+      } catch (e) {}
     });
   }
   function init() {

--- a/examples/viz/smart_world_choropleth.html
+++ b/examples/viz/smart_world_choropleth.html
@@ -312,11 +312,7 @@
         u[k + ".oceancolor"] = p.water;
         u[k + ".lakecolor"] = p.water;
       } else if (/^mapbox\d*$/.test(k) || /^map\d*$/.test(k)) {
-        // A choroplethmap (MapLibre) can't take a `.style` relayout in our pinned plotly fork: it
-        // throws "setData of undefined" and blanks the polygons. Skip the basemap restyle for it
-        // (its data + the page's paper/font still theme); other map types still switch basemap.
-        var hasChoro = (gd.data || []).some(function (t) { return t.type === "choroplethmap"; });
-        if (!hasChoro) u[k + ".style"] = p.mapbox;
+        u[k + ".style"] = p.mapbox;
       } else if (/^polar\d*$/.test(k) || /^scene\d*$/.test(k)) {
         u[k + ".bgcolor"] = p.bg;
       }
@@ -324,11 +320,40 @@
     if (hasAxis) u["plot_bgcolor"] = p.plot;
     return u;
   }
+  function hasChoropleth(gd) {
+    return (gd.data || []).some(function (t) { return t.type === "choroplethmap"; });
+  }
+  // Apply a flat dotted-key update (buildUpdate's shape) onto a nested layout, in place — so the
+  // same update can feed Plotly.newPlot (which wants nested layout) instead of relayout.
+  function setPath(obj, path, val) {
+    var parts = path.split("."), o = obj;
+    for (var i = 0; i < parts.length - 1; i++) {
+      if (o[parts[i]] == null || typeof o[parts[i]] !== "object") o[parts[i]] = {};
+      o = o[parts[i]];
+    }
+    o[parts[parts.length - 1]] = val;
+  }
   function apply(dark) {
     document.body.classList.toggle("qsv-dark", dark);
     var p = dark ? DARK : LIGHT;
     document.querySelectorAll(".js-plotly-plot").forEach(function (gd) {
-      try { Plotly.relayout(gd, buildUpdate(gd, p)); } catch (e) {}
+      var u = buildUpdate(gd, p);
+      try {
+        if (hasChoropleth(gd)) {
+          // A choroplethmap (MapLibre) throws "setData of undefined" on a relayout/react in our
+          // pinned plotly fork, so fold the theme update (incl. the basemap `.style`) into a full
+          // Plotly.newPlot — the only primitive that safely restyles a choroplethmap without
+          // blanking its polygons. Preserve the injected fullscreen modebar button via the div's
+          // existing config.
+          Object.keys(u).forEach(function (k) { setPath(gd.layout, k, u[k]); });
+          var cfg = { responsive: true };
+          var add = gd._context && gd._context.modeBarButtonsToAdd;
+          if (add && add.length) cfg.modeBarButtonsToAdd = add;
+          Plotly.newPlot(gd, gd.data, gd.layout, cfg);
+        } else {
+          Plotly.relayout(gd, u);
+        }
+      } catch (e) {}
     });
   }
   function init() {

--- a/src/cmd/viz.rs
+++ b/src/cmd/viz.rs
@@ -4888,11 +4888,7 @@ const SCRIPT_TEMPLATE: &str = r##"<script>
         u[k + ".oceancolor"] = p.water;
         u[k + ".lakecolor"] = p.water;
       } else if (/^mapbox\d*$/.test(k) || /^map\d*$/.test(k)) {
-        // A choroplethmap (MapLibre) can't take a `.style` relayout in our pinned plotly fork: it
-        // throws "setData of undefined" and blanks the polygons. Skip the basemap restyle for it
-        // (its data + the page's paper/font still theme); other map types still switch basemap.
-        var hasChoro = (gd.data || []).some(function (t) { return t.type === "choroplethmap"; });
-        if (!hasChoro) u[k + ".style"] = p.mapbox;
+        u[k + ".style"] = p.mapbox;
       } else if (/^polar\d*$/.test(k) || /^scene\d*$/.test(k)) {
         u[k + ".bgcolor"] = p.bg;
       }
@@ -4900,11 +4896,40 @@ const SCRIPT_TEMPLATE: &str = r##"<script>
     if (hasAxis) u["plot_bgcolor"] = p.plot;
     return u;
   }
+  function hasChoropleth(gd) {
+    return (gd.data || []).some(function (t) { return t.type === "choroplethmap"; });
+  }
+  // Apply a flat dotted-key update (buildUpdate's shape) onto a nested layout, in place — so the
+  // same update can feed Plotly.newPlot (which wants nested layout) instead of relayout.
+  function setPath(obj, path, val) {
+    var parts = path.split("."), o = obj;
+    for (var i = 0; i < parts.length - 1; i++) {
+      if (o[parts[i]] == null || typeof o[parts[i]] !== "object") o[parts[i]] = {};
+      o = o[parts[i]];
+    }
+    o[parts[parts.length - 1]] = val;
+  }
   function apply(dark) {
     document.body.classList.toggle("qsv-dark", dark);
     var p = dark ? DARK : LIGHT;
     document.querySelectorAll(".js-plotly-plot").forEach(function (gd) {
-      try { Plotly.relayout(gd, buildUpdate(gd, p)); } catch (e) {}
+      var u = buildUpdate(gd, p);
+      try {
+        if (hasChoropleth(gd)) {
+          // A choroplethmap (MapLibre) throws "setData of undefined" on a relayout/react in our
+          // pinned plotly fork, so fold the theme update (incl. the basemap `.style`) into a full
+          // Plotly.newPlot — the only primitive that safely restyles a choroplethmap without
+          // blanking its polygons. Preserve the injected fullscreen modebar button via the div's
+          // existing config.
+          Object.keys(u).forEach(function (k) { setPath(gd.layout, k, u[k]); });
+          var cfg = { responsive: true };
+          var add = gd._context && gd._context.modeBarButtonsToAdd;
+          if (add && add.length) cfg.modeBarButtonsToAdd = add;
+          Plotly.newPlot(gd, gd.data, gd.layout, cfg);
+        } else {
+          Plotly.relayout(gd, u);
+        }
+      } catch (e) {}
     });
   }
   function init() {
@@ -4958,6 +4983,7 @@ const FULLSCREEN_STYLE: &str =
 ///   - FULLSCREEN enter/exit: `applyFitCamera` moves the GL map camera directly via the
 ///     maplibre/mapbox-gl instance (`gd._fullLayout[k]._subplot.map.jumpTo`), which sits below
 ///     plotly's relayout/setData path — no tile reload, works even before the style loads.
+///
 /// Non-map charts just get `Plotly.Plots.resize`.
 ///
 /// plotly's own render runs in a deferred `<script type="module">` with a top-level

--- a/tests/test_viz.rs
+++ b/tests/test_viz.rs
@@ -5471,9 +5471,9 @@ fn viz_smart_map_has_zoom_autofit() {
     assert!(html.contains("Math.log2"));
     // Core/Full extent buttons re-fit to the current container size via the buttonclicked handler.
     assert!(html.contains("plotly_buttonclicked"));
-    // theme toggle skips the basemap restyle for a choroplethmap (the fork's relayout would blank
+    // theme toggle restyles a choroplethmap via newPlot, not relayout (the fork's relayout blanks
     // it).
-    assert!(html.contains("hasChoro"));
+    assert!(html.contains("hasChoropleth"));
     // smart panels frame against MAP_PANEL_ASSUMED_WIDTH_PX x MAP_PANEL_USABLE_HEIGHT_PX (960x352).
     assert!(html.contains("window.__qsvMapAssumedW=960"));
     assert!(html.contains("window.__qsvMapAssumedH=352"));


### PR DESCRIPTION
## Problem

Follow-up to #4108. That PR stopped the theme toggle from blanking the NYC 311 smart-dashboard choropleth by **skipping** the basemap `.style` relayout for choroplethmap divs — but the side effect was that the choropleth's basemap stayed **light even in dark mode**.

## Fix

A choroplethmap (MapLibre) throws `setData of undefined` on a `relayout`/`react` in our pinned plotly fork, so relayout can't restyle it. Instead, for choroplethmap divs the theme toggle now folds the whole theme update (including the basemap `.style`) into a full **`Plotly.newPlot`** — the only primitive that safely restyles a choroplethmap without blanking its polygons. The injected fullscreen modebar button is preserved via the div's existing config (`gd._context.modeBarButtonsToAdd`). Other map types keep the cheaper relayout path.

- `buildUpdate` emits `.style` for map keys again (applied via `newPlot` for choroplethmaps).
- A small `setPath` helper folds the flat dotted-key update onto the nested layout `newPlot` wants.
- Also fixes a latent clippy `doc_lazy_continuation` warning in the `FULLSCREEN_SCRIPT` doc comment.
- Regenerates the smart-dashboard iframes (uniform theme-block change; `gallery.html` left untouched — only float-summation regeneration noise, unrelated to the fix).

## Verification

- 167 `test_viz` tests pass; `cargo +nightly fmt` and `cargo clippy -F all_features` clean.
- Browser-checked: toggling dark/light switches the choropleth's `map.style` (`carto-positron` ↔ `carto-darkmatter`), data stays intact (`choroLocs:188`), the fullscreen button is preserved, round-trip is clean, and **no `setData` error** fires.
- **Verification limit:** offline, so the new basemap tiles don't actually paint here — confirmed via `layout.map.style` switching, data-layer survival, and absence of the `setData` throw rather than visual tiles. Worth a final online glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)