### PR TITLE
fix(get): make --timeout an inactivity timeout on the async HTTP client

### DIFF
--- a/docs/help/get.md
+++ b/docs/help/get.md
@@ -171,7 +171,7 @@ qsv get --help
 | &nbsp;`‑‑cloud‑opt`&nbsp; | string | Extra cloud object-store config as a `key=value` pair (repeatable), e.g. region=us-east-1 or skip_signature=true. Overrides the AWS_*/AZURE_*/GOOGLE_* environment. (get_cloud only) |  |
 | &nbsp;`‑‑ckan‑api`&nbsp; | string | CKAN Action API base URL. Overrides the QSV_CKAN_API env var. | `https://data.dathere.com/api/3/action` |
 | &nbsp;`‑‑ckan‑token`&nbsp; | string | CKAN API token. Overrides the QSV_CKAN_TOKEN env var. |  |
-| &nbsp;`‑‑timeout`&nbsp; | integer | HTTP inactivity timeout in seconds. Aborts only if no data is received from the server for this long (a slow-but-steady download is NOT aborted). 0 = no timeout. | `30` |
+| &nbsp;`‑‑timeout`&nbsp; | integer | HTTP timeout in seconds. For cache downloads this is an INACTIVITY timeout: the transfer aborts only if no data is received from the server for this long, so a slow-but-steady download is NOT cut off. Preview mode (--sample / --offset / --random) instead uses it as a total-request timeout. 0 = no timeout. | `30` |
 | &nbsp;`‑‑older‑than`&nbsp; | string | For cache-prune: remove entries older than this age. Accepts seconds, or a value with an s/m/h/d/w suffix (e.g. 3600, 90m, 30d, 2w). |  |
 | &nbsp;`‑‑json`&nbsp; | flag | For cache-list/cache-info: output JSON instead of a table. |  |
 | &nbsp;`‑‑verify`&nbsp; | flag | For cache-list: recompute each cached blob's BLAKE3 and report OK/FAIL per name (exits non-zero on any failure). |  |

--- a/docs/help/get.md
+++ b/docs/help/get.md
@@ -171,7 +171,7 @@ qsv get --help
 | &nbsp;`‑‑cloud‑opt`&nbsp; | string | Extra cloud object-store config as a `key=value` pair (repeatable), e.g. region=us-east-1 or skip_signature=true. Overrides the AWS_*/AZURE_*/GOOGLE_* environment. (get_cloud only) |  |
 | &nbsp;`‑‑ckan‑api`&nbsp; | string | CKAN Action API base URL. Overrides the QSV_CKAN_API env var. | `https://data.dathere.com/api/3/action` |
 | &nbsp;`‑‑ckan‑token`&nbsp; | string | CKAN API token. Overrides the QSV_CKAN_TOKEN env var. |  |
-| &nbsp;`‑‑timeout`&nbsp; | integer | HTTP request timeout in seconds. | `30` |
+| &nbsp;`‑‑timeout`&nbsp; | integer | HTTP inactivity timeout in seconds. Aborts only if no data is received from the server for this long (a slow-but-steady download is NOT aborted). 0 = no timeout. | `30` |
 | &nbsp;`‑‑older‑than`&nbsp; | string | For cache-prune: remove entries older than this age. Accepts seconds, or a value with an s/m/h/d/w suffix (e.g. 3600, 90m, 30d, 2w). |  |
 | &nbsp;`‑‑json`&nbsp; | flag | For cache-list/cache-info: output JSON instead of a table. |  |
 | &nbsp;`‑‑verify`&nbsp; | flag | For cache-list: recompute each cached blob's BLAKE3 and report OK/FAIL per name (exits non-zero on any failure). |  |

--- a/docs/help/get.md
+++ b/docs/help/get.md
@@ -171,7 +171,7 @@ qsv get --help
 | &nbsp;`‑‑cloud‑opt`&nbsp; | string | Extra cloud object-store config as a `key=value` pair (repeatable), e.g. region=us-east-1 or skip_signature=true. Overrides the AWS_*/AZURE_*/GOOGLE_* environment. (get_cloud only) |  |
 | &nbsp;`‑‑ckan‑api`&nbsp; | string | CKAN Action API base URL. Overrides the QSV_CKAN_API env var. | `https://data.dathere.com/api/3/action` |
 | &nbsp;`‑‑ckan‑token`&nbsp; | string | CKAN API token. Overrides the QSV_CKAN_TOKEN env var. |  |
-| &nbsp;`‑‑timeout`&nbsp; | integer | HTTP timeout in seconds. For cache downloads this is an INACTIVITY timeout: the transfer aborts only if no data is received from the server for this long, so a slow-but-steady download is NOT cut off. Preview mode (--sample / --offset / --random) instead uses it as a total-request timeout. 0 = no timeout. | `30` |
+| &nbsp;`‑‑timeout`&nbsp; | integer | HTTP timeout in seconds. For cache downloads this is an INACTIVITY timeout: the transfer aborts only if no data is received from the server for this long, so a slow-but-steady download is NOT cut off. Preview mode (--sample / --offset / --random) instead uses it as a total-request timeout. 0 = no timeout. | `60` |
 | &nbsp;`‑‑older‑than`&nbsp; | string | For cache-prune: remove entries older than this age. Accepts seconds, or a value with an s/m/h/d/w suffix (e.g. 3600, 90m, 30d, 2w). |  |
 | &nbsp;`‑‑json`&nbsp; | flag | For cache-list/cache-info: output JSON instead of a table. |  |
 | &nbsp;`‑‑verify`&nbsp; | flag | For cache-list: recompute each cached blob's BLAKE3 and report OK/FAIL per name (exits non-zero on any failure). |  |

--- a/docs/help/sample.md
+++ b/docs/help/sample.md
@@ -276,7 +276,7 @@ qsv sample --help
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Option&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Type | Description | Default |
 |--------|------|-------------|--------|
 | &nbsp;`‑‑user‑agent`&nbsp; | string | Specify custom user agent to use when the input is a URL. It supports the following variables - $QSV_VERSION, $QSV_TARGET, $QSV_BIN_NAME, $QSV_KIND and $QSV_COMMAND. Try to follow the syntax here - <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent> |  |
-| &nbsp;`‑‑timeout`&nbsp; | integer | Timeout for downloading URLs in seconds. If 0, no timeout is used. | `30` |
+| &nbsp;`‑‑timeout`&nbsp; | integer | Inactivity timeout for downloading URLs in seconds. Aborts only if no data is received from the server for this long. If 0, no timeout. | `30` |
 | &nbsp;`‑‑max‑size`&nbsp; | integer | Maximum size of the file to download in MB before sampling. Will download the entire file if not specified. If the CSV is partially downloaded, the sample will be taken only from the downloaded portion. |  |
 | &nbsp;`‑‑force`&nbsp; | flag | Do not use stats cache, even if its available. |  |
 

--- a/src/cmd/get.rs
+++ b/src/cmd/get.rs
@@ -116,7 +116,7 @@ get options:
                            timeout: the transfer aborts only if no data is received from the
                            server for this long, so a slow-but-steady download is NOT cut off.
                            Preview mode (--sample / --offset / --random) instead uses it as a
-                           total-request timeout. 0 = no timeout. [default: 30]
+                           total-request timeout. 0 = no timeout. [default: 60]
     --older-than <val>     For cache-prune: remove entries older than this age.
                            Accepts seconds, or a value with an s/m/h/d/w suffix
                            (e.g. 3600, 90m, 30d, 2w).

--- a/src/cmd/get.rs
+++ b/src/cmd/get.rs
@@ -112,9 +112,11 @@ get options:
     --ckan-api <url>       CKAN Action API base URL. Overrides the QSV_CKAN_API
                            env var. [default: https://data.dathere.com/api/3/action]
     --ckan-token <token>   CKAN API token. Overrides the QSV_CKAN_TOKEN env var.
-    --timeout <secs>       HTTP inactivity timeout in seconds. Aborts only if no data is
-                           received from the server for this long (a slow-but-steady
-                           download is NOT aborted). 0 = no timeout. [default: 30]
+    --timeout <secs>       HTTP timeout in seconds. For cache downloads this is an INACTIVITY
+                           timeout: the transfer aborts only if no data is received from the
+                           server for this long, so a slow-but-steady download is NOT cut off.
+                           Preview mode (--sample / --offset / --random) instead uses it as a
+                           total-request timeout. 0 = no timeout. [default: 30]
     --older-than <val>     For cache-prune: remove entries older than this age.
                            Accepts seconds, or a value with an s/m/h/d/w suffix
                            (e.g. 3600, 90m, 30d, 2w).

--- a/src/cmd/get.rs
+++ b/src/cmd/get.rs
@@ -112,7 +112,9 @@ get options:
     --ckan-api <url>       CKAN Action API base URL. Overrides the QSV_CKAN_API
                            env var. [default: https://data.dathere.com/api/3/action]
     --ckan-token <token>   CKAN API token. Overrides the QSV_CKAN_TOKEN env var.
-    --timeout <secs>       HTTP request timeout in seconds. [default: 30]
+    --timeout <secs>       HTTP inactivity timeout in seconds. Aborts only if no data is
+                           received from the server for this long (a slow-but-steady
+                           download is NOT aborted). 0 = no timeout. [default: 30]
     --older-than <val>     For cache-prune: remove entries older than this age.
                            Accepts seconds, or a value with an s/m/h/d/w suffix
                            (e.g. 3600, 90m, 30d, 2w).

--- a/src/cmd/sample.rs
+++ b/src/cmd/sample.rs
@@ -268,7 +268,8 @@ sample options:
                            $QSV_VERSION, $QSV_TARGET, $QSV_BIN_NAME, $QSV_KIND and $QSV_COMMAND.
                            Try to follow the syntax here -
                            https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent
-    --timeout <secs>       Timeout for downloading URLs in seconds. If 0, no timeout is used.
+    --timeout <secs>       Inactivity timeout for downloading URLs in seconds. Aborts only if
+                           no data is received from the server for this long. If 0, no timeout.
                            [default: 30]
     --max-size <mb>        Maximum size of the file to download in MB before sampling.
                            Will download the entire file if not specified.

--- a/src/diskcache.rs
+++ b/src/diskcache.rs
@@ -1810,6 +1810,20 @@ mod rich {
         )?;
         let rt = tokio::runtime::Runtime::new()?;
 
+        // Map a response-body read error to a CliError. A reqwest read (inactivity)
+        // timeout surfaces here as a body error whose `is_timeout()` is true; turn that
+        // into an actionable message instead of the cryptic raw reqwest text.
+        fn body_read_err(url: &str, e: &reqwest::Error) -> CliError {
+            if e.is_timeout() {
+                CliError::Other(format!(
+                    "get: download stalled: no data received from {url} within the inactivity \
+                     timeout — increase --timeout"
+                ))
+            } else {
+                CliError::Other(format!("get: reading {url} failed: {e}"))
+            }
+        }
+
         // Stream a whole response body into the sink, returning the byte count.
         async fn drain(
             sink: &mut IngestSink,
@@ -1820,8 +1834,7 @@ mod rich {
             let mut have = 0u64;
             let mut stream = resp.bytes_stream();
             while let Some(chunk) = stream.next().await {
-                let chunk = chunk
-                    .map_err(|e| CliError::Other(format!("get: reading {url} failed: {e}")))?;
+                let chunk = chunk.map_err(|e| body_read_err(url, &e))?;
                 have += chunk.len() as u64;
                 sink.write(&chunk)?;
             }
@@ -1985,9 +1998,10 @@ mod rich {
                                     )));
                                 },
                             }
-                            let body = resp.bytes().await.map_err(|err| {
-                                CliError::Other(format!("get: reading {url} failed: {err}"))
-                            })?;
+                            let body = resp
+                                .bytes()
+                                .await
+                                .map_err(|err| body_read_err(&url, &err))?;
                             if body.len() as u64 != e - s {
                                 return Err(CliError::Other(format!(
                                     "get: range {s}-{} of {url} returned {} bytes, expected {}",

--- a/src/util.rs
+++ b/src/util.rs
@@ -486,7 +486,7 @@ pub fn set_user_agent(user_agent: Option<String>) -> CliResult<String> {
 /// # Arguments
 ///
 /// * `user_agent` - Optional custom user agent string
-/// * `timeout_secs` - Timeout in seconds for HTTP requests. If 0, no timeout is used.
+/// * `timeout_secs` - Inactivity (idle) timeout in seconds for HTTP requests. If 0, no timeout.
 /// * `base_url` - Optional base URL for retry configuration
 ///
 /// # Returns
@@ -497,7 +497,7 @@ pub fn set_user_agent(user_agent: Option<String>) -> CliResult<String> {
 /// - Rustls TLS backend
 /// - HTTP/2 adaptive window
 /// - Connection verbose logging (when debug/trace enabled)
-/// - Timeout configuration
+/// - Idle/read timeout configuration (NOT a total-request deadline)
 /// - Retry logic for service unavailable errors
 pub fn create_reqwest_async_client(
     user_agent: Option<String>,
@@ -526,12 +526,16 @@ pub fn create_reqwest_async_client(
         .retry(retries);
 
     if timeout_secs > 0 {
-        // bound the total request AND the connect/TLS handshake separately.
-        // a stalled connect is not reliably caught by the total timeout alone
-        // (e.g. flaky windows-arm64 CI runners), so set connect_timeout too.
+        // Use an INACTIVITY (idle) timeout, not a total-request deadline. `read_timeout`
+        // applies to each read of the response body and RESETS after every successful read,
+        // so a slow-but-steady download (e.g. a large CSV trickling in over a slow proxy) is
+        // never aborted mid-stream — only a genuinely stalled connection (no bytes for
+        // `timeout_secs`) trips it. `connect_timeout` still bounds a stalled connect/TLS
+        // handshake (not reliably caught otherwise on flaky windows-arm64 CI runners).
+        // There is deliberately no total-request `.timeout()` cap.
         let timeout_duration = Duration::from_secs(timeout_secs.into());
         builder = builder
-            .timeout(timeout_duration)
+            .read_timeout(timeout_duration)
             .connect_timeout(timeout_duration);
     }
 
@@ -551,6 +555,12 @@ pub fn create_reqwest_async_client(
 ///
 /// Returns a configured blocking reqwest client with the same options
 /// as `create_reqwest_async_client`
+///
+/// NOTE: unlike the async client, this uses a TOTAL-request `.timeout()`, not an inactivity
+/// (`read_timeout`) one. reqwest 0.13.4's blocking client reads the response body on the
+/// calling thread via a park/unpark waker with NO Tokio timer running, so a `read_timeout`
+/// body wrapper panics ("there is no reactor running") the moment the body is read. The
+/// idle-timeout semantics therefore apply only to `create_reqwest_async_client`.
 pub fn create_reqwest_blocking_client(
     user_agent: Option<String>,
     timeout_secs: u16,

--- a/tests/test_get.rs
+++ b/tests/test_get.rs
@@ -96,6 +96,68 @@ async fn serve_big(c: web::Data<Counters>, req: HttpRequest) -> HttpResponse {
     ranged_response(big_csv().as_bytes(), BIG_ETAG, &req, &c)
 }
 
+// --- Inactivity (idle) timeout handlers -------------------------------------
+// Both IGNORE Range and return a 200 chunked/streaming body, mirroring the WPRDC
+// downstream proxy that motivated making `--timeout` an inactivity timeout: `get`
+// then takes the full-body streaming `drain` path.
+
+// Streams a small CSV in many chunks with a gap BETWEEN chunks that is short
+// enough to keep resetting the client's idle read-timeout, while the TOTAL stream
+// time deliberately EXCEEDS a short `--timeout`. A total-request deadline would
+// abort this; an inactivity timeout must not.
+async fn serve_slow_active(_req: HttpRequest) -> HttpResponse {
+    const CHUNKS: [&[u8]; 14] = [
+        b"id,name\n",
+        b"1,a\n",
+        b"2,b\n",
+        b"3,c\n",
+        b"4,d\n",
+        b"5,e\n",
+        b"6,f\n",
+        b"7,g\n",
+        b"8,h\n",
+        b"9,i\n",
+        b"10,j\n",
+        b"11,k\n",
+        b"12,l\n",
+        b"13,m\n",
+    ];
+    let body = futures_util::stream::unfold(0usize, |i| async move {
+        if i >= CHUNKS.len() {
+            return None;
+        }
+        if i > 0 {
+            // gap << --timeout, but summed across all chunks > --timeout
+            tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+        }
+        Some((
+            Ok::<_, std::io::Error>(web::Bytes::from_static(CHUNKS[i])),
+            i + 1,
+        ))
+    });
+    HttpResponse::Ok().content_type("text/csv").streaming(body)
+}
+
+// Sends headers + a first chunk, then STALLS (no data) far longer than the
+// client's `--timeout`, so an inactivity read-timeout must fire and abort.
+async fn serve_stalled(_req: HttpRequest) -> HttpResponse {
+    let body = futures_util::stream::unfold(0usize, |i| async move {
+        match i {
+            0 => Some((
+                Ok::<_, std::io::Error>(web::Bytes::from_static(b"id,name\n")),
+                1,
+            )),
+            1 => {
+                // Stall well past the client's --timeout (which the test sets to 1s).
+                tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+                Some((Ok(web::Bytes::from_static(b"1,a\n")), 2))
+            },
+            _ => None,
+        }
+    });
+    HttpResponse::Ok().content_type("text/csv").streaming(body)
+}
+
 // A request handler that serves STATES_CSV with an ETag and honors
 // conditional GETs: a matching `If-None-Match` yields 304 (counted as a
 // revalidation, NOT a body send), so a test can assert that a second
@@ -193,6 +255,9 @@ async fn run_webserver(
             .service(web::resource("/one_fresh.csv").to(serve_one_fresh))
             // A larger object for the HTTP ranged/streaming download test.
             .service(web::resource("/big.csv").to(serve_big))
+            // Inactivity-timeout tests: a slow-but-active stream and a stalled stream.
+            .service(web::resource("/slow_active.csv").to(serve_slow_active))
+            .service(web::resource("/stalled.csv").to(serve_stalled))
             // Path-style S3 object: object_store issues `GET /{bucket}/{key}`
             // against the endpoint override. Reuses the ETag/304 handler so the
             // cloud path can assert revalidation just like the HTTP path.
@@ -487,6 +552,64 @@ fn get_http_ranged_download() {
     let mut count = wrk.command("count");
     count.env("QSV_CACHE_DIR", &cache_dir).arg("dc:big.csv");
     assert_eq!(wrk.stdout::<String>(&mut count), "500");
+}
+
+#[test]
+#[serial]
+fn get_idle_timeout_allows_slow_but_active_stream() {
+    // A slow-but-steady download must NOT be aborted: the inactivity (read) timeout
+    // resets on every received chunk, even though the TOTAL stream time exceeds
+    // --timeout. (A total-request deadline — the old behavior — would fail this.)
+    let server = GetWebServer::start();
+    let wrk = Workdir::new("get_idle_timeout_allows_slow_but_active_stream");
+    let cache_dir = wrk.path("qsvcache");
+    let url = server.url("slow_active.csv");
+    let outfile = wrk.path("slow_out.csv");
+
+    let mut g = wrk.command("get");
+    g.env("QSV_CACHE_DIR", &cache_dir)
+        .args(["--name", "slow_active.csv"])
+        // 14 chunks, 250ms apart => ~3.25s total > 2s timeout, but each gap << 2s
+        .args(["--timeout", "2"])
+        .args(["--output", outfile.to_str().unwrap()])
+        .arg(&url);
+    wrk.assert_success(&mut g);
+
+    let out = std::fs::read_to_string(&outfile).unwrap();
+    assert!(out.starts_with("id,name\n"), "unexpected output:\n{out}");
+    assert!(out.contains("13,m\n"), "stream was truncated:\n{out}");
+    assert_eq!(
+        out.lines().count(),
+        14,
+        "expected the full 14-line stream:\n{out}"
+    );
+}
+
+#[test]
+#[serial]
+fn get_idle_timeout_aborts_stalled_stream() {
+    // A stalled connection (no data past the inactivity window) must abort with a
+    // clear, actionable message rather than a cryptic reqwest decode error.
+    let server = GetWebServer::start();
+    let wrk = Workdir::new("get_idle_timeout_aborts_stalled_stream");
+    let cache_dir = wrk.path("qsvcache");
+    let url = server.url("stalled.csv");
+
+    let mut g = wrk.command("get");
+    g.env("QSV_CACHE_DIR", &cache_dir)
+        .args(["--name", "stalled.csv"])
+        .args(["--timeout", "1"])
+        .arg(&url);
+    let out = wrk.output(&mut g);
+    assert!(
+        !out.status.success(),
+        "a stalled download should fail, but it succeeded"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("download stalled") && stderr.contains("increase --timeout"),
+        "expected a clear stalled-download error, got:\n{stderr}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Problem

`qsv get "ckan://911 EMS Dispatches?" --ckan-api https://data.wprdc.org/api/3/action` failed with:

```
get: reading https://tools.wprdc.org/downstream/… failed: error decoding response body
```

CKAN resolution succeeded; the **download** did not. The resolved WPRDC proxy returns `200 OK` with `Transfer-Encoding: chunked`, ignores the `Range` probe, and streams a large CSV **slowly but steadily** (~0.8 MB/s). qsv's shared reqwest client used reqwest's **total-request** `.timeout()` (default `--timeout 30`), which is "applied from when the request starts connecting until the response body has finished." That deadline fired mid-stream and aborted a perfectly healthy download. Raising `--timeout 600` let it complete, confirming the deadline — not any server error — was the limiter.

## Change

Redefine `--timeout` as an **inactivity (idle) timeout** on the async HTTP client via reqwest's `ClientBuilder::read_timeout()` — "applies to each read operation, and resets after a successful read." A slow-but-steady download is no longer aborted; only a genuinely stalled connection (no data for the configured seconds) trips it. `connect_timeout` is retained; there is deliberately **no** total-request cap.

- **`src/util.rs`** — `create_reqwest_async_client` uses `read_timeout` instead of `timeout`.
- **`src/diskcache.rs`** — an idle timeout now reports a clear `get: download stalled: no data received … within the inactivity timeout — increase --timeout` instead of the cryptic reqwest error.
- **Help text** — `get` and `sample` `--timeout` reworded; `docs/help/{get,sample}.md` regenerated.
- **Tests** — two deterministic actix-mock cases in `tests/test_get.rs`: a slow-but-active stream (total time > timeout, gaps < timeout) **succeeds**; a stalled stream **aborts** with the new message.

## Scope note (async client only)

This applies to `create_reqwest_async_client` only — which is exactly where the reported bug lives (the `get` download is the async path). It is **not** applied to the blocking client: reqwest 0.13.4 reads blocking response bodies on a thread with **no Tokio timer**, so a `read_timeout` body wrapper panics there (`there is no reactor running`) — reproduced via `get`'s CKAN resolution. There is no supported workaround in 0.13.4. Blocking-client commands (`apply`/`describegpt`/`validate`/lookups + `get`'s CKAN resolution) therefore keep their total-request `.timeout()`.

Verified no timer-panic across the other async-client callers (`sample`, `sniff`, `util::download_file`) — all drive the client under a `tokio::runtime::Runtime` (sniff nests `futures::executor::block_on` inside the outer tokio runtime, so the timer context is present). `sniff` and `sample` were also run live against a remote CSV.

## Testing

- New: `get_idle_timeout_allows_slow_but_active_stream`, `get_idle_timeout_aborts_stalled_stream`.
- Full suites pass: `test_get` (47), `test_sniff` (30), `test_sample` (67).
- `cargo +nightly fmt` + `cargo clippy` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)