### PR TITLE
feat(self-update): throttle background update checks to twice a month

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7953,8 +7953,7 @@ checksum = "2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813"
 [[package]]
 name = "self_update"
 version = "1.0.0-rc.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b7cc0b87814417b0e0697ae582dfc5f614f469fbac9b138e40457d88913187d"
+source = "git+https://github.com/jaemk/self_update?rev=91b0531a22b76cabf46152fd2aae0b34a75c177e#91b0531a22b76cabf46152fd2aae0b34a75c177e"
 dependencies = [
  "http 1.4.2",
  "indicatif",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -371,7 +371,10 @@ rmp-serde = { version = "1.3", optional = true }
 rust_decimal = { version = "1.42", default-features = false }
 sanitize-filename = { version = "0.6", optional = true }
 simd-json = "0.17"
-self_update = { version = "1.0.0-rc.4", features = [
+# pinned to git master for check_interval::UpdateCheckGuard, which is not yet in a
+# published release (still declared 1.0.0-rc.6 upstream). Switch back to the crates.io
+# version once an rc/stable ships check_interval.
+self_update = { git = "https://github.com/jaemk/self_update", rev = "91b0531a22b76cabf46152fd2aae0b34a75c177e", features = [
     "archive-zip",
     "compression-zip-deflate",
     "github",

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@ use std::{env, io, time::Instant};
 
 extern crate qsv_docopt as docopt;
 use docopt::Docopt;
-use rand::RngExt;
 use serde::Deserialize;
 
 use crate::{
@@ -354,11 +353,8 @@ fn main() -> QsvExitCode {
                  following {num_commands} commands:\n{enabled_commands}\n\n{SPONSOR_MESSAGE}"
             );
 
-            // if no command is specified, auto-check for updates 50% of the time
-            let mut rng = rand::rng(); //DevSkim: ignore DS148264
-            if rng.random_range(0..2) == 0 {
-                _ = util::qsv_check_for_update(true, false);
-            }
+            // if no command is specified, auto-check for updates (throttled to twice a month)
+            util::qsv_check_for_update_throttled();
             util::log_end(qsv_args, now);
             QsvExitCode::Good
         },
@@ -605,7 +601,7 @@ impl Command {
             Command::Headers => cmd::headers::run(argv),
             Command::Help => {
                 wout!("{USAGE}\n\n{SPONSOR_MESSAGE}");
-                util::qsv_check_for_update(true, false)?;
+                util::qsv_check_for_update_throttled();
                 Ok(())
             },
             Command::Implode => cmd::implode::run(argv),

--- a/src/maindp.rs
+++ b/src/maindp.rs
@@ -397,7 +397,7 @@ impl Command {
             Command::Headers => cmd::headers::run(argv),
             Command::Help => {
                 wout!("{USAGE}\n\n{SPONSOR_MESSAGE}");
-                util::qsv_check_for_update(true, false)?;
+                util::qsv_check_for_update_throttled();
                 Ok(())
             },
             Command::Index => cmd::index::run(argv),

--- a/src/mainlite.rs
+++ b/src/mainlite.rs
@@ -2,7 +2,6 @@ use std::{env, io, time::Instant};
 
 extern crate qsv_docopt as docopt;
 use docopt::Docopt;
-use rand::RngExt;
 use serde::Deserialize;
 
 use crate::{
@@ -162,11 +161,8 @@ fn main() -> QsvExitCode {
                  following 50 commands:\n{COMMAND_LIST}\n\n{SPONSOR_MESSAGE}",
             );
 
-            // if no command is specified, auto-check for updates 50% of the time
-            let mut rng = rand::rng(); //DevSkim: ignore DS148264
-            if rng.random_range(0..2) == 0 {
-                _ = util::qsv_check_for_update(true, false);
-            }
+            // if no command is specified, auto-check for updates (throttled to twice a month)
+            util::qsv_check_for_update_throttled();
             util::log_end(qsv_args, now);
             QsvExitCode::Good
         },
@@ -330,7 +326,7 @@ impl Command {
             Command::Headers => cmd::headers::run(argv),
             Command::Help => {
                 wout!("{USAGE}\n\n{SPONSOR_MESSAGE}");
-                util::qsv_check_for_update(true, false)?;
+                util::qsv_check_for_update_throttled();
                 Ok(())
             },
             Command::Implode => cmd::implode::run(argv),

--- a/src/util.rs
+++ b/src/util.rs
@@ -3886,9 +3886,10 @@ pub fn optimal_batch_size(rconfig: &Config, batch_size: usize, num_jobs: usize) 
 }
 
 /// Expand the tilde (`~`) from within the provided path.
-// only consumed by non-lite commands (describegpt, fetchpost, geocode) and the
-// `get`/diskcache subsystem, none of which are in qsvlite
-#[cfg(not(feature = "lite"))]
+// consumed by non-lite commands (describegpt, fetchpost, geocode) and the
+// `get`/diskcache subsystem (none of which are in qsvlite), plus the throttled
+// self-update check - which can be enabled alongside `lite`, hence the extra gate.
+#[cfg(any(not(feature = "lite"), feature = "self_update"))]
 pub fn expand_tilde(path: impl AsRef<Path>) -> Option<PathBuf> {
     let p = path.as_ref();
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1686,6 +1686,52 @@ pub fn qsv_check_for_update(_check_only: bool, _no_confirm: bool) -> Result<bool
     Err("Self-update is disabled in this build.".to_string())
 }
 
+// how often a background (non-flag) update check is allowed to hit GitHub: ~twice a month
+#[cfg(feature = "self_update")]
+const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(15 * 24 * 60 * 60);
+
+/// Background update check, throttled to at most twice a month via a persisted stamp file.
+///
+/// Used by the no-command screen and the `help` command so they don't hit GitHub on every
+/// invocation. The explicit `--update`/`--updatenow` flags bypass this and call
+/// `qsv_check_for_update` directly. Best-effort: all errors are swallowed.
+#[cfg(feature = "self_update")]
+pub fn qsv_check_for_update_throttled() {
+    // honor the opt-out BEFORE touching the filesystem
+    if get_envvar_flag("QSV_NO_UPDATE") {
+        return;
+    }
+
+    // stamp lives in the qsv cache dir: QSV_CACHE_DIR override, else ~/.qsv-cache
+    let raw = std::env::var("QSV_CACHE_DIR")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "~/.qsv-cache".to_string());
+    let Some(cache_dir) = expand_tilde(&raw) else {
+        return; // can't resolve home; skip silently
+    };
+
+    // create the parent dir so record_check() can persist. If it can't, should_check()
+    // would return Ok(true) forever => a check on EVERY startup (worse than no throttle).
+    if fs::create_dir_all(&cache_dir).is_err() {
+        return;
+    }
+
+    let stamp_path = cache_dir.join(".last_update_check");
+    let guard =
+        self_update::check_interval::UpdateCheckGuard::new(stamp_path, UPDATE_CHECK_INTERVAL);
+
+    // on a genuine IO error reading the stamp, DON'T check (avoid hammering GitHub);
+    // a missing/corrupt stamp already yields Ok(true), so first run still checks.
+    if guard.should_check().unwrap_or(false) {
+        _ = qsv_check_for_update(true, false); // best-effort; ignore network errors
+        _ = guard.record_check(); // record regardless of outcome => real throttle
+    }
+}
+
+#[cfg(not(feature = "self_update"))]
+pub fn qsv_check_for_update_throttled() {}
+
 // the qsv hwsurvey allows us to keep a better
 // track of qsv's usage in the wild, so we can do a
 // better job of prioritizing platforms/features we support
@@ -4847,6 +4893,20 @@ mod tests {
             is_ascii,
             ..Default::default()
         }
+    }
+
+    #[cfg(feature = "self_update")]
+    #[test]
+    fn update_check_guard_throttles() {
+        let dir = tempfile::tempdir().unwrap();
+        let stamp = dir.path().join(".last_update_check");
+        let guard =
+            self_update::check_interval::UpdateCheckGuard::new(&stamp, Duration::from_secs(3600));
+        // no stamp yet => a check is due
+        assert!(guard.should_check().unwrap());
+        // after recording, the interval throttles the next check
+        guard.record_check().unwrap();
+        assert!(!guard.should_check().unwrap());
     }
 
     #[test]


### PR DESCRIPTION
## What & why

qsv had **no persisted throttle** on its background update checks. The two background auto-check sites were:

1. A stateless **50% coin-flip** on the no-command screen — re-rolled every invocation, remembered nothing.
2. An **unconditional** check every time the `help` command rendered — hit GitHub on *every* `qsv help`.

This replaces both with [`self_update::check_interval::UpdateCheckGuard`](https://github.com/jaemk/self_update/blob/master/CHANGELOG.md), persisting the last-check time to a stamp file so a background check hits GitHub **at most twice a month** (~15-day interval). The stamp survives across process invocations.

The explicit `--update` / `--updatenow` flags stay **unconditional** — they are never throttled.

## Changes

- **`src/util.rs`** — new `qsv_check_for_update_throttled()` (real impl under `self_update` + no-op stub otherwise) and an `UPDATE_CHECK_INTERVAL` const. Stamp lives at `~/.qsv-cache/.last_update_check` (honors `QSV_CACHE_DIR`); short-circuits on `QSV_NO_UPDATE` before touching the filesystem; `create_dir_all`s the parent dir before `record_check()` so the throttle actually persists (otherwise `should_check()` would return true forever); records after every attempt regardless of the network result so a transient failure doesn't defeat the throttle. Plus a deterministic wiring test.
- **`src/main.rs` / `src/mainlite.rs`** — route the no-command site and the `help` arm through the guard; remove the now-dead `use rand::RngExt;`.
- **`src/maindp.rs`** — route the `help` arm through the guard (also removes a latent `?`-propagation bug in non-`self_update` builds).

## Dependency note

`check_interval::UpdateCheckGuard` is **not yet in a published `self_update` release** (upstream still declares `1.0.0-rc.6`), so this pins `self_update` to git master rev `91b0531`. Switch back to a crates.io version once an rc/stable ships `check_interval`.

## Verification

- All four binaries build (`qsv` / `qsvlite` / `qsvdp` / `qsvmcp`); clippy clean; wiring test passes.
- End-to-end: first run checks GitHub + writes the epoch stamp; subsequent runs (including `qsv help`) skip; `QSV_NO_UPDATE=1` writes nothing; `QSV_CACHE_DIR` override is honored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)