### PR TITLE
test(pragmastat): assert guaranteed bound invariants instead of straddling

### DIFF
--- a/tests/test_pragmastat.rs
+++ b/tests/test_pragmastat.rs
@@ -33,8 +33,11 @@ fn pragmastat_onesample_basic() {
     assert_eq!(lat_row[3], "0.0259"); // spread
     assert_eq!(lat_row[4], "42.3272"); // center_lower (deterministic)
     assert_eq!(lat_row[5], "42.3503"); // center_upper (deterministic)
-    // spread_lower/upper are randomized — verify bounds are valid and straddle spread
-    let spread: f64 = lat_row[3].parse().unwrap();
+    // spread bounds are randomized (time-seeded RNG) and are a distribution-free interval
+    // for the TRUE parameter, not for the sample point estimate. They are order statistics
+    // of a random disjoint pairing (n/2 diffs), while spread is the Shamos estimator over
+    // all C(n,2) diffs — so the interval is NOT guaranteed to contain spread. Only assert
+    // what the algorithm actually guarantees.
     let spread_lower: f64 = lat_row[6]
         .parse()
         .expect("spread_lower should be non-empty");
@@ -42,12 +45,12 @@ fn pragmastat_onesample_basic() {
         .parse()
         .expect("spread_upper should be non-empty");
     assert!(
-        spread_lower <= spread,
-        "spread_lower ({spread_lower}) should be <= spread ({spread})"
+        spread_lower <= spread_upper,
+        "spread_lower ({spread_lower}) should be <= spread_upper ({spread_upper})"
     );
     assert!(
-        spread_upper >= spread,
-        "spread_upper ({spread_upper}) should be >= spread ({spread})"
+        spread_lower >= 0.0 && spread_upper.is_finite(),
+        "spread bounds should be non-negative and finite ({spread_lower}, {spread_upper})"
     );
 
     // Verify longitude: deterministic center bounds, randomized spread bounds
@@ -57,7 +60,6 @@ fn pragmastat_onesample_basic() {
     assert_eq!(lon_row[3], "0.0249"); // spread
     assert_eq!(lon_row[4], "-71.0814"); // center_lower (deterministic)
     assert_eq!(lon_row[5], "-71.0587"); // center_upper (deterministic)
-    let lon_spread: f64 = lon_row[3].parse().unwrap();
     let lon_spread_lower: f64 = lon_row[6]
         .parse()
         .expect("spread_lower should be non-empty");
@@ -65,12 +67,12 @@ fn pragmastat_onesample_basic() {
         .parse()
         .expect("spread_upper should be non-empty");
     assert!(
-        lon_spread_lower <= lon_spread,
-        "spread_lower ({lon_spread_lower}) should be <= spread ({lon_spread})"
+        lon_spread_lower <= lon_spread_upper,
+        "spread_lower ({lon_spread_lower}) should be <= spread_upper ({lon_spread_upper})"
     );
     assert!(
-        lon_spread_upper >= lon_spread,
-        "spread_upper ({lon_spread_upper}) should be >= spread ({lon_spread})"
+        lon_spread_lower >= 0.0 && lon_spread_upper.is_finite(),
+        "spread bounds should be non-negative and finite ({lon_spread_lower}, {lon_spread_upper})"
     );
 
     // Non-numeric columns should have n=0 and empty estimator cells
@@ -210,8 +212,9 @@ fn pragmastat_twosample_basic() {
     // ratio bounds are empty (ratio was empty)
     assert!(row[9].is_empty(), "ratio_lower should be empty");
     assert!(row[10].is_empty(), "ratio_upper should be empty");
-    // disparity_lower/upper are randomized — verify bounds are valid and straddle disparity
-    let disparity: f64 = row[6].parse().unwrap();
+    // disparity bounds are randomized (time-seeded RNG) and bound the TRUE parameter, not
+    // the sample point estimate — so they are NOT guaranteed to contain `disparity`.
+    // Only assert what the algorithm actually guarantees.
     let disparity_lower: f64 = row[11]
         .parse()
         .expect("disparity_lower should be non-empty");
@@ -219,12 +222,12 @@ fn pragmastat_twosample_basic() {
         .parse()
         .expect("disparity_upper should be non-empty");
     assert!(
-        disparity_lower <= disparity,
-        "disparity_lower ({disparity_lower}) should be <= disparity ({disparity})"
+        disparity_lower <= disparity_upper,
+        "disparity_lower ({disparity_lower}) should be <= disparity_upper ({disparity_upper})"
     );
     assert!(
-        disparity_upper >= disparity,
-        "disparity_upper ({disparity_upper}) should be >= disparity ({disparity})"
+        disparity_lower.is_finite() && disparity_upper.is_finite(),
+        "disparity bounds should be finite ({disparity_lower}, {disparity_upper})"
     );
 }
 


### PR DESCRIPTION
`pragmastat_onesample_basic` and `pragmastat_twosample_basic` flake intermittently in CI. Observed on the CI run for #4249:

```
thread 'test_pragmastat::pragmastat_onesample_basic' panicked at tests/test_pragmastat.rs:71:5:
spread_upper (0.0246) should be >= spread (0.0249)
```

(That PR changed only `.claude/skills/package-lock.json`, so it categorically could not have caused a Rust regression — the flakiness is pre-existing.)

## Root cause: the assertion, not the bounds

Both tests asserted that the randomized `spread`/`disparity` bounds contain the **sample point estimate**. That is not an invariant the algorithm provides.

The bounds are a distribution-free interval for the **true parameter** — precisely what `--misrate` documents: *"Probability that bounds fail to contain the true parameter."* The two quantities are computed by different estimators:

- `spread` — Shamos estimator, the median over all C(100,2) = 4,950 pairwise differences
- `spread_lower/upper` — order statistics of a **random disjoint pairing**, only n/2 = 50 differences (`pragmastat-13.0.1/src/estimators.rs:517-540`: shuffle → pairwise diffs → order statistics)

Two different estimators of the same quantity, so the interval need not contain the point estimate. It is merely *usually* true.

The RNG is time-seeded as well — `raw::spread_bounds` calls `Rng::new()`, which seeds from `SystemTime::now()` (`pragmastat-13.0.1/src/rng.rs:50-55`) — and qsv's `--seed` only reaches subsampling (`src/cmd/pragmastat.rs:341`), so every run differs.

## The fix

Assert only what the algorithm guarantees by construction:

- `lower <= upper` — order statistics with `k_left <= k_right` over a sorted buffer
- non-negative for `spread` — the buffer holds `.abs()` differences
- finite

`disparity` is signed, so it gets the finite check only.

This touches 6 assertions across the 2 tests. `center_*`, `shift_*`, and `ratio_*` bounds are computed by deterministic code paths (no `Rng::new()`), so their existing exact-value assertions are untouched.

## Verification

- `cargo t pragmastat -F all_features` — **47 passed / 0 failed**
- Ran the underlying command 5,600 times and checked the bounds distribution. The old assertion's failure is a genuine but rare tail event: minimum observed `spread_upper` was **0.0267** against a `spread` of **0.0249** — CI's 0.0246 is that same tail, one notch deeper. The new invariants held across all 5,600 samples.

Caveat, stated plainly: the flake was never reproduced locally (0 hits in 5,600 runs), so the argument that it is now fixed is mathematical, not statistical — the new assertions cannot fail by construction.

## Note: a reproducibility gap this leaves open

`--seed` is documented as *"Seed for reproducible subsampling"* and warns "no effect" without `--subsample`, yet `pragmastat` output genuinely varies run-to-run because the bounds RNG is unseeded. The crate exposes `spread_bounds_with_seed` / `disparity_bounds_with_seed`, so wiring `--seed` through would make output fully reproducible. Deliberately left out of this PR — it is a behavior change and a product decision, not a test fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)