### PR TITLE
fix(self-update): add timeouts, retries & structured error messages for self_update rc.4

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -1530,11 +1530,41 @@ pub fn init_logger() -> CliResult<(String, flexi_logger::LoggerHandle)> {
     }
 }
 
+/// Turn a `self_update` error into an accurate, actionable message.
+///
+/// rc.4's `Error` is `#[non_exhaustive]` with structured HTTP variants, so we can
+/// distinguish a genuine GitHub rate-limit / auth failure (403/401/429) from a network
+/// timeout or connection failure - instead of the old blanket "Github is rate-limiting"
+/// message that masked every failure mode (including the fixed pagination-URL 403 bug).
+#[cfg(feature = "self_update")]
+fn describe_self_update_error(e: &self_update::errors::Error) -> String {
+    use self_update::errors::Error;
+
+    match e {
+        // 429 (and 403 below) are how GitHub signals secondary/primary rate limits
+        Error::HttpStatus { status: 429, .. } => {
+            format!(
+                "GitHub is rate-limiting self-update checks (HTTP 429). Try again in an hour: {e}"
+            )
+        },
+        Error::Unauthorized { status: 403, .. } => {
+            format!("GitHub returned HTTP 403 - likely rate-limiting. Try again in an hour: {e}")
+        },
+        Error::Unauthorized { status, .. } => {
+            format!("GitHub authorization failed (HTTP {status}): {e}")
+        },
+        Error::HttpStatus { status, .. } => format!("GitHub returned HTTP {status}: {e}"),
+        Error::NotFound { .. } => format!("Release not found on GitHub: {e}"),
+        Error::Transport(_) => {
+            format!("Network error reaching GitHub (timeout or connection failure): {e}")
+        },
+        _ => format!("Self-update check failed: {e}"),
+    }
+}
+
 #[cfg(feature = "self_update")]
 pub fn qsv_check_for_update(check_only: bool, no_confirm: bool) -> Result<bool, String> {
     use self_update::cargo_crate_version;
-    const GITHUB_RATELIMIT_MSG: &str =
-        "Github is rate-limiting self-update checks at the moment. Try again in an hour.";
 
     if get_envvar_flag("QSV_NO_UPDATE") {
         return Ok(false);
@@ -1557,16 +1587,21 @@ pub fn qsv_check_for_update(check_only: bool, no_confirm: bool) -> Result<bool, 
     let releases = match self_update::backends::github::ReleaseList::configure()
         .repo_owner("dathere")
         .repo_name("qsv")
+        // the release listing is a small JSON response, so bound it with a short timeout
+        // to avoid hanging indefinitely on a stalled connection. Pair with a couple of
+        // retries (exponential backoff, per self_update defaults) for transient failures.
+        .timeout(Duration::from_secs(20))
+        .retries(2)
         .build()
     {
         Ok(releases_list) => match releases_list.fetch() {
             Ok(releases) => releases,
             Err(e) => {
-                return fail!(format!("{GITHUB_RATELIMIT_MSG}: {e}"));
+                return fail!(describe_self_update_error(&e));
             },
         },
         Err(e) => {
-            return fail!(format!("{GITHUB_RATELIMIT_MSG}: {e}"));
+            return fail!(describe_self_update_error(&e));
         },
     };
     let Some(first_release) = releases.latest() else {
@@ -1597,6 +1632,12 @@ pub fn qsv_check_for_update(check_only: bool, no_confirm: bool) -> Result<bool, 
                 .no_confirm(no_confirm)
                 .current_version(curr_version)
                 .verifying_keys([*include_bytes!("qsv-zipsign-public.key")])
+                // NOTE: on the Update builder, timeout() also bounds the multi-MB binary
+                // download (a total-request timeout), so use a generous cap here - NOT the
+                // short listing timeout - to avoid aborting legitimate slow downloads.
+                // retries() only re-attempts before any bytes are streamed to disk.
+                .timeout(Duration::from_secs(600))
+                .retries(2)
                 .build()
             {
                 Ok(update_job) => match update_job.update() {
@@ -1609,9 +1650,9 @@ pub fn qsv_check_for_update(check_only: bool, no_confirm: bool) -> Result<bool, 
                         );
                         winfo!("{update_status}");
                     },
-                    Err(e) => werr!("Update job error: {e}"),
+                    Err(e) => werr!("Update job error: {}", describe_self_update_error(&e)),
                 },
-                Err(e) => werr!("Update builder error: {e}"),
+                Err(e) => werr!("Update builder error: {}", describe_self_update_error(&e)),
             }
         } else if check_only {
             winfo!("Use the --update option to upgrade {bin_name} to the latest release.");


### PR DESCRIPTION
## Context

We recently bumped `self_update` to `1.0.0-rc.4` (#4181). This PR reviews whether qsv uses the crate optimally per the [0.x→1.0 migration guide](https://github.com/jaemk/self_update/blob/master/docs/migrations/0.x-to-1.0.md).

**The API migration itself was already complete and correct** — `show_download_progress()`, `releases.latest()`, the `.version()` getters, and `verifying_keys()` are all proper 1.0 shape, and every `self_update` feature flag in `Cargo.toml` is a valid rc.4 name. So this isn't a migration to redo; it closes the robustness gaps the 1.0 API now lets us address.

All changes are in `qsv_check_for_update()` in `src/util.rs`.

## Changes

### 1. Listing timeout + retries (ReleaseList builder)
`.timeout(Duration::from_secs(20))` + `.retries(2)`. rc.4's `.timeout()` defaults to `None` (unbounded), so this closes the original "hang forever on a stalled connection" bug that previously required a fork. The listing is a small JSON response, so a short timeout is safe.

### 2. Generous download timeout + retries (Update builder)
`.timeout(Duration::from_secs(600))` + `.retries(2)`. **Deliberately not** the short listing value: on the `Update` builder, `timeout()` also bounds the multi-MB binary download (a total-request timeout), so a tight cap would abort legitimate slow-link downloads. `retries()` only re-attempts before any bytes are streamed to disk.

### 3. Structured error messages
New `describe_self_update_error()` helper matches rc.4's `#[non_exhaustive]` `Error` variants (`Unauthorized{401/403}`, `HttpStatus{429}`, `NotFound`, `Transport`) to report accurately, replacing the blanket `"Github is rate-limiting"` catch-all. That message was always misleading — the real cause of the "rate limiting" hangs was the pagination-URL 403 bug, now fixed upstream in rc.4's `Link`-header pagination.

## Deliberate non-changes
- **Kept the two-step listing + manual-semver flow** rather than `is_update_available()` — qsv needs the `latest_release` string for the hwsurvey and user messaging.
- **`archive-zip` Cargo feature** (redundant with `compression-zip-deflate`) and **`.verify_binary()`** — deferred; zipsign signatures already gate integrity.
- **`QSV_GITHUB_TOKEN` / auth-token support and a TTL cache** are separate, unmerged feature work and not part of the migration guide — out of scope here. (An earlier draft error message suggested setting `QSV_GITHUB_TOKEN`; removed after confirming qsv doesn't honor it for self-update.)

## Verification
- `cargo build --locked --bin qsv -F all_features` — compiles clean on rc.4
- `cargo clippy --bin qsv -F all_features` — no new warnings
- `cargo +nightly fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)