### PR TITLE
feat(validate): add --split-ragged to quarantine wrong-column-count rows (#4231)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,7 +302,7 @@ dependencies = [
  "ratatui-core",
  "simdutf8",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -357,9 +357,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "approx"
@@ -729,13 +729,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.0",
 ]
 
 [[package]]
@@ -824,9 +824,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.1"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -834,9 +834,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.42.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "cc",
  "cmake",
@@ -1055,9 +1055,9 @@ checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "borsh"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
+checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
 dependencies = [
  "borsh-derive",
  "bytes",
@@ -1066,9 +1066,9 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae8fb4fb5740e4b2c4884ff95f5f32f5e8479db1e8fd8eb49ddbe09eb09bb7c"
+checksum = "d8f347189c62a579b8cd5f80714efa178f52e461dc2e6d701d264f5ff22e566c"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
@@ -1189,9 +1189,9 @@ checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.1"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -1279,7 +1279,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "web-time",
 ]
 
@@ -1331,9 +1331,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.67"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
+checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1962,7 +1962,7 @@ dependencies = [
  "csv",
  "mown",
  "rayon",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "xxhash-rust",
 ]
 
@@ -1989,7 +1989,7 @@ dependencies = [
  "rayon",
  "regex",
  "simdutf8",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -2010,7 +2010,7 @@ dependencies = [
  "sorted-vec",
  "tempfile",
  "terminal-colorsaurus",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tui-input",
 ]
 
@@ -2041,7 +2041,7 @@ dependencies = [
  "snafu",
  "spreadsheet-ods",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "threadpool",
  "typed-builder",
  "walkdir",
@@ -2235,7 +2235,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -2470,7 +2470,7 @@ dependencies = [
  "erased-serde",
  "regex",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -2743,9 +2743,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fiat-crypto"
@@ -2827,7 +2827,7 @@ dependencies = [
  "crossbeam-queue",
  "flate2",
  "log",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3130,7 +3130,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3142,7 +3142,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
 ]
 
@@ -3191,7 +3191,7 @@ dependencies = [
  "geojson 0.24.2",
  "log",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "wkt",
 ]
 
@@ -3330,7 +3330,7 @@ dependencies = [
  "log",
  "num_cpus",
  "snap",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -4066,11 +4066,12 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.32"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
+checksum = "dc43d6fb25860892c78ef7ce2ffed572087a6853ecb60f587f499329717ed7da"
 dependencies = [
  "defmt",
+ "jiff-core",
  "jiff-static",
  "jiff-tzdb-platform",
  "log",
@@ -4081,11 +4082,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "jiff-static"
-version = "0.2.32"
+name = "jiff-core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
 dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96fb828bff41eeb269a9665f950cb359e8018f7288b8f34db24937ff54ed8fc5"
+dependencies = [
+ "jiff-core",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -4118,7 +4129,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "walkdir",
  "windows-link",
 ]
@@ -4233,7 +4244,7 @@ checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
 dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5253,7 +5264,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "url",
@@ -6458,9 +6469,9 @@ checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "portable-atomic-util"
@@ -6578,9 +6589,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -6984,7 +6995,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2 0.6.5",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "web-time",
@@ -7007,7 +7018,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "web-time",
@@ -7029,9 +7040,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -7250,7 +7261,7 @@ dependencies = [
  "palette",
  "serde",
  "strum 0.28.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width",
@@ -7426,27 +7437,27 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "ref-cast"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.0",
 ]
 
 [[package]]
@@ -7748,7 +7759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -8173,13 +8184,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.0",
 ]
 
 [[package]]
@@ -8510,9 +8521,9 @@ dependencies = [
 
 [[package]]
 name = "sorted-vec"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f58d7b0190c7f12df7e8be6b79767a0836059159811b869d5ab55721fe14d0"
+checksum = "238653bedf881fede50103cb7838b029e2b73d3d3d8e70d36f0a96be32a65c7b"
 
 [[package]]
 name = "spin"
@@ -9011,11 +9022,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -9031,13 +9042,13 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.0",
 ]
 
 [[package]]
@@ -9216,9 +9227,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9344,7 +9355,7 @@ dependencies = [
  "indexmap 2.14.0",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -10037,18 +10048,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -10519,7 +10530,7 @@ dependencies = [
  "log",
  "os_pipe",
  "rustix 1.1.4",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tree_magic_mini",
  "wayland-backend",
  "wayland-client",
@@ -10823,7 +10834,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a55ebb27e67d9a9d116dd3a19637ee8cc0570c8ef816fb504c453f15448c99"
 dependencies = [
  "ed25519-dalek",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]

--- a/docs/help/validate.md
+++ b/docs/help/validate.md
@@ -183,6 +183,13 @@ If all records are valid, no output files are produced.
 qsv validate data.csv
 ```
 
+> Quarantine rows with the wrong number of columns instead of aborting.
+> Well-formed rows go to data.csv.valid; ragged rows go to data.csv.invalid.
+
+```console
+qsv validate --split-ragged data.csv
+```
+
 > Validate a TSV file against a JSON Schema
 
 ```console
@@ -243,6 +250,7 @@ qsv validate --help
 | &nbsp;`‑‑fail‑fast`&nbsp; | flag | Stops on first error. |  |
 | &nbsp;`‑‑valid`&nbsp; | string | Valid record output file suffix. | `valid` |
 | &nbsp;`‑‑invalid`&nbsp; | string | Invalid record output file suffix. | `invalid` |
+| &nbsp;`‑‑split‑ragged`&nbsp; | flag | Opt-in mode: instead of aborting on the first row with the wrong number of columns (a "ragged" row), write well-formed rows to the '<input>.<valid>' file and the ragged rows to the '<input>.<invalid>' file, with a report appended to '<input>.validation-errors.tsv'. Returns a non-zero exit code when any ragged row is found. Only column-count mismatches are diverted; malformed quoting and non-UTF-8 data still abort validation. Works in both RFC 4180 and JSON Schema validation modes. The split files are written next to each input file, so this is intended for on-disk file input(s). |  |
 | &nbsp;`‑‑json`&nbsp; | flag | When validating without a JSON Schema, return the RFC 4180 check as a JSON file instead of a message. |  |
 | &nbsp;`‑‑pretty‑json`&nbsp; | flag | Same as --json, but pretty printed. |  |
 | &nbsp;`‑‑valid‑output`&nbsp; | string | Change validation mode behavior so if ALL rows are valid, to pass it to output, return exit code 1, and set stderr to the number of valid rows. Setting this will override the default behavior of creating a valid file only when there are invalid records. To send valid records to stdout, use `-` as the filename. |  |

--- a/src/cmd/validate.rs
+++ b/src/cmd/validate.rs
@@ -161,8 +161,12 @@ If all records are valid, no output files are produced.
 
 Examples:
 
-  # Validate a CSV file. Use this to check if a CSV file is readable by qsv. 
+  # Validate a CSV file. Use this to check if a CSV file is readable by qsv.
   qsv validate data.csv
+
+  # Quarantine rows with the wrong number of columns instead of aborting.
+  # Well-formed rows go to data.csv.valid; ragged rows go to data.csv.invalid.
+  qsv validate --split-ragged data.csv
 
   # Validate a TSV file against a JSON Schema
   qsv validate data.tsv schema.json
@@ -206,6 +210,15 @@ Validate options:
     --fail-fast                Stops on first error.
     --valid <suffix>           Valid record output file suffix. [default: valid]
     --invalid <suffix>         Invalid record output file suffix. [default: invalid]
+    --split-ragged             Opt-in mode: instead of aborting on the first row with the wrong
+                               number of columns (a "ragged" row), write well-formed rows to the
+                               '<input>.<valid>' file and the ragged rows to the '<input>.<invalid>'
+                               file, with a report appended to '<input>.validation-errors.tsv'.
+                               Returns a non-zero exit code when any ragged row is found.
+                               Only column-count mismatches are diverted; malformed quoting and
+                               non-UTF-8 data still abort validation. Works in both RFC 4180 and
+                               JSON Schema validation modes. The split files are written next to
+                               each input file, so this is intended for on-disk file input(s).
     --json                     When validating without a JSON Schema, return the RFC 4180 check
                                as a JSON file instead of a message.
     --pretty-json              Same as --json, but pretty printed.
@@ -364,6 +377,7 @@ struct Args {
     flag_fail_fast:            bool,
     flag_valid:                Option<String>,
     flag_invalid:              Option<String>,
+    flag_split_ragged:         bool,
     flag_json:                 bool,
     flag_pretty_json:          bool,
     flag_valid_output:         Option<String>,
@@ -1235,6 +1249,13 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     // don't panic; first-call value wins, which is fine for a single-shot command.
     let _ = DELIMITER.set(args.flag_delimiter);
 
+    // in --split-ragged mode, read flexibly so ragged rows don't abort; we detect and
+    // quarantine them ourselves. rconfig stays flexible so split_invalid_records' re-read
+    // (which demuxes the same ragged rows) also tolerates them.
+    if args.flag_split_ragged {
+        rconfig = rconfig.flexible(true);
+    }
+
     let mut rdr = rconfig.reader()?;
 
     // prep progress bar
@@ -1248,7 +1269,8 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     // for full row count, prevent CSV reader from aborting on inconsistent column count
     rconfig = rconfig.flexible(true);
     let record_count = util::count_rows(&rconfig)?;
-    rconfig = rconfig.flexible(false);
+    // keep flexible in --split-ragged mode so split_invalid_records' re-read tolerates ragged rows
+    rconfig = rconfig.flexible(args.flag_split_ragged);
 
     #[cfg(any(feature = "feature_capable", feature = "lite"))]
     if show_progress {
@@ -1422,6 +1444,7 @@ Try running `qsv validate schema {}` to check the JSON Schema file.", json_schem
     let mut validation_error_messages: Vec<String> = Vec::with_capacity(50);
     let flag_trim = args.flag_trim;
     let flag_fail_fast = args.flag_fail_fast;
+    let split_ragged = args.flag_split_ragged;
     let mut itoa_buffer = itoa::Buffer::new();
     let batch_pariter_min_len = batch_size / num_jobs;
 
@@ -1463,6 +1486,24 @@ Try running `qsv validate schema {}` to check the JSON Schema file.", json_schem
             .par_iter()
             .with_min_len(batch_pariter_min_len)
             .map(|record| {
+                // --split-ragged: a ragged row has a field count != header_len. Because we append
+                // the row number as an extra field, a well-formed row here has exactly
+                // header_len + 1 fields. Ragged rows are always marked invalid (quarantined) and
+                // skip schema validation entirely (which would otherwise silently zip to the
+                // shorter length and possibly pass). The reader is only flexible when
+                // --split-ragged is set, so this never fires otherwise.
+                if split_ragged && record.len() != header_len + 1 {
+                    std::hint::cold_path();
+                    // the row number is always the last appended field, regardless of raggedness
+                    // safety: row number was appended via itoa, so it is always valid ASCII
+                    let row_number_string =
+                        simdutf8::basic::from_utf8(&record[record.len() - 1]).unwrap();
+                    return Some(format!(
+                        "{row_number_string}\t<RECORD>\tfound {} fields, but expected {header_len}",
+                        record.len() - 1
+                    ));
+                }
+
                 // convert CSV record to JSON instance
                 let json_instance = match to_json_instance(&header_types, header_len, record) {
                     Ok(obj) => obj,
@@ -1639,9 +1680,23 @@ fn validate_rfc4180_mode(args: &Args) -> CliResult<()> {
     let flag_json = args.flag_json || args.flag_pretty_json;
     let flag_pretty_json = args.flag_pretty_json;
 
+    // --split-ragged output naming: valid/invalid suffixes and whether input came from stdin
+    // (in which case the split files use a "stdin.csv" base in the current dir, like schema mode)
+    let split_ragged = args.flag_split_ragged;
+    let valid_suffix = args
+        .flag_valid
+        .clone()
+        .unwrap_or_else(|| "valid".to_string());
+    let invalid_suffix = args
+        .flag_invalid
+        .clone()
+        .unwrap_or_else(|| "invalid".to_string());
+    let is_stdin_input = args.arg_input.is_empty();
+
     let mut all_valid = true;
     let mut total_files = 0;
     let mut valid_files = 0;
+    let mut total_split_count: u64 = 0;
 
     for input_path in processed_inputs {
         total_files += 1;
@@ -1660,6 +1715,11 @@ fn validate_rfc4180_mode(args: &Args) -> CliResult<()> {
 
         if args.flag_delimiter.is_some() {
             rconfig = rconfig.delimiter(args.flag_delimiter);
+        }
+
+        // in --split-ragged mode, read flexibly so ragged rows are diverted rather than aborting
+        if split_ragged {
+            rconfig = rconfig.flexible(true);
         }
 
         let mut rdr = match rconfig.reader() {
@@ -1687,6 +1747,12 @@ fn validate_rfc4180_mode(args: &Args) -> CliResult<()> {
             },
         };
 
+        let output_base = if is_stdin_input {
+            "stdin.csv".to_string()
+        } else {
+            input_path.to_string_lossy().to_string()
+        };
+
         // Validate the file
         let validation_result = validate_single_file_rfc4180(
             &mut rdr,
@@ -1694,11 +1760,23 @@ fn validate_rfc4180_mode(args: &Args) -> CliResult<()> {
             flag_json,
             flag_pretty_json,
             args.flag_quiet,
+            split_ragged,
+            &valid_suffix,
+            &invalid_suffix,
+            &output_base,
         );
 
         match validation_result {
-            Ok(()) => {
+            Ok(0) => {
                 valid_files += 1;
+            },
+            Ok(n) => {
+                // --split-ragged: n ragged rows were quarantined into this file's .invalid output
+                all_valid = false;
+                total_split_count += n;
+                if !args.flag_quiet && input_count > 1 {
+                    woutinfo!("⚠ {}: {n} ragged row(s) quarantined", input_path.display());
+                }
             },
             Err(e) => {
                 all_valid = false;
@@ -1728,6 +1806,13 @@ fn validate_rfc4180_mode(args: &Args) -> CliResult<()> {
 
     if all_valid {
         Ok(())
+    } else if total_split_count > 0 {
+        // --split-ragged: split files were produced; return non-zero with the quarantine count
+        fail_clierror!(
+            "{} ragged row(s) quarantined across {} file(s).",
+            HumanCount(total_split_count),
+            total_files
+        )
     } else if input_count > 1 {
         fail_clierror!(
             "{} out of {} files failed validation",
@@ -1747,7 +1832,11 @@ fn validate_single_file_rfc4180(
     flag_json: bool,
     flag_pretty_json: bool,
     quiet: bool,
-) -> CliResult<()> {
+    split_ragged: bool,
+    valid_suffix: &str,
+    invalid_suffix: &str,
+    output_base: &str,
+) -> CliResult<u64> {
     // first, let's validate the header row
     let mut header_msg = String::new();
     let mut header_len = 0_usize;
@@ -1822,6 +1911,143 @@ fn validate_single_file_rfc4180(
                 return fail_clierror!("Header Validation error: {e}.");
             },
         }
+    }
+
+    // --split-ragged: stream rows, routing well-formed rows to `<output_base>.<valid_suffix>`
+    // and ragged rows (wrong column count) to `<output_base>.<invalid_suffix>`, with a report
+    // appended to `<output_base>.validation-errors.tsv`, instead of aborting on the first ragged
+    // row. Genuine parse errors (bad quoting) and non-UTF-8 data still abort. The reader is only
+    // flexible when --split-ragged is set, so ragged rows arrive here instead of erroring.
+    if split_ragged {
+        let has_headers = !rconfig.no_headers;
+        let header_record = if has_headers {
+            rdr.byte_headers()?.clone()
+        } else {
+            ByteRecord::new()
+        };
+
+        // `.valid` is written by streaming; if no ragged rows are found we delete it at EOF so a
+        // clean file produces no output files (matching JSON Schema mode). The `.invalid` writer
+        // and error report are created lazily, only once the first ragged row is seen.
+        let valid_path = format!("{output_base}.{valid_suffix}");
+        let mut valid_wtr = Config::new(Some(&valid_path)).writer()?;
+        if has_headers {
+            valid_wtr.write_byte_record(&header_record)?;
+        }
+        let mut invalid_wtr: Option<csv::Writer<Box<dyn std::io::Write + 'static>>> = None;
+
+        // expected width = header count, or (with --no-headers) the first data record's width
+        let mut expected_len = header_len; // 0 until first record sets it when --no-headers
+        let mut split_count: u64 = 0;
+        let mut data_row_num: u64 = 0;
+        let mut error_messages: Vec<String> = Vec::new();
+        let mut record = ByteRecord::new();
+
+        loop {
+            match rdr.read_byte_record(&mut record) {
+                Ok(false) => break,
+                Ok(true) => {
+                    data_row_num += 1;
+                    // non-UTF-8 still aborts (--split-ragged only diverts column-count mismatches)
+                    if simdutf8::basic::from_utf8(record.as_slice()).is_err() {
+                        return fail_encoding_clierror!(
+                            "non-utf8 sequence at record {data_row_num}.\nInvalid record: \
+                             {record:?}\nUse `qsv input` to fix formatting and to handle non-utf8 \
+                             sequences.\nAlternatively, transcode your data to UTF-8 first using \
+                             `iconv` or `recode`."
+                        );
+                    }
+                    if expected_len == 0 {
+                        // --no-headers: the first data record defines the expected width
+                        expected_len = record.len();
+                    }
+                    if record.len() == expected_len {
+                        valid_wtr.write_byte_record(&record)?;
+                    } else {
+                        split_count += 1;
+                        // lazily create the invalid writer on the first ragged row; it must be
+                        // flexible since ragged rows vary in width
+                        if invalid_wtr.is_none() {
+                            let mut w =
+                                Config::new(Some(&format!("{output_base}.{invalid_suffix}")))
+                                    .flexible(true)
+                                    .writer()?;
+                            if has_headers {
+                                w.write_byte_record(&header_record)?;
+                            }
+                            invalid_wtr = Some(w);
+                        }
+                        // safety: just ensured Some above
+                        invalid_wtr.as_mut().unwrap().write_byte_record(&record)?;
+                        error_messages.push(format!(
+                            "{data_row_num}\t<RECORD>\tfound {} fields, but expected \
+                             {expected_len}",
+                            record.len()
+                        ));
+                    }
+                },
+                Err(e) => {
+                    // with a flexible reader, UnequalLengths never fires; any error here is a
+                    // genuine, non-recoverable parse error — still abort.
+                    return fail_clierror!(
+                        "Validation error: {e}.\nLast valid record: {data_row_num}"
+                    );
+                },
+            }
+        }
+
+        if split_count == 0 {
+            // clean file: drop the writer (closing the file handle) and remove `.valid` so a
+            // fully valid file produces no output, consistent with JSON Schema mode
+            drop(valid_wtr);
+            let _ = std::fs::remove_file(&valid_path);
+        } else {
+            valid_wtr.flush()?;
+            if let Some(mut w) = invalid_wtr {
+                w.flush()?;
+            }
+            write_error_report(output_base, error_messages)?;
+        }
+
+        if !quiet {
+            if flag_json {
+                let summary = json!({
+                    "split_ragged": {
+                        "valid_records": data_row_num - split_count,
+                        "quarantined_records": split_count,
+                        "valid_file": if split_count > 0 { json!(valid_path) } else { json!(null) },
+                        "invalid_file": if split_count > 0 {
+                            json!(format!("{output_base}.{invalid_suffix}"))
+                        } else {
+                            json!(null)
+                        },
+                        "error_report": if split_count > 0 {
+                            json!(format!("{output_base}.validation-errors.tsv"))
+                        } else {
+                            json!(null)
+                        },
+                    }
+                });
+                let out = if flag_pretty_json {
+                    // safety: summary is valid JSON by construction
+                    simd_json::to_string_pretty(&summary).unwrap()
+                } else {
+                    summary.to_string()
+                };
+                woutinfo!("{out}");
+            } else if split_count == 0 {
+                woutinfo!("Valid: {header_msg} No ragged rows found.");
+            } else {
+                woutinfo!(
+                    "{} ragged row(s) quarantined out of {} data row(s).\nWrote \
+                     {output_base}.{invalid_suffix} and {output_base}.validation-errors.tsv",
+                    HumanCount(split_count),
+                    HumanCount(data_row_num)
+                );
+            }
+        }
+
+        return Ok(split_count);
     }
 
     // Now, let's validate the rest of the records the fastest way possible.
@@ -1951,7 +2177,8 @@ Alternatively, transcode your data to UTF-8 first using `iconv` or `recode`."
         woutinfo!("{msg}");
     }
 
-    Ok(())
+    // if we're here, the CSV is valid (no ragged rows to split out)
+    Ok(0)
 }
 
 /// Re-reads the input CSV and demuxes records into `.valid` / `.invalid` files.
@@ -1982,8 +2209,11 @@ fn split_invalid_records(
         Config::new(Some(input_path.to_owned() + "." + valid_suffix).as_ref()).writer()?;
     valid_wtr.write_byte_record(headers)?;
 
-    let mut invalid_wtr =
-        Config::new(Some(input_path.to_owned() + "." + invalid_suffix).as_ref()).writer()?;
+    // the invalid writer must be flexible when quarantining ragged rows (--split-ragged),
+    // since those rows have field counts that differ from the header width.
+    let mut invalid_wtr = Config::new(Some(input_path.to_owned() + "." + invalid_suffix).as_ref())
+        .flexible(rconfig.flexible)
+        .writer()?;
     invalid_wtr.write_byte_record(headers)?;
 
     let mut rdr = rconfig.reader()?;

--- a/src/cmd/validate.rs
+++ b/src/cmd/validate.rs
@@ -1962,11 +1962,14 @@ fn validate_single_file_rfc4180(
         // writer (which goes through Config::writer()).
         let valid_cfg = Config::new(Some(&valid_path));
         let valid_handle = valid_tmp.as_file().try_clone()?;
-        let valid_sink: Box<dyn std::io::Write + 'static> = if valid_cfg.is_snappy() {
-            Box::new(snap::write::FrameEncoder::new(valid_handle))
-        } else {
-            Box::new(valid_handle)
-        };
+        // use the unconditional `is_snappy_extension` helper rather than `Config::is_snappy()`,
+        // which is `#[cfg(feature = "polars")]`-gated and would break non-polars builds (qsvlite).
+        let valid_sink: Box<dyn std::io::Write + 'static> =
+            if crate::config::is_snappy_extension(std::path::Path::new(&valid_path)) {
+                Box::new(snap::write::FrameEncoder::new(valid_handle))
+            } else {
+                Box::new(valid_handle)
+            };
         let mut valid_wtr = valid_cfg.from_writer(valid_sink);
         if has_headers {
             valid_wtr.write_byte_record(&header_record)?;

--- a/src/cmd/validate.rs
+++ b/src/cmd/validate.rs
@@ -1680,8 +1680,7 @@ fn validate_rfc4180_mode(args: &Args) -> CliResult<()> {
     let flag_json = args.flag_json || args.flag_pretty_json;
     let flag_pretty_json = args.flag_pretty_json;
 
-    // --split-ragged output naming: valid/invalid suffixes and whether input came from stdin
-    // (in which case the split files use a "stdin.csv" base in the current dir, like schema mode)
+    // --split-ragged output naming: valid/invalid suffixes
     let split_ragged = args.flag_split_ragged;
     let valid_suffix = args
         .flag_valid
@@ -1691,7 +1690,6 @@ fn validate_rfc4180_mode(args: &Args) -> CliResult<()> {
         .flag_invalid
         .clone()
         .unwrap_or_else(|| "invalid".to_string());
-    let is_stdin_input = args.arg_input.is_empty();
 
     let mut all_valid = true;
     let mut total_files = 0;
@@ -1747,8 +1745,15 @@ fn validate_rfc4180_mode(args: &Args) -> CliResult<()> {
             },
         };
 
-        let output_base = if is_stdin_input {
-            "stdin.csv".to_string()
+        // stdin ("-"), snappy-decompressed, and zip-extracted inputs are materialized inside
+        // `tmpdir`, which is removed on exit — writing split files next to them would silently
+        // lose them. For those, write the split files under the input's file name in the current
+        // directory instead (so stdin lands on `stdin.csv.valid` etc., like schema mode).
+        let output_base = if input_path.starts_with(tmpdir.path()) {
+            input_path.file_name().map_or_else(
+                || "stdin.csv".to_string(),
+                |n| n.to_string_lossy().to_string(),
+            )
         } else {
             input_path.to_string_lossy().to_string()
         };
@@ -1926,11 +1931,26 @@ fn validate_single_file_rfc4180(
             ByteRecord::new()
         };
 
-        // `.valid` is written by streaming; if no ragged rows are found we delete it at EOF so a
-        // clean file produces no output files (matching JSON Schema mode). The `.invalid` writer
-        // and error report are created lazily, only once the first ragged row is seen.
+        // Stream valid rows to a temp file in the target directory, then rename it into
+        // `<output_base>.<valid_suffix>` only if we actually quarantine a ragged row. This way a
+        // clean file never truncates or deletes a pre-existing `.valid` file (matching JSON Schema
+        // mode's "no output when all valid"), and an aborted run leaves no stray files — the
+        // NamedTempFile removes itself on drop. The `.invalid` writer and error report are likewise
+        // created lazily, only once the first ragged row is seen.
         let valid_path = format!("{output_base}.{valid_suffix}");
-        let mut valid_wtr = Config::new(Some(&valid_path)).writer()?;
+        let valid_dir = std::path::Path::new(&valid_path)
+            .parent()
+            .filter(|p| !p.as_os_str().is_empty())
+            .map_or_else(
+                || std::path::PathBuf::from("."),
+                std::path::Path::to_path_buf,
+            );
+        let valid_tmp = tempfile::Builder::new()
+            .prefix(".qsv-validate-")
+            .tempfile_in(&valid_dir)?;
+        // clone the temp file's handle so `valid_tmp` still owns the NamedTempFile for persist()
+        let mut valid_wtr =
+            Config::new(Some(&valid_path)).from_writer(valid_tmp.as_file().try_clone()?);
         if has_headers {
             valid_wtr.write_byte_record(&header_record)?;
         }
@@ -1996,13 +2016,17 @@ fn validate_single_file_rfc4180(
             }
         }
 
+        valid_wtr.flush()?;
+        drop(valid_wtr); // release the cloned handle before persisting/dropping the temp (Windows)
         if split_count == 0 {
-            // clean file: drop the writer (closing the file handle) and remove `.valid` so a
-            // fully valid file produces no output, consistent with JSON Schema mode
-            drop(valid_wtr);
-            let _ = std::fs::remove_file(&valid_path);
+            // clean file: drop the temp (NamedTempFile removes it) so no output is produced and
+            // any pre-existing `.valid` file is left untouched, consistent with JSON Schema mode
+            drop(valid_tmp);
         } else {
-            valid_wtr.flush()?;
+            // rename the temp into place atomically; only now does `.valid` appear/get replaced
+            valid_tmp
+                .persist(&valid_path)
+                .map_err(|e| CliError::Other(format!("Cannot write {valid_path}: {e}")))?;
             if let Some(mut w) = invalid_wtr {
                 w.flush()?;
             }

--- a/src/cmd/validate.rs
+++ b/src/cmd/validate.rs
@@ -1745,15 +1745,23 @@ fn validate_rfc4180_mode(args: &Args) -> CliResult<()> {
             },
         };
 
+        // `output_base` is only used (and its parent dirs only created) in --split-ragged mode;
+        // computing it unconditionally would create stray directories on the normal validate path.
         // stdin ("-"), snappy-decompressed, and zip-extracted inputs are materialized inside
         // `tmpdir`, which is removed on exit — writing split files next to them would silently
-        // lose them. For those, write the split files under the input's file name in the current
-        // directory instead (so stdin lands on `stdin.csv.valid` etc., like schema mode).
-        let output_base = if input_path.starts_with(tmpdir.path()) {
-            input_path.file_name().map_or_else(
-                || "stdin.csv".to_string(),
-                |n| n.to_string_lossy().to_string(),
-            )
+        // lose them. For those, write the split files under the input's tmpdir-*relative* subpath
+        // in the current directory (creating parent dirs as needed). Preserving the subpath keeps
+        // stdin on `stdin.csv.*` while avoiding collisions between distinct entries that share a
+        // base name (e.g. a zip's `a/data.csv` and `b/data.csv`).
+        let output_base = if !split_ragged {
+            String::new()
+        } else if let Ok(rel) = input_path.strip_prefix(tmpdir.path()) {
+            if let Some(parent) = rel.parent()
+                && !parent.as_os_str().is_empty()
+            {
+                std::fs::create_dir_all(parent)?;
+            }
+            rel.to_string_lossy().to_string()
         } else {
             input_path.to_string_lossy().to_string()
         };
@@ -1948,9 +1956,18 @@ fn validate_single_file_rfc4180(
         let valid_tmp = tempfile::Builder::new()
             .prefix(".qsv-validate-")
             .tempfile_in(&valid_dir)?;
-        // clone the temp file's handle so `valid_tmp` still owns the NamedTempFile for persist()
-        let mut valid_wtr =
-            Config::new(Some(&valid_path)).from_writer(valid_tmp.as_file().try_clone()?);
+        // clone the temp file's handle so `valid_tmp` still owns the NamedTempFile for persist().
+        // Mirror Config::writer()'s io_writer(): snappy-compress the temp when the final path is
+        // `.sz` (e.g. `--valid csv.sz`), so the valid output stays consistent with the invalid
+        // writer (which goes through Config::writer()).
+        let valid_cfg = Config::new(Some(&valid_path));
+        let valid_handle = valid_tmp.as_file().try_clone()?;
+        let valid_sink: Box<dyn std::io::Write + 'static> = if valid_cfg.is_snappy() {
+            Box::new(snap::write::FrameEncoder::new(valid_handle))
+        } else {
+            Box::new(valid_handle)
+        };
+        let mut valid_wtr = valid_cfg.from_writer(valid_sink);
         if has_headers {
             valid_wtr.write_byte_record(&header_record)?;
         }

--- a/tests/test_validate.rs
+++ b/tests/test_validate.rs
@@ -196,6 +196,234 @@ Use `qsv fixlengths` to fix record length issues.
 }
 
 #[test]
+fn validate_split_ragged_rfc4180() {
+    let wrk = Workdir::new("validate_split_ragged_rfc4180").flexible(true);
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["title", "name", "age"],
+            svec!["Professor", "Xaviers", "60"],
+            svec!["Magneto", "90"], // ragged: too few
+            svec!["First Class Student", "Iceman", "14"],
+            svec!["Extra", "Field", "Here", "Boom"], // ragged: too many
+        ],
+    );
+    let mut cmd = wrk.command("validate");
+    cmd.arg("--split-ragged").arg("data.csv");
+
+    // ragged rows quarantined -> non-zero exit
+    wrk.assert_err(&mut cmd);
+
+    // well-formed rows go to .valid
+    let valid_records: Vec<Vec<String>> = wrk.read_csv("data.csv.valid");
+    assert_eq!(
+        valid_records,
+        vec![
+            svec!["Professor", "Xaviers", "60"],
+            svec!["First Class Student", "Iceman", "14"],
+        ]
+    );
+
+    // ragged rows go to .invalid (read as text since widths vary)
+    let invalid_output = wrk.read_to_string("data.csv.invalid").unwrap();
+    assert_eq!(
+        invalid_output,
+        "title,name,age\nMagneto,90\nExtra,Field,Here,Boom\n"
+    );
+
+    // report lists the ragged rows with 1-based data-row numbers
+    let errors = wrk
+        .read_to_string("data.csv.validation-errors.tsv")
+        .unwrap();
+    assert_eq!(
+        errors,
+        "row_number\tfield\terror\n2\t<RECORD>\tfound 2 fields, but expected \
+         3\n4\t<RECORD>\tfound 4 fields, but expected 3\n"
+    );
+}
+
+#[test]
+fn validate_split_ragged_no_headers() {
+    let wrk = Workdir::new("validate_split_ragged_no_headers").flexible(true);
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["a", "b", "c"], // first data row -> defines width 3
+            svec!["d", "e"],      // ragged
+            svec!["f", "g", "h"],
+        ],
+    );
+    let mut cmd = wrk.command("validate");
+    cmd.arg("--split-ragged")
+        .arg("--no-headers")
+        .arg("data.csv");
+
+    wrk.assert_err(&mut cmd);
+
+    // no spurious header line: the first row is data (read raw, since read_csv would treat the
+    // first data row as a header)
+    let valid_output = wrk.read_to_string("data.csv.valid").unwrap();
+    assert_eq!(valid_output, "a,b,c\nf,g,h\n");
+
+    let invalid_output = wrk.read_to_string("data.csv.invalid").unwrap();
+    assert_eq!(invalid_output, "d,e\n");
+
+    let errors = wrk
+        .read_to_string("data.csv.validation-errors.tsv")
+        .unwrap();
+    assert_eq!(
+        errors,
+        "row_number\tfield\terror\n2\t<RECORD>\tfound 2 fields, but expected 3\n"
+    );
+}
+
+#[test]
+fn validate_split_ragged_all_valid() {
+    let wrk = Workdir::new("validate_split_ragged_all_valid").flexible(true);
+    wrk.create(
+        "data.csv",
+        vec![svec!["x", "y"], svec!["1", "2"], svec!["3", "4"]],
+    );
+    let mut cmd = wrk.command("validate");
+    cmd.arg("--split-ragged").arg("data.csv");
+
+    // no ragged rows -> success, and no output files at all (consistent with JSON Schema mode)
+    wrk.assert_success(&mut cmd);
+    assert!(!wrk.path("data.csv.valid").exists());
+    assert!(!wrk.path("data.csv.invalid").exists());
+    assert!(!wrk.path("data.csv.validation-errors.tsv").exists());
+}
+
+#[test]
+fn validate_split_ragged_custom_suffixes() {
+    let wrk = Workdir::new("validate_split_ragged_custom_suffixes").flexible(true);
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["a", "b"],
+            svec!["1", "2"],
+            svec!["3"], // ragged
+        ],
+    );
+    let mut cmd = wrk.command("validate");
+    cmd.arg("--split-ragged")
+        .args(["--valid", "good"])
+        .args(["--invalid", "bad"])
+        .arg("data.csv");
+
+    wrk.assert_err(&mut cmd);
+
+    let valid_records: Vec<Vec<String>> = wrk.read_csv("data.csv.good");
+    assert_eq!(valid_records, vec![svec!["1", "2"]]);
+
+    let invalid_output = wrk.read_to_string("data.csv.bad").unwrap();
+    assert_eq!(invalid_output, "a,b\n3\n");
+}
+
+#[test]
+fn validate_split_ragged_off_still_aborts() {
+    // regression: without the flag, a ragged row still aborts (no split files produced)
+    let wrk = Workdir::new("validate_split_ragged_off_still_aborts").flexible(true);
+    wrk.create(
+        "data.csv",
+        vec![svec!["a", "b"], svec!["1", "2"], svec!["3"]],
+    );
+    let mut cmd = wrk.command("validate");
+    cmd.arg("data.csv");
+
+    wrk.assert_err(&mut cmd);
+    assert!(!wrk.path("data.csv.valid").exists());
+    assert!(!wrk.path("data.csv.invalid").exists());
+}
+
+#[test]
+fn validate_split_ragged_schema() {
+    let wrk = Workdir::new("validate_split_ragged_schema").flexible(true);
+    // permissive all-string schema so ONLY ragged rows are quarantined (deterministic)
+    wrk.create_from_string(
+        "schema.json",
+        r#"{
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "val": { "type": "string" }
+            }
+        }"#,
+    );
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["id", "val"],
+            svec!["1", "apple"],
+            svec!["2"],                    // ragged: too few (would panic without the fix)
+            svec!["3", "cherry", "extra"], // ragged: too many
+            svec!["4", "date"],
+        ],
+    );
+    let mut cmd = wrk.command("validate");
+    cmd.arg("--split-ragged").arg("data.csv").arg("schema.json");
+
+    wrk.assert_err(&mut cmd);
+
+    let valid_records: Vec<Vec<String>> = wrk.read_csv("data.csv.valid");
+    assert_eq!(valid_records, vec![svec!["1", "apple"], svec!["4", "date"]]);
+
+    let invalid_output = wrk.read_to_string("data.csv.invalid").unwrap();
+    assert_eq!(invalid_output, "id,val\n2\n3,cherry,extra\n");
+
+    let errors = wrk
+        .read_to_string("data.csv.validation-errors.tsv")
+        .unwrap();
+    assert_eq!(
+        errors,
+        "row_number\tfield\terror\n2\t<RECORD>\tfound 1 fields, but expected \
+         2\n3\t<RECORD>\tfound 3 fields, but expected 2\n"
+    );
+}
+
+#[test]
+fn validate_split_ragged_aborts_on_bad_utf8() {
+    // scope boundary: --split-ragged only diverts column-count mismatches; non-UTF-8 still aborts
+    let wrk = Workdir::new("validate_split_ragged_aborts_on_bad_utf8").flexible(true);
+    // write a CSV with a non-UTF-8 byte (0xFF) in a data cell
+    std::fs::write(wrk.path("data.csv"), b"a,b\n1,2\n3,\xFF\n").unwrap();
+
+    let mut cmd = wrk.command("validate");
+    cmd.arg("--split-ragged").arg("data.csv");
+
+    wrk.assert_err(&mut cmd);
+    let stderr = wrk.output_stderr(&mut cmd);
+    assert!(stderr.contains("non-utf8"), "stderr was: {stderr}");
+}
+
+#[test]
+fn validate_split_ragged_multifile() {
+    let wrk = Workdir::new("validate_split_ragged_multifile").flexible(true);
+    wrk.create("clean.csv", vec![svec!["a", "b"], svec!["1", "2"]]);
+    wrk.create(
+        "ragged.csv",
+        vec![svec!["a", "b"], svec!["1", "2"], svec!["3"]],
+    );
+
+    let mut cmd = wrk.command("validate");
+    cmd.arg("--split-ragged").arg("clean.csv").arg("ragged.csv");
+
+    // one file has ragged rows -> overall non-zero exit
+    wrk.assert_err(&mut cmd);
+
+    // the clean file is untouched (no split files)
+    assert!(!wrk.path("clean.csv.valid").exists());
+    assert!(!wrk.path("clean.csv.invalid").exists());
+
+    // the ragged file is split
+    let valid_records: Vec<Vec<String>> = wrk.read_csv("ragged.csv.valid");
+    assert_eq!(valid_records, vec![svec!["1", "2"]]);
+    let invalid_output = wrk.read_to_string("ragged.csv.invalid").unwrap();
+    assert_eq!(invalid_output, "a,b\n3\n");
+}
+
+#[test]
 fn validate_bad_csv_prettyjson() {
     let wrk = Workdir::new("validate_bad_csv_prettyjson").flexible(true);
     wrk.create(

--- a/tests/test_validate.rs
+++ b/tests/test_validate.rs
@@ -424,6 +424,56 @@ fn validate_split_ragged_multifile() {
 }
 
 #[test]
+fn validate_split_ragged_preserves_existing_valid_on_clean() {
+    // a clean run must NOT truncate/delete a pre-existing `.valid` file (roborev #3705)
+    let wrk =
+        Workdir::new("validate_split_ragged_preserves_existing_valid_on_clean").flexible(true);
+    wrk.create(
+        "data.csv",
+        vec![svec!["x", "y"], svec!["1", "2"], svec!["3", "4"]],
+    );
+    wrk.create_from_string("data.csv.valid", "PRECIOUS-USER-DATA\n");
+
+    let mut cmd = wrk.command("validate");
+    cmd.arg("--split-ragged").arg("data.csv");
+
+    wrk.assert_success(&mut cmd);
+    // the pre-existing file is untouched, and no `.invalid` is produced
+    let preserved = wrk.read_to_string("data.csv.valid").unwrap();
+    assert_eq!(preserved, "PRECIOUS-USER-DATA\n");
+    assert!(!wrk.path("data.csv.invalid").exists());
+}
+
+#[test]
+fn validate_split_ragged_explicit_stdin() {
+    // explicit stdin ("-") must write split files to the cwd, not into a tempdir that vanishes
+    // (roborev #3705)
+    use std::io::Write;
+    let wrk = Workdir::new("validate_split_ragged_explicit_stdin").flexible(true);
+
+    let mut cmd = wrk.command("validate");
+    cmd.arg("--split-ragged").arg("-");
+    cmd.stdin(std::process::Stdio::piped());
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
+
+    let mut child = cmd.spawn().unwrap();
+    {
+        let mut stdin_handle = child.stdin.take().unwrap();
+        stdin_handle.write_all(b"a,b\n1,2\n3\n").unwrap();
+    }
+    let output = child.wait_with_output().unwrap();
+    // ragged row -> non-zero exit
+    assert!(!output.status.success());
+
+    // split files land on stdin.csv.* in the working directory
+    let valid = wrk.read_to_string("stdin.csv.valid").unwrap();
+    assert_eq!(valid, "a,b\n1,2\n");
+    let invalid = wrk.read_to_string("stdin.csv.invalid").unwrap();
+    assert_eq!(invalid, "a,b\n3\n");
+}
+
+#[test]
 fn validate_bad_csv_prettyjson() {
     let wrk = Workdir::new("validate_bad_csv_prettyjson").flexible(true);
     wrk.create(

--- a/tests/test_validate.rs
+++ b/tests/test_validate.rs
@@ -474,6 +474,60 @@ fn validate_split_ragged_explicit_stdin() {
 }
 
 #[test]
+fn validate_split_ragged_snappy_input() {
+    // a snappy-compressed input is materialized under a tempdir; its split output must land in
+    // the cwd under the input's (relative) name, not be lost in the tempdir (roborev #3706)
+    let wrk = Workdir::new("validate_split_ragged_snappy_input").flexible(true);
+    wrk.create(
+        "data.csv",
+        vec![svec!["x", "y"], svec!["1", "2"], svec!["3"]],
+    );
+
+    // compress data.csv -> data.csv.sz
+    let mut compress = wrk.command("snappy");
+    compress
+        .arg("compress")
+        .arg("data.csv")
+        .args(["--output", "data.csv.sz"]);
+    wrk.assert_success(&mut compress);
+
+    let mut cmd = wrk.command("validate");
+    cmd.arg("--split-ragged").arg("data.csv.sz");
+    wrk.assert_err(&mut cmd);
+
+    let valid: Vec<Vec<String>> = wrk.read_csv("data.csv.valid");
+    assert_eq!(valid, vec![svec!["1", "2"]]);
+    let invalid = wrk.read_to_string("data.csv.invalid").unwrap();
+    assert_eq!(invalid, "x,y\n3\n");
+}
+
+#[test]
+fn validate_split_ragged_compressed_valid_suffix() {
+    // a `.sz` custom --valid suffix must produce a genuinely snappy-compressed file, consistent
+    // with the invalid writer's Config::writer() path (roborev #3706)
+    let wrk = Workdir::new("validate_split_ragged_compressed_valid_suffix").flexible(true);
+    wrk.create(
+        "data.csv",
+        vec![svec!["x", "y"], svec!["1", "2"], svec!["3"]],
+    );
+
+    let mut cmd = wrk.command("validate");
+    cmd.arg("--split-ragged")
+        .args(["--valid", "csv.sz"])
+        .arg("data.csv");
+    wrk.assert_err(&mut cmd);
+
+    // the valid output is <input>.<suffix> = data.csv.csv.sz and is snappy-framed
+    let bytes = std::fs::read(wrk.path("data.csv.csv.sz")).unwrap();
+    // the snappy stream identifier starts with 0xFF and carries the ascii "sNaPpY"
+    assert_eq!(bytes[0], 0xFF, "valid output was not snappy-compressed");
+    assert!(
+        bytes.windows(6).any(|w| w == b"sNaPpY"),
+        "valid output is missing the snappy stream identifier"
+    );
+}
+
+#[test]
 fn validate_bad_csv_prettyjson() {
     let wrk = Workdir::new("validate_bad_csv_prettyjson").flexible(true);
     wrk.create(


### PR DESCRIPTION
## Summary

Resolves #4231.

`qsv validate` currently aborts on the first row with the wrong number of columns, so there is no way to isolate ragged rows for inspection while validating the rest. This adds an opt-in **`--split-ragged`** flag that quarantines wrong-column-count rows instead of failing the whole file.

When set, `--split-ragged`:
- streams well-formed rows to `<input>.valid`,
- diverts ragged rows to `<input>.invalid`,
- appends a report to `<input>.validation-errors.tsv` (`row_number`, `<RECORD>`, `found N fields, but expected M`),
- returns a non-zero exit code when any row is quarantined.

It works in **both** RFC 4180 mode and JSON Schema mode. In schema mode, ragged rows are marked invalid and skip schema validation (which would otherwise silently zip to the shorter length and possibly pass), reusing the existing `split_invalid_records` / `write_error_report` machinery.

## Behavior notes

- **Scope is column-count mismatch only.** Malformed quoting and non-UTF-8 data still abort — the flag never suppresses those.
- Expected width = header count, or the first data record's width with `--no-headers`.
- **A fully valid file produces no output files** (exit 0), consistent with existing schema-mode behavior. This differs from behavior with the flag off only in that ragged rows are quarantined rather than fatal.
- Default off — existing fail-fast behavior is unchanged.

## Example

```console
$ qsv validate --split-ragged data.csv
2 ragged row(s) quarantined out of 4 data row(s).
Wrote data.csv.invalid and data.csv.validation-errors.tsv

$ cat data.csv.validation-errors.tsv
row_number	field	error
2	<RECORD>	found 2 fields, but expected 3
3	<RECORD>	found 4 fields, but expected 3
```

## Robustness fixes (addressing review rounds)

Follow-up commits hardened the output handling based on code review:

- **No data loss on a clean run.** Valid rows stream to a temp file and are atomically renamed into `<input>.valid` *only* when a ragged row is actually quarantined. A clean run therefore never truncates or deletes a pre-existing `.valid` file, and an aborted run leaves no stray files.
- **stdin / compressed / zip inputs.** stdin (`-`), snappy-decompressed, and zip-extracted inputs are materialized under a temp dir that is removed on exit. Split files for those are written under the input's temp-dir-relative subpath in the current directory (e.g. `stdin.csv.valid`), so they aren't lost, and distinct entries that share a base name (e.g. a zip's `a/data.csv` and `b/data.csv`) don't collide. This output-path computation runs only in `--split-ragged` mode, so the normal validate path has no filesystem side effects.
- **Compressed valid output.** A snappy custom suffix (e.g. `--valid csv.sz`) produces a genuinely snappy-compressed file, consistent with the invalid writer, using the ungated `config::is_snappy_extension` helper (so `qsvlite`, which has no `polars`, still builds).

## Known limitation (pre-existing, not a regression)

Output `.valid`/`.invalid` files inherit the default comma delimiter, not the input's — a `.tsv` input yields comma-delimited split files. This matches existing schema-mode `split_invalid_records` behavior.

## Testing

- 12 new tests in `tests/test_validate.rs`: RFC-4180 split, `--no-headers` first-row width, all-valid (no files), custom suffixes, flag-off regression, JSON Schema split (guards against the short-row panic), non-UTF-8 still aborts, multi-file, pre-existing `.valid` preserved on clean run, explicit stdin (`-`), snappy input naming, and compressed (`.sz`) valid suffix.
- Full `test_validate` suite: 74 passed / 0 failed.
- `cargo build --locked` (qsv + qsvlite), `cargo +nightly fmt`, `cargo clippy` (qsv `-F all_features` and qsvlite `-F lite`) all clean.
- `docs/help/validate.md` regenerated via `qsv --generate-help-md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0184VpwBz2qvdLicJWgBpk6u
