### PR TITLE
chore(viz): fail loudly if gen_gallery scrapes compressed viz output

### DIFF
--- a/examples/viz/gen_gallery.py
+++ b/examples/viz/gen_gallery.py
@@ -827,26 +827,38 @@ def extract_inline_panels(html):
     return panels
 
 
-# Markers of a gzip+base64 payload in viz output. Both are literals viz emits (a script-tag
-# content type and a JS call), never anything that could appear in scraped user data.
-GZ_MARKERS = ('type="application/gzip-b64"', "qsvNewPlotGz(")
+# Markers of a non-plaintext payload in viz output. All three are literals viz emits — a
+# script-tag content type, a JS call, and the exact typed-array serialization — none of which
+# scraped user data can produce.
+#
+# The two encodings QSV_VIZ_NO_COMPRESS disables have DIFFERENT thresholds, so checking only the
+# gzip ones is not enough: a figure gzips at >=64KB of JSON (MAP_FIG_GZ_MIN_BYTES) but a coordinate
+# array becomes base64 float32 at just >=64 elements (BDATA_MIN_LEN). A small map panel (e.g.
+# delivery_stops.csv, 201 rows) therefore emits `bdata` and no gzip marker at all.
+COMPRESSED_MARKERS = (
+    'type="application/gzip-b64"',       # gzipped bundle / figure payload
+    "qsvNewPlotGz(",                     # deferred render of a gzipped figure
+    '"dtype":"float32","bdata":"',       # base64 float32 typed array (fields serialized in order)
+)
 
 
-def assert_plaintext(html, args):
-    """Fail loudly if viz emitted compressed payloads.
+def assert_plaintext(html, source):
+    """Fail loudly if viz output is not fully plain text.
 
     `extract_inline_panels` scrapes plaintext `Plotly.newPlot(...)` calls; a gzipped panel is
     emitted as `qsvNewPlotGz(...)` + a base64 blob instead, so it would be skipped *silently* —
-    a map panel would simply vanish from the gallery with no error. The committed iframes would
-    also become undiffable base64. QSV_VIZ_NO_COMPRESS in `run_html` prevents both; this asserts
-    it actually took effect (e.g. it wasn't dropped, or overridden to a falsy value)."""
-    found = [m for m in GZ_MARKERS if m in html]
+    a map panel would simply vanish from the gallery with no error. Typed arrays don't break the
+    scrape (they parse as nested JSON) but do turn committed iframes into undiffable base64.
+    QSV_VIZ_NO_COMPRESS in `run_html` prevents both; this asserts it actually took effect (e.g.
+    it wasn't dropped, or overridden to a falsy value)."""
+    found = [m for m in COMPRESSED_MARKERS if m in html]
     if found:
         raise ValueError(
-            f"`qsv viz {' '.join(args)}` emitted compressed payloads ({', '.join(found)}). "
-            "The gallery needs plain-text output to scrape figure JSON and to commit diffable "
-            "iframes — run_html sets QSV_VIZ_NO_COMPRESS=1 for this; check it is not being "
-            "overridden (a falsy value in the environment or a .env file disables it)."
+            f"{source} is not plain text ({', '.join(found)}). The gallery needs plain-text "
+            "output to scrape figure JSON and to commit diffable iframes — run_html sets "
+            "QSV_VIZ_NO_COMPRESS=1 for this; check it is not being overridden (a falsy value in "
+            "the environment or a .env file disables it). Pre-generated iframes must have been "
+            "produced the same way."
         )
 
 
@@ -870,7 +882,7 @@ def run_html(qsv, args):
             html = fh.read()
     finally:
         os.unlink(out)
-    assert_plaintext(html, args)
+    assert_plaintext(html, f"`qsv viz {' '.join(args)}` output")
     return html
 
 
@@ -985,6 +997,9 @@ def main():
                 pre_path = os.path.join(VIZ_DIR, iframe_name)
                 with open(pre_path, encoding="utf-8") as fh:
                     existing = fh.read()
+                # reused verbatim, so it never passed through run_html's check — validate it here,
+                # else a dashboard refreshed without QSV_VIZ_NO_COMPRESS gets silently re-committed
+                assert_plaintext(existing, f"pre-generated {iframe_name}")
                 refreshed = inject_resize_reporter(existing)
                 if refreshed != existing:
                     with open(pre_path, "w", encoding="utf-8") as fh:

--- a/examples/viz/gen_gallery.py
+++ b/examples/viz/gen_gallery.py
@@ -827,13 +827,39 @@ def extract_inline_panels(html):
     return panels
 
 
+# Markers of a gzip+base64 payload in viz output. Both are literals viz emits (a script-tag
+# content type and a JS call), never anything that could appear in scraped user data.
+GZ_MARKERS = ('type="application/gzip-b64"', "qsvNewPlotGz(")
+
+
+def assert_plaintext(html, args):
+    """Fail loudly if viz emitted compressed payloads.
+
+    `extract_inline_panels` scrapes plaintext `Plotly.newPlot(...)` calls; a gzipped panel is
+    emitted as `qsvNewPlotGz(...)` + a base64 blob instead, so it would be skipped *silently* —
+    a map panel would simply vanish from the gallery with no error. The committed iframes would
+    also become undiffable base64. QSV_VIZ_NO_COMPRESS in `run_html` prevents both; this asserts
+    it actually took effect (e.g. it wasn't dropped, or overridden to a falsy value)."""
+    found = [m for m in GZ_MARKERS if m in html]
+    if found:
+        raise ValueError(
+            f"`qsv viz {' '.join(args)}` emitted compressed payloads ({', '.join(found)}). "
+            "The gallery needs plain-text output to scrape figure JSON and to commit diffable "
+            "iframes — run_html sets QSV_VIZ_NO_COMPRESS=1 for this; check it is not being "
+            "overridden (a falsy value in the environment or a .env file disables it)."
+        )
+
+
 def run_html(qsv, args):
     """Run `qsv viz <args>` and return its HTML output as a string.
 
     QSV_VIZ_CDN makes viz emit a plotly CDN `<script src>` instead of the ~4.6MB inline bundle,
     so the smart-dashboard iframes are small enough to commit. QSV_VIZ_NO_COMPRESS keeps figure
     payloads in the fully readable plain form (no gzip+DecompressionStream, no base64 float32
-    typed arrays), which this script needs to scrape figure JSON out of the HTML."""
+    typed arrays), which this script needs to scrape figure JSON out of the HTML.
+
+    Note QSV_VIZ_CDN alone is not enough: it only swaps the plotly *bundle* for a CDN tag, while
+    map-panel *figures* keep their gzip+bdata encoding."""
     fd, out = tempfile.mkstemp(suffix=".html")
     os.close(fd)
     try:
@@ -841,9 +867,11 @@ def run_html(qsv, args):
                        check=True, capture_output=True, text=True,
                        env={**os.environ, "QSV_VIZ_CDN": "1", "QSV_VIZ_NO_COMPRESS": "1"})
         with open(out, encoding="utf-8") as fh:
-            return fh.read()
+            html = fh.read()
     finally:
         os.unlink(out)
+    assert_plaintext(html, args)
+    return html
 
 
 def run_fig(qsv, args):


### PR DESCRIPTION
Follow-up to #4170.

## The silent failure

`gen_gallery.py`'s `extract_inline_panels()` scrapes plaintext `Plotly.newPlot("qsv-viz-panel-N", {...})` calls out of `qsv viz smart` output. When viz compresses a map panel it emits `qsvNewPlotGz(...)` + a base64 blob instead — which the scraper doesn't match, so the panel is **dropped silently**. No error, no warning, no missing-figure check.

Reproduced on the committed nyc311 dashboard:

```
[ok] guard passes on normal run; scraped 39 panels
[!!] without the env var, extract_inline_panels silently returns 38 panels (vs 39)
```

The map just vanishes from the gallery.

`run_html()` already sets `QSV_VIZ_NO_COMPRESS=1` to prevent this, but nothing verified it took effect — an override to a falsy value, or a stray `.env`, and the gallery regenerates a panel short. (A repo-root `.env` leaking `QSV_GEOJSON_SHORTCUTS` has already broken viz tests twice, so this is not hypothetical.)

## The guard

`assert_plaintext()`, keyed on three literals viz emits and scraped user data cannot contain:

- `type="application/gzip-b64"` (a script-tag content type)
- `qsvNewPlotGz(` (a JS call)
- `"dtype":"float32","bdata":"` (the exact typed-array serialization)

It runs on every `run_html()` result **and** on the reused `PREGENERATED` iframes, which are read straight off disk and so never pass through `run_html`.

It guards the **iframe path** too, not just scraping: a compressed dashboard committed as an iframe would be an undiffable multi-MB base64 blob.

### Why all three markers

The two encodings `QSV_VIZ_NO_COMPRESS` disables have **different thresholds**: a figure gzips at `>=64KB` of JSON (`MAP_FIG_GZ_MIN_BYTES`), but a coordinate array becomes base64 float32 at just `>=64` elements (`BDATA_MIN_LEN`). So a *small* map panel emits `bdata` and no gzip marker at all — `viz smart delivery_stops.csv` (201 rows, already in the gallery) yields 0 gzip markers and 2 `bdata` arrays. A gzip-only guard would wave it through.

`bdata` alone doesn't cause panel loss (typed arrays parse as nested JSON, so the scrape still finds the panel) — it defeats the guard's *second* purpose, diffable committed artifacts.

The `bdata` marker uses the adjacent `dtype`/`bdata` pair rather than either field alone, so a CSV cell can't trip it.

## Why not just enable compression for the gallery?

Considered and measured, since the gallery is published to GitHub Pages, which serves `content-encoding: gzip`. For `smart_nyc311.html`:

| | on-disk | over-wire |
|---|---|---|
| plain (today) | 3,653,716 | 624,385 |
| gz figures + `bdata` | 1,453,594 | 607,499 |
| | 2.51× smaller | **2.7% smaller** |

Transport gzip already reclaims nearly all of it, so embedded compression would buy ~2.7% over the wire in exchange for silent panel loss, undiffable artifacts, and a double-inflate on every visitor. Not worth it. Pages also gives no control over `Content-Encoding` and won't serve a pre-compressed `.gz`, so there is nothing to change in `viz-gallery-pages.yml`.

## Also documented

`QSV_VIZ_CDN` alone does **not** make output plaintext — it swaps only the plotly *bundle* for a CDN tag; map *figures* keep their gzip+`bdata` encoding. The two vars are easy to conflate, so `run_html`'s docstring now says so explicitly.

## Testing

- Guard fires on compressed output, with the 39→38 panel loss reproduced first to confirm it is guarding a real defect rather than a hypothetical one.
- Verification matrix: fires on `bdata`-only output; fires on gzipped output; passes on correct output; all four committed `PREGENERATED` iframes pass (no false positives).
- Full 37-figure regen passes the guard; `gallery.html` and all iframes byte-identical apart from `Compiled:` timestamps (reverted, not committed).
- Both roborev findings on the first commit (job 3545) confirmed reachable, fixed in the second commit, and closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
