### PR TITLE
fix(viz): gz replay chain no longer stalls after a MapLibre map panel

### DIFF
--- a/src/cmd/viz.rs
+++ b/src/cmd/viz.rs
@@ -6778,10 +6778,16 @@ const GZ_PRELUDE_SCRIPT: &str = r#"<script>
 </script>"#;
 
 /// Bootstrap that inflates the gzip+base64 plotly.js payload, installs the real `Plotly` global
-/// via indirect eval (global scope), replays the stub's queued `newPlot` calls sequentially
-/// (deterministic panel order), and announces readiness. Emitted right after the payload tag in
-/// `<head>`, so inflation overlaps the browser's parse of the multi-MB body. A browser without
-/// `DecompressionStream` (pre-2023) gets an explanatory banner instead of a blank page.
+/// via indirect eval (global scope), replays the stub's queued `newPlot` calls in queue order,
+/// and announces readiness. Emitted right after the payload tag in `<head>`, so inflation
+/// overlaps the browser's parse of the multi-MB body. A browser without `DecompressionStream`
+/// (pre-2023) gets an explanatory banner instead of a blank page.
+///
+/// The replay deliberately does NOT chain each panel behind the previous panel's render promise:
+/// a MapLibre panel's `newPlot` promise can stay pending forever (map style/tile load never
+/// resolves it), and a sequential `then` chain would stall every later panel behind it (#4155).
+/// Firing the calls independently mirrors the uncompressed page, where each panel's inline
+/// script invokes `newPlot` as it is parsed.
 const PLOTLY_GZ_BOOTSTRAP: &str = r##"<script>
 (function () {
   function fail(msg) {
@@ -6800,14 +6806,21 @@ const PLOTLY_GZ_BOOTSTRAP: &str = r##"<script>
     window.__qsvPlotQ = null;
     delete window.Plotly;
     (0, eval)(src);
-    var chain = Promise.resolve();
     q.forEach(function (args) {
-      // per-panel catch: one failed render must not skip the remaining queued panels
-      chain = chain.then(function () { return Plotly.newPlot.apply(Plotly, args); })
-        .catch(function (e) { console.error("qsv viz: queued panel render failed:", e); });
+      // per-panel isolation: one failed (or forever-pending) render must not block the rest
+      try {
+        var p = Plotly.newPlot.apply(Plotly, args);
+        // per-panel settle -> ready, so a stuck panel can't hold the theme re-apply hostage
+        if (p && p.then) p.then(window.__qsvReady, function (e) {
+          console.error("qsv viz: queued panel render failed:", e);
+          window.__qsvReady();
+        });
+      } catch (e) {
+        console.error("qsv viz: queued panel render failed:", e);
+      }
     });
-    // every branch above settles, so readiness always fires even if some panels failed
-    chain.then(window.__qsvReady);
+    // readiness floor: fires even if every queued panel's promise stays pending
+    window.__qsvReady();
   }).catch(function (e) { fail("Failed to inflate the embedded plotly.js bundle: " + e); });
 })();
 </script>"##;


### PR DESCRIPTION
## Summary

Fixes #4155.

Under the default compressed plotly bundle (#4154), `PLOTLY_GZ_BOOTSTRAP` replayed the stub-queued `newPlot` calls as a **sequential promise chain** (`chain = chain.then(...)`). A MapLibre `scattermap` panel's `newPlot` promise never settles (map style/tile load never resolves it), so the chain stalled after the map panel — every subsequently queued panel (e.g. the PIP choropleth "Regions" panel from `--geojson`) never rendered, and `qsv:plotly-ready` never fired.

## Fix

Replay the queue with an **independent per-panel loop** instead of a chain, mirroring the proven uncompressed path where each panel's inline script fires `newPlot` as it is parsed (call order stays deterministic — it's a synchronous loop in queue order):

- per-panel `try` / reject-handler preserves the roborev #3482/#3483 isolation: one failed render can't skip the remaining panels
- each settled panel dispatches `qsv:plotly-ready` itself, plus a readiness floor after the loop, so a forever-pending map promise can't hold the theme re-apply hostage

## Verification

- Reproduced the issue's exact repro on master in Chrome: panel-0 (map) rendered, panel-1 empty, queue drained, 1 `.js-plotly-plot` div
- With the fix: both panels render (2 divs, panel-1 has choropleth data), verified visually in dark theme
- Only console error is the pre-existing benign fullscreen-enhance AbortError on map panels noted in the issue
- Non-map compressed smart dashboard (single subplot grid) still renders
- `cargo t viz -F all_features`: 257 passed; `cargo clippy -F all_features`: no new warnings (the two doc-indent warnings at viz.rs:824-825 pre-date this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZx1jyKAYwSX2TyB4i4DNp