### PR TITLE
perf(moarstats): fuse outlier+KGA into one parallel scan; parallelize KGA

### DIFF
--- a/src/cmd/moarstats.rs
+++ b/src/cmd/moarstats.rs
@@ -2445,6 +2445,13 @@ fn compute_outliers_and_kga(
     let n_outlier = outlier_fields.len();
     let n_kga = kga_fields.len();
 
+    // Resolve the job count up front (also sizes Rayon's global pool via
+    // `util::njobs`). This must happen on EVERY path — including the sequential
+    // scan fallbacks below — so the parallel KGA finalize (`into_par_iter`) honors
+    // `--jobs` (e.g. `--jobs 1` stays single-threaded) instead of defaulting to
+    // Rayon's all-cores global pool.
+    let njobs = util::njobs(flag_jobs);
+
     // (merged_outliers, kga_concat) produced by whichever path runs.
     let (merged_outliers, kga_concat): (Vec<OutlierStats>, Vec<Vec<f64>>) = if let Some(idx) =
         indexed_result
@@ -2470,7 +2477,6 @@ fn compute_outliers_and_kga(
             (fused.outlier_stats, fused.kga_values)
         } else {
             // Parallel path: chunk by index, one fused scan per chunk.
-            let njobs = util::njobs(flag_jobs);
             let chunk_size = util::chunk_size(idx_count, njobs);
             let nchunks = util::num_of_chunks(idx_count, chunk_size);
 
@@ -4369,11 +4375,13 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             .has_headers(true)
             .from_path(actual_input_path)?;
         let csv_headers = csv_rdr.headers()?.clone();
-        let header_pos: HashMap<&str, usize> = csv_headers
-            .iter()
-            .enumerate()
-            .map(|(idx, h)| (h, idx))
-            .collect();
+        // First occurrence wins for duplicate header names, matching the prior
+        // `csv_headers.iter().position(|h| h == field_name)` (first-match) semantics
+        // — a plain `.collect()` would keep the LAST duplicate instead.
+        let mut header_pos: HashMap<&str, usize> = HashMap::with_capacity(csv_headers.len());
+        for (idx, h) in csv_headers.iter().enumerate() {
+            header_pos.entry(h).or_insert(idx);
+        }
 
         let mut o_fields = Vec::with_capacity(fields_to_count.len());
         let mut o_names = Vec::with_capacity(fields_to_count.len());

--- a/src/cmd/moarstats.rs
+++ b/src/cmd/moarstats.rs
@@ -2576,14 +2576,21 @@ fn compute_outliers_and_kga(
         outlier_names.into_iter().zip(merged_outliers).collect();
 
     // Finalize KGA per field (slot -> name) over its file-ordered value vector.
-    let mut kga_stats: HashMap<String, KGAStats> = HashMap::with_capacity(n_kga);
-    for (j, values) in kga_concat.into_iter().enumerate() {
-        let (mean, variance, sum) = kga_precalc[j];
-        kga_stats.insert(
-            kga_names[j].clone(),
-            finalize_kga(&values, mean, variance, sum, atkinson_epsilon),
-        );
-    }
+    // Each field's finalize is independent and dominated by a per-column sort
+    // (Gini) plus kurtosis/Theil/mean_ad, so fan out across fields with rayon.
+    // Results are keyed by name and each field's math is order-independent of the
+    // others, so this stays bit-identical to a sequential finalize.
+    let kga_stats: HashMap<String, KGAStats> = kga_concat
+        .into_par_iter()
+        .zip(kga_precalc)
+        .zip(kga_names)
+        .map(|((values, (mean, variance, sum)), name)| {
+            (
+                name,
+                finalize_kga(&values, mean, variance, sum, atkinson_epsilon),
+            )
+        })
+        .collect();
 
     Ok((outlier_counts, kga_stats))
 }

--- a/src/cmd/moarstats.rs
+++ b/src/cmd/moarstats.rs
@@ -2123,46 +2123,169 @@ struct KGAFieldInfo {
     sum:        Option<f64>, // sum for Gini coefficient
 }
 
-/// Count outliers for a chunk of records and compute statistics
-/// Returns a `HashMap` mapping field names to their outlier statistics
-fn count_chunk_outliers<I>(
-    fields_to_count: &HashMap<String, OutlierFieldInfo>,
+/// Combined per-chunk output from a single fused scan that BOTH counts outliers
+/// and collects values for Kurtosis/Gini/Atkinson (KGA). Both vectors are
+/// slot-indexed (parallel to the `outlier_fields` / `kga_fields` slices passed to
+/// `count_and_collect_chunk`).
+struct FusedChunkOutput {
+    outlier_stats: Vec<OutlierStats>,
+    kga_values:    Vec<Vec<f64>>,
+}
+
+/// Merge one chunk's outlier stats for a single field slot into the running total.
+/// Order-independent (sums, counts, min/max), so chunks may be merged in any order.
+fn merge_outlier_stats(total: &mut OutlierStats, stats: &OutlierStats) {
+    for i in 0..OUTLIER_COUNTS_LEN {
+        total.counts[i] += stats.counts[i];
+    }
+    total.sum_outliers += stats.sum_outliers;
+    total.sum_normal += stats.sum_normal;
+    total.sum_all += stats.sum_all;
+    total.count_all += stats.count_all;
+    total.winsorized_sum += stats.winsorized_sum;
+    total.winsorized_count += stats.winsorized_count;
+    total.trimmed_sum += stats.trimmed_sum;
+    total.trimmed_count += stats.trimmed_count;
+    total.sum_squares_outliers += stats.sum_squares_outliers;
+    total.sum_squares_normal += stats.sum_squares_normal;
+    total.sum_squares_trimmed += stats.sum_squares_trimmed;
+    total.sum_squares_winsorized += stats.sum_squares_winsorized;
+    if let Some(min) = stats.min_outliers {
+        total.min_outliers = Some(total.min_outliers.map_or(min, |m| m.min(min)));
+    }
+    if let Some(max) = stats.max_outliers {
+        total.max_outliers = Some(total.max_outliers.map_or(max, |m| m.max(max)));
+    }
+    if let Some(min) = stats.min_normal {
+        total.min_normal = Some(total.min_normal.map_or(min, |m| m.min(min)));
+    }
+    if let Some(max) = stats.max_normal {
+        total.max_normal = Some(total.max_normal.map_or(max, |m| m.max(max)));
+    }
+    if let Some(min) = stats.min_trimmed {
+        total.min_trimmed = Some(total.min_trimmed.map_or(min, |m| m.min(min)));
+    }
+    if let Some(max) = stats.max_trimmed {
+        total.max_trimmed = Some(total.max_trimmed.map_or(max, |m| m.max(max)));
+    }
+    if let Some(min) = stats.min_winsorized {
+        total.min_winsorized = Some(total.min_winsorized.map_or(min, |m| m.min(min)));
+    }
+    if let Some(max) = stats.max_winsorized {
+        total.max_winsorized = Some(total.max_winsorized.map_or(max, |m| m.max(max)));
+    }
+}
+
+/// Finalize Kurtosis, Gini, Atkinson, Theil & mean absolute deviation for a single
+/// field from its full (file-ordered) value vector. Kept bit-identical to the former
+/// sequential `compute_all_kga_from_reader` finalize block.
+fn finalize_kga(
+    values: &[f64],
+    precalc_mean: Option<f64>,
+    precalc_variance: Option<f64>,
+    precalc_sum: Option<f64>,
+    atkinson_epsilon: f64,
+) -> KGAStats {
+    // Need at least 2 values for meaningful statistics
+    if values.len() < 2 {
+        return KGAStats::default();
+    }
+
+    // Compute kurtosis with precalculated mean and variance
+    let kurtosis_val = kurtosis(values.iter().copied(), precalc_mean, precalc_variance);
+
+    // Compute Gini coefficient with precalculated sum (not mean!)
+    let gini_val = gini(values.iter().copied(), precalc_sum);
+
+    // Compute Atkinson Index (epsilon parameter configurable via --epsilon)
+    let atkinson_val = atkinson(values.iter().copied(), atkinson_epsilon, precalc_mean, None);
+
+    // Compute Theil Index: (1/n) * Σ((x_i / mean) * ln(x_i / mean))
+    // Only for positive values (Theil index is undefined for non-positive values)
+    #[allow(clippy::cast_precision_loss)]
+    let theil_val = {
+        // First pass: compute sum and count of positive values
+        let mut pos_sum = 0.0_f64;
+        let mut pos_count: usize = 0;
+        for &v in values {
+            if v > 0.0 {
+                pos_sum += v;
+                pos_count += 1;
+            }
+        }
+
+        if pos_count >= 2 {
+            let n = pos_count as f64;
+            let pos_mean = pos_sum / n;
+            if pos_mean > f64::EPSILON {
+                // Second pass: accumulate Theil sum over positive values
+                let mut theil_sum = 0.0_f64;
+                for &v in values {
+                    if v > 0.0 {
+                        let ratio = v / pos_mean;
+                        // use CPU's Fused Multiply-Add (FMA) for better precision
+                        theil_sum = ratio.mul_add(ratio.ln(), theil_sum);
+                    }
+                }
+                Some(theil_sum / n)
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    };
+
+    // Compute Mean Absolute Deviation from mean: (1/n) * Σ|x_i - mean|
+    #[allow(clippy::cast_precision_loss)]
+    let mean_ad_val = if let Some(mean_val) = precalc_mean {
+        let n = values.len() as f64;
+        let sum_abs_dev: f64 = values.iter().map(|&x| (x - mean_val).abs()).sum();
+        Some(sum_abs_dev / n)
+    } else {
+        None
+    };
+
+    KGAStats {
+        kurtosis:         kurtosis_val,
+        gini_coefficient: gini_val,
+        atkinson_index:   atkinson_val,
+        theil_index:      theil_val,
+        mean_ad:          mean_ad_val,
+    }
+}
+
+/// Single fused scan over a chunk of records that BOTH counts outliers (into
+/// slot-indexed `OutlierStats`) and collects numeric values for KGA (into
+/// slot-indexed `Vec<f64>`), replacing the two former independent full-file passes.
+/// Uses index-based slot access (no per-cell String-keyed HashMap lookup) and a
+/// single reused `csv::ByteRecord`.
+fn count_and_collect_chunk<I>(
+    outlier_fields: &[OutlierFieldInfo],
+    kga_fields: &[KGAFieldInfo],
+    prefer_dmy: bool,
     records: I,
-) -> CliResult<HashMap<String, OutlierStats>>
+) -> CliResult<FusedChunkOutput>
 where
     I: Iterator<Item = csv::Result<csv::ByteRecord>>,
 {
-    if fields_to_count.is_empty() {
-        return Ok(HashMap::new());
-    }
+    let mut outlier_stats: Vec<OutlierStats> = vec![OutlierStats::default(); outlier_fields.len()];
+    let mut kga_values: Vec<Vec<f64>> = vec![Vec::new(); kga_fields.len()];
 
-    // Initialize statistics for all fields
-    let mut chunk_stats: HashMap<String, OutlierStats> = fields_to_count
-        .keys()
-        .map(|k| (k.clone(), OutlierStats::default()))
-        .collect();
-
-    let prefer_dmy = util::get_envvar_flag("QSV_PREFER_DMY");
     #[allow(unused_assignments)]
     let mut record: csv::ByteRecord = csv::ByteRecord::new();
-    let mut value_bytes;
-    let mut numeric_value;
 
-    // Process each record in the chunk
     for result in records {
         record = result?;
 
-        for (field_name, field_info) in fields_to_count {
-            value_bytes = record.get(field_info.col_idx).unwrap_or(&[]);
-
+        // --- Outlier slots: bucket each value against its IQR fences ---
+        for (i, field_info) in outlier_fields.iter().enumerate() {
+            let value_bytes = record.get(field_info.col_idx).unwrap_or(&[]);
             if value_bytes.is_empty() {
                 continue; // Skip null/empty values
             }
 
-            // Parse the value based on field type
-            numeric_value = if field_info.field_type.is_date_or_datetime() {
-                // Convert bytes to string for date parsing. UTF-8 decode failure
-                // is exceptional in CSV data — mark as cold for branch prediction.
+            let numeric_value = if field_info.field_type.is_date_or_datetime() {
                 if let Ok(value_str) = from_utf8(value_bytes) {
                     parse_date_to_days(value_str, prefer_dmy)
                 } else {
@@ -2177,13 +2300,8 @@ where
                 continue; // Skip values that can't be parsed
             };
 
-            // Get mutable reference to stats for this field
-            // safety: chunk_stats is pre-populated with all field names
-            let Some(stats) = chunk_stats.get_mut(field_name) else {
-                cold_path();
-                debug_assert!(false, "chunk_stats missing expected key: {field_name}");
-                continue;
-            };
+            // safety: outlier_stats is sized to outlier_fields.len()
+            let stats = &mut outlier_stats[i];
 
             // Update sums and count
             stats.sum_all += val;
@@ -2195,7 +2313,6 @@ where
                 .min(field_info.upper_threshold);
             stats.winsorized_sum += winsorized_val;
             stats.winsorized_count += 1;
-            // Track winsorized min/max and sum of squares
             stats.min_winsorized = Some(
                 stats
                     .min_winsorized
@@ -2213,7 +2330,6 @@ where
             if val >= field_info.lower_threshold && val <= field_info.upper_threshold {
                 stats.trimmed_sum += val;
                 stats.trimmed_count += 1;
-                // Track trimmed min/max and sum of squares
                 stats.min_trimmed = Some(stats.min_trimmed.map_or(val, |m| m.min(val)));
                 stats.max_trimmed = Some(stats.max_trimmed.map_or(val, |m| m.max(val)));
                 stats.sum_squares_trimmed = val.mul_add(val, stats.sum_squares_trimmed);
@@ -2256,177 +2372,220 @@ where
                 stats.max_outliers = Some(stats.max_outliers.map_or(val, |m| m.max(val)));
             }
         }
+
+        // --- KGA slots: collect parsed values in file order for later finalize ---
+        for (j, field_info) in kga_fields.iter().enumerate() {
+            let value_bytes = record.get(field_info.col_idx).unwrap_or(&[]);
+            if value_bytes.is_empty() {
+                continue; // Skip null/empty values
+            }
+
+            let numeric_value = if field_info.field_type.is_date_or_datetime() {
+                if let Ok(value_str) = from_utf8(value_bytes) {
+                    parse_date_to_days(value_str, prefer_dmy)
+                } else {
+                    cold_path();
+                    None
+                }
+            } else {
+                parse_float_opt_from_bytes(value_bytes)
+            };
+
+            if let Some(val) = numeric_value {
+                // safety: kga_values is sized to kga_fields.len()
+                kga_values[j].push(val);
+            }
+        }
     }
 
-    Ok(chunk_stats)
+    Ok(FusedChunkOutput {
+        outlier_stats,
+        kga_values,
+    })
 }
 
-/// Count outliers for all fields, using parallel processing if index is available
-/// Returns a `HashMap` mapping field names to their outlier statistics
-fn count_all_outliers(
-    fields_to_count: HashMap<String, OutlierFieldInfo>,
+/// Fused replacement for the former `count_all_outliers` + `compute_all_kga`:
+/// computes outlier statistics AND Kurtosis/Gini/Atkinson in a SINGLE scan of the
+/// original CSV (chunked & parallel when an index exists and the file is large
+/// enough, sequential otherwise). Outlier stats merge order-independently; KGA
+/// value vectors are concatenated in strict chunk-index (file) order so results
+/// are bit-identical to a sequential read.
+///
+/// `outlier_names`/`kga_names` are parallel to `outlier_fields`/`kga_fields` (slot
+/// i <-> field name i) and map the slot-indexed results back to name-keyed maps.
+#[allow(clippy::type_complexity)]
+fn compute_outliers_and_kga(
+    outlier_fields: Vec<OutlierFieldInfo>,
+    outlier_names: Vec<String>,
+    kga_fields: Vec<KGAFieldInfo>,
+    kga_names: Vec<String>,
     input_path: &Path,
     flag_jobs: Option<usize>,
-) -> CliResult<HashMap<String, OutlierStats>> {
-    if fields_to_count.is_empty() {
-        return Ok(HashMap::new());
+    atkinson_epsilon: f64,
+) -> CliResult<(HashMap<String, OutlierStats>, HashMap<String, KGAStats>)> {
+    if outlier_fields.is_empty() && kga_fields.is_empty() {
+        return Ok((HashMap::new(), HashMap::new()));
     }
 
-    // Check if index exists for parallel processing
+    // Precompute KGA per-field (mean, variance, sum) for finalize BEFORE the field
+    // list is moved into an Arc for the parallel workers.
+    let kga_precalc: Vec<(Option<f64>, Option<f64>, Option<f64>)> = kga_fields
+        .iter()
+        .map(|f| (f.mean, f.variance, f.sum))
+        .collect();
+
     let input_path_str = input_path
         .to_str()
         .ok_or_else(|| CliError::Other(format!("Invalid input path: {}", input_path.display())))?;
     let input_path_string = input_path_str.to_string();
     let rconfig = Config::new(Some(&input_path_string));
     let indexed_result = rconfig.indexed()?;
+    let prefer_dmy = util::get_envvar_flag("QSV_PREFER_DMY");
 
-    if let Some(idx) = indexed_result {
-        // Parallel processing path
+    let n_outlier = outlier_fields.len();
+    let n_kga = kga_fields.len();
+
+    // (merged_outliers, kga_concat) produced by whichever path runs.
+    let (merged_outliers, kga_concat): (Vec<OutlierStats>, Vec<Vec<f64>>) = if let Some(idx) =
+        indexed_result
+    {
         let idx_count = idx.count() as usize;
-        if idx_count == 0 {
-            return Ok(HashMap::new());
-        }
 
-        // Only parallelize if file is large enough
-        if idx_count < PARALLEL_THRESHOLD {
-            // Fall back to sequential for small files
+        if idx_count == 0 {
+            // Empty CSV: match the former behavior — outliers = empty map (the old
+            // count_all_outliers early-returned an empty map), KGA = all-None
+            // entries (finalize on empty vecs). Empty merged_outliers zips to an
+            // empty outlier map below.
+            (Vec::new(), vec![Vec::new(); n_kga])
+        } else if idx_count < PARALLEL_THRESHOLD {
+            // Sequential fallback for small files (test-covered golden path).
             let mut rdr = rconfig.reader_file()?;
             let _headers = rdr.headers()?.clone();
-            return count_chunk_outliers(&fields_to_count, rdr.byte_records());
-        }
+            let fused = count_and_collect_chunk(
+                &outlier_fields,
+                &kga_fields,
+                prefer_dmy,
+                rdr.byte_records(),
+            )?;
+            (fused.outlier_stats, fused.kga_values)
+        } else {
+            // Parallel path: chunk by index, one fused scan per chunk.
+            let njobs = util::njobs(flag_jobs);
+            let chunk_size = util::chunk_size(idx_count, njobs);
+            let nchunks = util::num_of_chunks(idx_count, chunk_size);
 
-        let njobs = util::njobs(flag_jobs);
-        let chunk_size = util::chunk_size(idx_count, njobs);
-        let nchunks = util::num_of_chunks(idx_count, chunk_size);
+            log::info!("Parallelizing outlier+KGA computation: {nchunks} chunks, {njobs} jobs");
 
-        log::info!("Parallelizing outlier counting: {nchunks} chunks, {njobs} jobs");
+            // Retain freed jemalloc pages for this parallel, allocation-heavy pass.
+            util::retain_alloc_pages_for_aggregation();
 
-        // Retain freed jemalloc pages for this parallel, hashmap-heavy outlier pass
-        // (no-op when background_thread is active or QSV_NO_ALLOC_TUNING is set).
-        util::retain_alloc_pages_for_aggregation();
+            let pool = ThreadPool::new(njobs);
+            let (send, recv) = crossbeam_channel::bounded(nchunks);
 
-        let pool = ThreadPool::new(njobs);
-        let (send, recv) = crossbeam_channel::bounded(nchunks);
+            // Share the read-only slot-ordered field lists via Arc (no clones).
+            let outlier_arc = Arc::new(outlier_fields);
+            let kga_arc = Arc::new(kga_fields);
 
-        // Process each chunk in parallel. Share the read-only field map via Arc
-        // instead of deep-cloning the HashMap into every worker. Since the caller
-        // no longer needs `fields_to_count` after this call, we move it directly
-        // into the Arc — zero map clones. `input_path_string` from above is already
-        // UTF-8-validated, so no need to re-validate here.
-        let fields_arc = Arc::new(fields_to_count);
-        for i in 0..nchunks {
-            let send = send.clone();
-            let fields_arc = Arc::clone(&fields_arc);
-            let input_path_string_clone = input_path_string.clone();
-            pool.execute(move || {
-                // Open index for this thread. If this fails, propagate an error
-                // through the channel — dropping the chunk silently would
-                // under-count outliers without any indication to the user.
-                let rconfig_chunk = Config::new(Some(&input_path_string_clone));
-                let mut idx_chunk = match rconfig_chunk.indexed() {
-                    Ok(Some(idx)) => idx,
-                    Ok(None) => {
-                        let _ = send.send(Err(CliError::Other(format!(
-                            "Chunk {i}: index is not available for {input_path_string_clone}"
-                        ))));
+            for i in 0..nchunks {
+                let send = send.clone();
+                let outlier_arc = Arc::clone(&outlier_arc);
+                let kga_arc = Arc::clone(&kga_arc);
+                let input_path_string_clone = input_path_string.clone();
+                pool.execute(move || {
+                    // Open index for this thread; propagate failures through the
+                    // channel rather than silently dropping (would under-count).
+                    let rconfig_chunk = Config::new(Some(&input_path_string_clone));
+                    let mut idx_chunk = match rconfig_chunk.indexed() {
+                        Ok(Some(idx)) => idx,
+                        Ok(None) => {
+                            let _ = send.send((
+                                i,
+                                Err(CliError::Other(format!(
+                                    "Chunk {i}: index is not available for \
+                                     {input_path_string_clone}"
+                                ))),
+                            ));
+                            return;
+                        },
+                        Err(e) => {
+                            let _ = send.send((
+                                i,
+                                Err(CliError::Other(format!(
+                                    "Chunk {i}: failed to open index: {e}"
+                                ))),
+                            ));
+                            return;
+                        },
+                    };
+
+                    // Seek to chunk start position
+                    if let Err(e) = idx_chunk.seek((i * chunk_size) as u64) {
+                        let _ = send.send((
+                            i,
+                            Err(CliError::Other(format!("Chunk {i}: seek failed: {e}"))),
+                        ));
                         return;
-                    },
-                    Err(e) => {
-                        let _ = send.send(Err(CliError::Other(format!(
-                            "Chunk {i}: failed to open index: {e}"
-                        ))));
-                        return;
-                    },
+                    }
+
+                    let it = idx_chunk.byte_records().take(chunk_size);
+                    let result = count_and_collect_chunk(&outlier_arc, &kga_arc, prefer_dmy, it);
+                    let _ = send.send((i, result));
+                });
+            }
+
+            drop(send);
+
+            // Collect chunks by index so the KGA merge can be file-ordered.
+            let mut chunks: Vec<Option<FusedChunkOutput>> = (0..nchunks).map(|_| None).collect();
+            for (i, chunk_result) in recv {
+                chunks[i] = Some(chunk_result?);
+            }
+
+            let mut merged_outliers: Vec<OutlierStats> = vec![OutlierStats::default(); n_outlier];
+            let mut kga_concat: Vec<Vec<f64>> = vec![Vec::new(); n_kga];
+
+            // Merge in ASCENDING chunk index. Outliers are order-independent, but
+            // KGA value vectors MUST be concatenated in file order to keep float
+            // summation bit-identical to a sequential read.
+            for chunk in &mut chunks {
+                let Some(c) = chunk.take() else {
+                    continue;
                 };
-
-                // Seek to chunk start position
-                if let Err(e) = idx_chunk.seek((i * chunk_size) as u64) {
-                    let _ = send.send(Err(CliError::Other(format!("Chunk {i}: seek failed: {e}"))));
-                    return;
+                for (slot, stats) in c.outlier_stats.iter().enumerate() {
+                    merge_outlier_stats(&mut merged_outliers[slot], stats);
                 }
-
-                // Process chunk records
-                let it = idx_chunk.byte_records().take(chunk_size);
-                let result = count_chunk_outliers(&fields_arc, it);
-                let _ = send.send(result);
-            });
-        }
-
-        drop(send);
-
-        // Aggregate results from all chunks
-        let mut all_stats: HashMap<String, OutlierStats> = fields_arc
-            .keys()
-            .map(|k| (k.clone(), OutlierStats::default()))
-            .collect();
-
-        for chunk_result in &recv {
-            let chunk_stats = chunk_result?;
-            for (field_name, stats) in chunk_stats {
-                if let Some(total_stats) = all_stats.get_mut(&field_name) {
-                    // Aggregate counts
-                    for i in 0..OUTLIER_COUNTS_LEN {
-                        total_stats.counts[i] += stats.counts[i];
-                    }
-                    // Aggregate sums
-                    total_stats.sum_outliers += stats.sum_outliers;
-                    total_stats.sum_normal += stats.sum_normal;
-                    total_stats.sum_all += stats.sum_all;
-                    total_stats.count_all += stats.count_all;
-                    // Aggregate winsorized/trimmed stats
-                    total_stats.winsorized_sum += stats.winsorized_sum;
-                    total_stats.winsorized_count += stats.winsorized_count;
-                    total_stats.trimmed_sum += stats.trimmed_sum;
-                    total_stats.trimmed_count += stats.trimmed_count;
-                    // Aggregate sum of squares
-                    total_stats.sum_squares_outliers += stats.sum_squares_outliers;
-                    total_stats.sum_squares_normal += stats.sum_squares_normal;
-                    total_stats.sum_squares_trimmed += stats.sum_squares_trimmed;
-                    total_stats.sum_squares_winsorized += stats.sum_squares_winsorized;
-                    // Aggregate min/max
-                    if let Some(min) = stats.min_outliers {
-                        total_stats.min_outliers =
-                            Some(total_stats.min_outliers.map_or(min, |m| m.min(min)));
-                    }
-                    if let Some(max) = stats.max_outliers {
-                        total_stats.max_outliers =
-                            Some(total_stats.max_outliers.map_or(max, |m| m.max(max)));
-                    }
-                    if let Some(min) = stats.min_normal {
-                        total_stats.min_normal =
-                            Some(total_stats.min_normal.map_or(min, |m| m.min(min)));
-                    }
-                    if let Some(max) = stats.max_normal {
-                        total_stats.max_normal =
-                            Some(total_stats.max_normal.map_or(max, |m| m.max(max)));
-                    }
-                    if let Some(min) = stats.min_trimmed {
-                        total_stats.min_trimmed =
-                            Some(total_stats.min_trimmed.map_or(min, |m| m.min(min)));
-                    }
-                    if let Some(max) = stats.max_trimmed {
-                        total_stats.max_trimmed =
-                            Some(total_stats.max_trimmed.map_or(max, |m| m.max(max)));
-                    }
-                    if let Some(min) = stats.min_winsorized {
-                        total_stats.min_winsorized =
-                            Some(total_stats.min_winsorized.map_or(min, |m| m.min(min)));
-                    }
-                    if let Some(max) = stats.max_winsorized {
-                        total_stats.max_winsorized =
-                            Some(total_stats.max_winsorized.map_or(max, |m| m.max(max)));
-                    }
+                for (slot, mut v) in c.kga_values.into_iter().enumerate() {
+                    kga_concat[slot].append(&mut v);
                 }
             }
-        }
 
-        Ok(all_stats)
+            (merged_outliers, kga_concat)
+        }
     } else {
-        // Sequential fallback when no index exists
+        // No index: single sequential fused scan over the whole file.
         let mut rdr = rconfig.reader_file()?;
         let _headers = rdr.headers()?.clone();
-        count_chunk_outliers(&fields_to_count, rdr.byte_records())
+        let fused =
+            count_and_collect_chunk(&outlier_fields, &kga_fields, prefer_dmy, rdr.byte_records())?;
+        (fused.outlier_stats, fused.kga_values)
+    };
+
+    // Build the outlier map (slot -> name). For the empty-CSV case merged_outliers
+    // is empty and this yields an empty map (matching the former behavior).
+    let outlier_counts: HashMap<String, OutlierStats> =
+        outlier_names.into_iter().zip(merged_outliers).collect();
+
+    // Finalize KGA per field (slot -> name) over its file-ordered value vector.
+    let mut kga_stats: HashMap<String, KGAStats> = HashMap::with_capacity(n_kga);
+    for (j, values) in kga_concat.into_iter().enumerate() {
+        let (mean, variance, sum) = kga_precalc[j];
+        kga_stats.insert(
+            kga_names[j].clone(),
+            finalize_kga(&values, mean, variance, sum, atkinson_epsilon),
+        );
     }
+
+    Ok((outlier_counts, kga_stats))
 }
 
 /// Process a chunk of records and update bivariate statistics
@@ -3080,189 +3239,6 @@ fn compute_all_bivariatestats_sequential(
             )
         })
         .collect()
-}
-
-/// Compute Kurtosis, Gini coefficient, and Atkinson index for all fields.
-/// Since Kurtosis, Gini & Atkinson Index require all values from the entire dataset, this always
-/// uses sequential processing to read all values in a single pass.
-/// Returns a `HashMap` mapping field names to their Kurtosis, Gini coefficient, and Atkinson index
-/// statistics
-fn compute_all_kga(
-    fields_to_compute: &HashMap<String, KGAFieldInfo>,
-    input_path: &Path,
-    atkinson_epsilon: f64,
-) -> CliResult<HashMap<String, KGAStats>> {
-    if fields_to_compute.is_empty() {
-        return Ok(HashMap::new());
-    }
-
-    let input_path_str = input_path
-        .to_str()
-        .ok_or_else(|| CliError::Other(format!("Invalid input path: {}", input_path.display())))?;
-    let input_path_string = input_path_str.to_string();
-    let rconfig = Config::new(Some(&input_path_string));
-    let mut rdr = rconfig.reader_file()?;
-    let _headers = rdr.headers()?.clone();
-    compute_all_kga_from_reader(fields_to_compute, rdr, atkinson_epsilon)
-}
-
-/// Compute Kurtosis, Gini coefficient, and Atkinson index for all fields in a single pass through
-/// the CSV (sequential) The CSV reader should already be positioned after the headers
-/// Returns a `HashMap` mapping field names to their Kurtosis, Gini coefficient, and Atkinson index
-/// statistics
-fn compute_all_kga_from_reader(
-    fields_to_compute: &HashMap<String, KGAFieldInfo>,
-    mut rdr: csv::Reader<std::fs::File>,
-    atkinson_epsilon: f64,
-) -> CliResult<HashMap<String, KGAStats>> {
-    if fields_to_compute.is_empty() {
-        return Ok(HashMap::new());
-    }
-
-    // Collect all values for each field
-    let mut field_values: HashMap<String, Vec<f64>> = fields_to_compute
-        .keys()
-        .map(|k| (k.clone(), Vec::new()))
-        .collect();
-
-    let prefer_dmy = util::get_envvar_flag("QSV_PREFER_DMY");
-
-    // amortize allocations
-    #[allow(unused_assignments)]
-    let mut record: StringRecord = StringRecord::new();
-    let mut value_str;
-    let mut numeric_value;
-
-    // Process each record once, collecting values for all fields
-    for result in rdr.records() {
-        record = result?;
-
-        for (field_name, field_info) in fields_to_compute {
-            value_str = record.get(field_info.col_idx).unwrap_or("");
-
-            if value_str.is_empty() {
-                continue; // Skip null/empty values
-            }
-
-            // Parse the value based on field type
-            numeric_value = if field_info.field_type.is_date_or_datetime() {
-                parse_date_to_days(value_str, prefer_dmy)
-            } else {
-                parse_float_opt(value_str)
-            };
-
-            if let Some(val) = numeric_value
-                && let Some(values) = field_values.get_mut(field_name)
-            {
-                values.push(val);
-            }
-        }
-    }
-
-    // Compute statistics for each field
-    let mut all_stats: HashMap<String, KGAStats> = HashMap::with_capacity(field_values.len());
-
-    for (field_name, values) in field_values {
-        if values.len() < 2 {
-            // Need at least 2 values for meaningful statistics
-            all_stats.insert(
-                field_name,
-                KGAStats {
-                    kurtosis:         None,
-                    gini_coefficient: None,
-                    atkinson_index:   None,
-                    theil_index:      None,
-                    mean_ad:          None,
-                },
-            );
-            continue;
-        }
-
-        // Get precalculated stats for this field
-        let (precalc_mean, precalc_variance, precalc_sum) = fields_to_compute
-            .get(&field_name)
-            .map_or((None, None, None), |info| {
-                (info.mean, info.variance, info.sum)
-            });
-
-        // Compute kurtosis with precalculated mean and variance
-        let kurtosis_val = kurtosis(values.iter().copied(), precalc_mean, precalc_variance);
-
-        // Compute Gini coefficient with precalculated sum (not mean!)
-        let gini_val = gini(values.iter().copied(), precalc_sum);
-
-        // Compute Atkinson Index (epsilon parameter typically 0.5 or 1.0, configurable via
-        // --epsilon) atkinson function signature: atkinson(iter, epsilon,
-        // precalc_mean, precalc_geometric_sum) See: https://docs.rs/qsv-stats/latest/stats/fn.atkinson.html
-        let atkinson_val = atkinson(
-            values.iter().copied(),
-            atkinson_epsilon,
-            precalc_mean,
-            None, // geometric sum not precalculated
-        );
-
-        // Compute Theil Index: (1/n) * Σ((x_i / mean) * ln(x_i / mean))
-        // Only for positive values (Theil index is undefined for non-positive values)
-        // Uses mean of positive values only, so it works even when overall mean is <= 0
-        #[allow(clippy::cast_precision_loss)]
-        let theil_val = {
-            // First pass: compute sum and count of positive values
-            let mut pos_sum = 0.0_f64;
-            let mut pos_count: usize = 0;
-            for &v in &values {
-                if v > 0.0 {
-                    pos_sum += v;
-                    pos_count += 1;
-                }
-            }
-
-            if pos_count >= 2 {
-                let n = pos_count as f64;
-                let pos_mean = pos_sum / n;
-                if pos_mean > f64::EPSILON {
-                    // Second pass: accumulate Theil sum over positive values
-                    let mut theil_sum = 0.0_f64;
-                    for &v in &values {
-                        if v > 0.0 {
-                            let ratio = v / pos_mean;
-                            // use CPU's Fused Multiply-Add (FMA) for better precision and to reduce
-                            // intermediate rounding errors in the sum
-                            // theil_sum += ratio * ratio.ln();
-                            theil_sum = ratio.mul_add(ratio.ln(), theil_sum);
-                        }
-                    }
-                    Some(theil_sum / n)
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        };
-
-        // Compute Mean Absolute Deviation from mean: (1/n) * Σ|x_i - mean|
-        #[allow(clippy::cast_precision_loss)]
-        let mean_ad_val = if let Some(mean_val) = precalc_mean {
-            let n = values.len() as f64;
-            let sum_abs_dev: f64 = values.iter().map(|&x| (x - mean_val).abs()).sum();
-            Some(sum_abs_dev / n)
-        } else {
-            None
-        };
-
-        all_stats.insert(
-            field_name,
-            KGAStats {
-                kurtosis:         kurtosis_val,
-                gini_coefficient: gini_val,
-                atkinson_index:   atkinson_val,
-                theil_index:      theil_val,
-                mean_ad:          mean_ad_val,
-            },
-        );
-    }
-
-    Ok(all_stats)
 }
 
 /// Compute Shannon Entropy for all fields by calling the frequency command.
@@ -4376,54 +4352,59 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         }
     }
 
-    // Count outliers for all fields in a single pass through the original CSV
-    let outlier_counts = if fields_to_count.is_empty() {
-        HashMap::new()
-    } else {
-        // Get headers to map field names to column indices
+    // Build slot-ordered field vectors for the FUSED outlier + KGA pass. Both
+    // outliers and KGA scan the same original CSV over the same numeric/date
+    // columns, so they are computed together in a SINGLE (chunked, parallel) pass
+    // instead of two independent full-file reads. A single header read maps each
+    // field name to its column index (dropping fields not present in the CSV).
+    let (outlier_fields, outlier_names, kga_fields, kga_names) = {
         let mut csv_rdr = ReaderBuilder::new()
             .has_headers(true)
             .from_path(actual_input_path)?;
         let csv_headers = csv_rdr.headers()?.clone();
+        let header_pos: HashMap<&str, usize> = csv_headers
+            .iter()
+            .enumerate()
+            .map(|(idx, h)| (h, idx))
+            .collect();
 
-        // Update column indices in fields_to_count and remove fields not found in CSV
-        fields_to_count.retain(|field_name, field_info| {
-            if let Some(col_idx) = csv_headers.iter().position(|h| h == field_name) {
-                field_info.col_idx = col_idx;
-                true
-            } else {
-                false
+        let mut o_fields = Vec::with_capacity(fields_to_count.len());
+        let mut o_names = Vec::with_capacity(fields_to_count.len());
+        for (name, mut info) in fields_to_count {
+            if let Some(&col_idx) = header_pos.get(name.as_str()) {
+                info.col_idx = col_idx;
+                o_fields.push(info);
+                o_names.push(name);
             }
-        });
+        }
 
-        // Count outliers (will use parallel processing if index exists).
-        // Pass fields_to_count by value so the parallel path can move it
-        // directly into an Arc without an extra deep-clone.
-        count_all_outliers(fields_to_count, actual_input_path, args.flag_jobs)?
+        let mut k_fields = Vec::with_capacity(fields_for_kga.len());
+        let mut k_names = Vec::with_capacity(fields_for_kga.len());
+        for (name, mut info) in fields_for_kga {
+            if let Some(&col_idx) = header_pos.get(name.as_str()) {
+                info.col_idx = col_idx;
+                k_fields.push(info);
+                k_names.push(name);
+            }
+        }
+
+        (o_fields, o_names, k_fields, k_names)
     };
 
-    // Compute kurtosis, Gini coefficient & Atkinson Index for all fields
-    let kga_stats = if fields_for_kga.is_empty() {
-        HashMap::new()
+    // Single fused pass: outlier counting + Kurtosis/Gini/Atkinson in one scan
+    // (parallel when an index exists and the file is large enough).
+    let (outlier_counts, kga_stats) = if outlier_fields.is_empty() && kga_fields.is_empty() {
+        (HashMap::new(), HashMap::new())
     } else {
-        // Get headers to map field names to column indices
-        let mut csv_rdr = ReaderBuilder::new()
-            .has_headers(true)
-            .from_path(actual_input_path)?;
-        let csv_headers = csv_rdr.headers()?.clone();
-
-        // Update column indices in fields_for_kga and remove fields not found in CSV
-        fields_for_kga.retain(|field_name, field_info| {
-            if let Some(col_idx) = csv_headers.iter().position(|h| h == field_name) {
-                field_info.col_idx = col_idx;
-                true
-            } else {
-                false
-            }
-        });
-
-        // Compute Kurtosis, Gini & Atkinson Index (will use sequential processing for correctness)
-        compute_all_kga(&fields_for_kga, actual_input_path, args.flag_epsilon)?
+        compute_outliers_and_kga(
+            outlier_fields,
+            outlier_names,
+            kga_fields,
+            kga_names,
+            actual_input_path,
+            args.flag_jobs,
+            args.flag_epsilon,
+        )?
     };
 
     // Compute Shannon Entropy for all fields

--- a/tests/test_moarstats.rs
+++ b/tests/test_moarstats.rs
@@ -2155,11 +2155,27 @@ fn moarstats_parallel_path_matches_sequential() {
     // Regression for the fused outlier+KGA PARALLEL path. The exact-value goldens
     // only exercise files below PARALLEL_THRESHOLD (10_000 rows), i.e. the
     // sequential fallback. This drives an indexed CSV ABOVE the threshold and
-    // asserts that a single-chunk run (--jobs 1) and a multi-chunk run (--jobs 8)
-    // produce byte-identical output — proving the chunk-index-ordered KGA merge is
-    // deterministic and equal to a single-pass read. Both runs share ONE stats
-    // cache (--stats-options omits --force, so it is built once and reused), so any
-    // difference can only come from the outlier/KGA parallel code.
+    // asserts that a single-chunk run and a multi-chunk run produce byte-identical
+    // output — proving the chunk-index-ordered KGA merge is deterministic and equal
+    // to a single-pass read. Both runs share ONE stats cache (--stats-options omits
+    // --force, so it is built once and reused), so any difference can only come from
+    // the outlier/KGA parallel code.
+    //
+    // `util::njobs` caps the effective job count to the available cores (and
+    // QSV_MAX_JOBS), so on a single-core/constrained runner BOTH runs would collapse
+    // to a single chunk and the multi-chunk merge would go untested while the test
+    // still passed. Guard against that: skip when < 2 cores, pin QSV_MAX_JOBS per run
+    // so the chunk counts are deterministic, and assert from the log that the
+    // parallel run actually used >= 2 chunks.
+    let cores = std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get);
+    if cores < 2 {
+        eprintln!(
+            "skipping moarstats_parallel_path_matches_sequential: needs >= 2 cores to exercise \
+             the multi-chunk path (have {cores})"
+        );
+        return;
+    }
+
     let wrk = Workdir::new("moarstats_parallel_path");
 
     let mut rows: Vec<Vec<String>> = vec![svec!["id", "amount", "score", "when"]];
@@ -2202,28 +2218,37 @@ fn moarstats_parallel_path_matches_sequential() {
         .args(["--output", "primed.csv"]);
     wrk.assert_success(&mut prime);
 
-    // Single chunk (reference).
+    // Single chunk (reference): QSV_MAX_JOBS=1 pins njobs=1 regardless of the
+    // runner's core count or any inherited QSV_MAX_JOBS -> exactly one chunk.
     let mut cmd1 = wrk.command("moarstats");
-    cmd1.arg("--advanced")
+    cmd1.env("QSV_MAX_JOBS", "1")
+        .arg("--advanced")
         .args(["--jobs", "1"])
         .args(["--stats-options", shared_opts])
         .arg("data.csv")
         .args(["--output", "out_jobs1.csv"]);
     wrk.assert_success(&mut cmd1);
 
-    // Many chunks (parallel).
-    let mut cmd8 = wrk.command("moarstats");
-    cmd8.arg("--advanced")
-        .args(["--jobs", "8"])
+    // Multiple chunks (parallel): QSV_MAX_JOBS=2 + --jobs 2 pins njobs=2 (cores >= 2
+    // was checked above), which with 15_000 rows yields 2 chunks via
+    // util::chunk_size / util::num_of_chunks. Capture the log to prove it.
+    let log_dir = wrk.path("mchunk_logs");
+    std::fs::create_dir_all(&log_dir).unwrap();
+    let mut cmd2 = wrk.command("moarstats");
+    cmd2.env("QSV_MAX_JOBS", "2")
+        .env("QSV_LOG_LEVEL", "info")
+        .env("QSV_LOG_DIR", &log_dir)
+        .arg("--advanced")
+        .args(["--jobs", "2"])
         .args(["--stats-options", shared_opts])
         .arg("data.csv")
-        .args(["--output", "out_jobs8.csv"]);
-    wrk.assert_success(&mut cmd8);
+        .args(["--output", "out_jobs2.csv"]);
+    wrk.assert_success(&mut cmd2);
 
     let out1 = wrk.read_to_string("out_jobs1.csv").unwrap();
-    let out8 = wrk.read_to_string("out_jobs8.csv").unwrap();
+    let out2 = wrk.read_to_string("out_jobs2.csv").unwrap();
     assert_eq!(
-        out1, out8,
+        out1, out2,
         "multi-chunk parallel output must equal the single-chunk reference"
     );
 
@@ -2232,6 +2257,26 @@ fn moarstats_parallel_path_matches_sequential() {
     assert!(
         out1.contains("kurtosis") && out1.contains("gini_coefficient"),
         "advanced KGA columns should be present in the output"
+    );
+
+    // Prove the parallel run genuinely used >= 2 chunks (otherwise the multi-chunk
+    // merge would be untested even though the equality assertion passed).
+    let log_name = format!(
+        "{}_rCURRENT.log",
+        wrk.qsv_bin().file_stem().unwrap().to_string_lossy()
+    );
+    let log = std::fs::read_to_string(log_dir.join(&log_name)).unwrap_or_default();
+    let chunks = log
+        .lines()
+        .filter_map(|l| l.split("outlier+KGA computation: ").nth(1))
+        .filter_map(|s| s.split(" chunks").next())
+        .filter_map(|s| s.trim().parse::<usize>().ok())
+        .max()
+        .unwrap_or(0);
+    assert!(
+        chunks >= 2,
+        "expected the parallel moarstats run to use >= 2 chunks, but the log reported {chunks}; \
+         log ({log_name}):\n{log}"
     );
 }
 

--- a/tests/test_moarstats.rs
+++ b/tests/test_moarstats.rs
@@ -2234,8 +2234,9 @@ fn moarstats_parallel_path_matches_sequential() {
     // util::chunk_size / util::num_of_chunks. Capture the log to prove it.
     let log_dir = wrk.path("mchunk_logs");
     std::fs::create_dir_all(&log_dir).unwrap();
-    let mut cmd2 = wrk.command("moarstats");
-    cmd2.env("QSV_MAX_JOBS", "2")
+    let mut cmd_2 = wrk.command("moarstats");
+    cmd_2
+        .env("QSV_MAX_JOBS", "2")
         .env("QSV_LOG_LEVEL", "info")
         .env("QSV_LOG_DIR", &log_dir)
         .arg("--advanced")
@@ -2243,7 +2244,7 @@ fn moarstats_parallel_path_matches_sequential() {
         .args(["--stats-options", shared_opts])
         .arg("data.csv")
         .args(["--output", "out_jobs2.csv"]);
-    wrk.assert_success(&mut cmd2);
+    wrk.assert_success(&mut cmd_2);
 
     let out1 = wrk.read_to_string("out_jobs1.csv").unwrap();
     let out2 = wrk.read_to_string("out_jobs2.csv").unwrap();

--- a/tests/test_moarstats.rs
+++ b/tests/test_moarstats.rs
@@ -2151,6 +2151,91 @@ fn moarstats_kurtosis_gini_multiple_numeric_fields() {
 }
 
 #[test]
+fn moarstats_parallel_path_matches_sequential() {
+    // Regression for the fused outlier+KGA PARALLEL path. The exact-value goldens
+    // only exercise files below PARALLEL_THRESHOLD (10_000 rows), i.e. the
+    // sequential fallback. This drives an indexed CSV ABOVE the threshold and
+    // asserts that a single-chunk run (--jobs 1) and a multi-chunk run (--jobs 8)
+    // produce byte-identical output — proving the chunk-index-ordered KGA merge is
+    // deterministic and equal to a single-pass read. Both runs share ONE stats
+    // cache (--stats-options omits --force, so it is built once and reused), so any
+    // difference can only come from the outlier/KGA parallel code.
+    let wrk = Workdir::new("moarstats_parallel_path");
+
+    let mut rows: Vec<Vec<String>> = vec![svec!["id", "amount", "score", "when"]];
+    for i in 0..15_000u32 {
+        let base = 1000.0 + f64::from(i % 500);
+        // Occasional extreme values so IQR fences flag real outliers.
+        let amount = if i % 250 == 0 {
+            base + 90_000.0
+        } else {
+            base + f64::from(i % 37) * 1.7
+        };
+        let score = f64::from(i % 1000) * 0.125 + 0.333;
+        let month = 1 + (i % 9);
+        let year = 2000 + (i % 25);
+        rows.push(vec![
+            i.to_string(),
+            format!("{amount:.4}"),
+            format!("{score:.6}"),
+            format!("{year}-0{month}-15"),
+        ]);
+    }
+    wrk.create("data.csv", rows);
+
+    // Index so the parallel path is reachable.
+    let mut idx_cmd = wrk.command("index");
+    idx_cmd.arg("data.csv");
+    wrk.assert_success(&mut idx_cmd);
+
+    // Options WITHOUT --force so the baseline stats cache is generated once and
+    // then reused by every moarstats run below (identical baseline for all runs).
+    let shared_opts = "--infer-dates --infer-boolean --cardinality --mode --mad --quartiles \
+                       --percentiles --stats-jsonl";
+
+    // Prime the shared stats cache.
+    let mut prime = wrk.command("moarstats");
+    prime
+        .arg("--advanced")
+        .args(["--stats-options", shared_opts])
+        .arg("data.csv")
+        .args(["--output", "primed.csv"]);
+    wrk.assert_success(&mut prime);
+
+    // Single chunk (reference).
+    let mut cmd1 = wrk.command("moarstats");
+    cmd1.arg("--advanced")
+        .args(["--jobs", "1"])
+        .args(["--stats-options", shared_opts])
+        .arg("data.csv")
+        .args(["--output", "out_jobs1.csv"]);
+    wrk.assert_success(&mut cmd1);
+
+    // Many chunks (parallel).
+    let mut cmd8 = wrk.command("moarstats");
+    cmd8.arg("--advanced")
+        .args(["--jobs", "8"])
+        .args(["--stats-options", shared_opts])
+        .arg("data.csv")
+        .args(["--output", "out_jobs8.csv"]);
+    wrk.assert_success(&mut cmd8);
+
+    let out1 = wrk.read_to_string("out_jobs1.csv").unwrap();
+    let out8 = wrk.read_to_string("out_jobs8.csv").unwrap();
+    assert_eq!(
+        out1, out8,
+        "multi-chunk parallel output must equal the single-chunk reference"
+    );
+
+    // Sanity: the advanced KGA columns are actually present (so the test really
+    // exercised the fused KGA path, not an empty diff).
+    assert!(
+        out1.contains("kurtosis") && out1.contains("gini_coefficient"),
+        "advanced KGA columns should be present in the output"
+    );
+}
+
+#[test]
 fn moarstats_without_advanced_flag() {
     let wrk = Workdir::new("moarstats_without_advanced");
     let test_file = wrk.load_test_file("boston311-100.csv");

--- a/tests/test_viz.rs
+++ b/tests/test_viz.rs
@@ -447,11 +447,11 @@ fn viz_box_y_range_invalid_errors() {
     assert!(stderr.contains("--y-range"));
 
     // non-numeric is rejected
-    let mut cmd2 = wrk.command("viz");
-    cmd2.args(["box", "fruits.csv", "--y", "Price", "--y-range=abc"]);
-    let out2 = wrk.output(&mut cmd2);
+    let mut cmd_2 = wrk.command("viz");
+    cmd_2.args(["box", "fruits.csv", "--y", "Price", "--y-range=abc"]);
+    let out2 = wrk.output(&mut cmd_2);
     assert!(!out2.status.success());
-    let stderr2 = wrk.output_stderr(&mut cmd2);
+    let stderr2 = wrk.output_stderr(&mut cmd_2);
     assert!(stderr2.contains("--y-range"));
 }
 


### PR DESCRIPTION
## What

Speeds up `qsv moarstats --advanced` by restructuring the original-CSV scans it performs. Previously `--advanced` read the input up to **three** times: outlier counting, KGA (kurtosis/Gini/Atkinson/Theil/mean_ad), and entropy. This PR fuses the first two into a single chunked parallel scan and parallelizes KGA — which was the lone single-threaded heavy pass — end to end (scan **and** finalize).

### Changes
- **Fuse outlier + KGA into one scan.** New `count_and_collect_chunk` computes outlier stats **and** collects KGA values in a single reused-`ByteRecord` row scan, using slot-indexed `Vec` access instead of the former per-cell String-keyed `HashMap::get_mut` (also helps the default, non-`--advanced` path).
- **Parallelize the KGA scan.** New `compute_outliers_and_kga` orchestrator mirrors the existing outlier `ThreadPool` + index-seek chunk pattern. Outlier stats merge order-independently; KGA value vectors are concatenated in strict **chunk-index (file) order**, so KGA results are bit-identical to a sequential read.
- **Parallelize the KGA finalize** (per-column Gini sort / kurtosis / Theil) across fields with rayon `into_par_iter` — it dominated the remaining phase time. Each field's math is independent and keyed by name, so results stay bit-identical.
- Deletes the superseded `count_chunk_outliers` / `count_all_outliers` / `compute_all_kga` / `compute_all_kga_from_reader`.

### Not in scope (deliberately)
- **Overlapping the already-parallel phases** (e.g. `rayon::join`): outliers/bivariate already saturate all cores via their own `ThreadPool`, so overlapping them would oversubscribe and likely regress. The win here is *removing a pass* and *parallelizing the one phase that wasn't*.
- **Entropy.** Investigated but left as-is. The `frequency --limit 0` subprocess already short-circuits all-unique columns via the stats cache (emitting `<ALL_UNIQUE>`), and the remaining cost is genuine frequency-table work over high-cardinality columns whose entropy is *not* recoverable from cardinality alone — so an analytic shortcut would be either redundant or inexact. Its cost is very data-dependent (near-zero on typical ID-column datasets).

## Determinism / correctness

The `--advanced` golden tests pin exact stat values, and KGA sums floats (kurtosis/Theil/mean_ad) where summation order matters. Safety is preserved by:
- concatenating KGA chunk vectors in ascending chunk index (identical to a single sequential read);
- merging outlier stats via commutative sums (same as the prior parallel outlier code);
- finalizing each field independently, keyed by name.

## Benchmarks

1M rows × 6 numeric + 1 date column, `--advanced`, **debug build** (absolute times are inflated ~10–20× vs release; the *shape* holds):

| Phase | OLD (master) | NEW | Changed? |
|---|---|---|---|
| stats baseline | ~2.9s | ~2.9s | no |
| **outlier + KGA** | **~13–18s** (two passes, KGA single-threaded) | **~8.8s** (one fused parallel pass) | **yes — ~1.5–2×** |
| entropy (`frequency --limit 0`, cached) | ~27s | ~27s | no |
| **Total `--advanced`** | **~43–47s** | **~38.5s** | **~10–19%** |

The changed phase (outlier+KGA) is **~1.5–2× faster** (NEW is stable at ~8.8s; OLD's single-threaded KGA is load-sensitive, hence the range). Total moves less because ~69% of the time is the **unchanged** stats + entropy phases, entropy alone being ~27s of high-cardinality frequency work. The default (no `--advanced`) path gets just the outlier hot-loop micro-opt (~0.82s → ~0.73s).

## Testing
- `cargo t moarstats -F all_features` → **92 passed** (goldens prove the fused sequential path is byte-identical).
- New `moarstats_parallel_path_matches_sequential`: an indexed 15,000-row CSV (above `PARALLEL_THRESHOLD`) asserts single-chunk vs multi-chunk output is byte-identical over a shared stats cache, covering the parallel KGA merge the sub-threshold goldens never exercised. Guards against single-core runners (skips < 2 cores; pins `QSV_MAX_JOBS`; asserts from the log that the parallel run used ≥ 2 chunks).
- Ad-hoc: 3× `--advanced` on 1M rows byte-identical; outlier sequential-vs-parallel identical; `--jobs 1` vs `--jobs 8` (shared cache) identical incl. all KGA columns.
- `cargo clippy --bin qsv -F all_features` clean; `cargo +nightly fmt` applied.

## Review follow-ups (roborev)
- **3668** — restored first-match semantics for duplicate header names (a `.collect()` map had silently switched to last-match).
- **3669** — hoisted `util::njobs(flag_jobs)` so the rayon KGA finalize honors `--jobs` on sequential/no-index paths (was using Rayon's default all-cores global pool).
- **3670** — hardened the new parallel-path test against constrained/single-core runners so it can't pass vacuously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)