### PR TITLE
viz: escape axis and colorbar titles on the standalone chart paths

### DIFF
--- a/src/cmd/viz.rs
+++ b/src/cmd/viz.rs
@@ -2522,10 +2522,12 @@ fn build_slider_xy_plot(args: &Args, kind: Chart, slider_col: &SelectColumns) ->
     if let Some(title) = &args.flag_title {
         layout = layout.title(Title::with_text(title));
     }
+    // same sink as `build_layout`: the fallback is a raw CSV header, so it is escaped; an explicit
+    // --x-title is operator-supplied and stays raw.
     let mut x = Axis::new().title(Title::with_text(
         args.flag_x_title
             .clone()
-            .unwrap_or_else(|| data.x_label.clone()),
+            .unwrap_or_else(|| escape_hover(&data.x_label)),
     ));
     if let Some((lo, hi)) = data.x_range {
         x = x.range(vec![lo, hi]);
@@ -2542,7 +2544,7 @@ fn build_slider_xy_plot(args: &Args, kind: Chart, slider_col: &SelectColumns) ->
     let mut y = Axis::new().title(Title::with_text(
         args.flag_y_title
             .clone()
-            .unwrap_or_else(|| data.y_label.clone()),
+            .unwrap_or_else(|| escape_hover(&data.y_label)),
     ));
     // an explicit --y-range wins over the pinned global range
     let (ylo, yhi) = if let Some(r) = &args.flag_y_range {
@@ -2770,7 +2772,9 @@ fn build_scatter_encoded(args: &Args) -> CliResult<(Vec<Box<dyn Trace>>, String,
             .color_array(colors)
             .color_scale(ColorScale::Palette(ColorScalePalette::Viridis))
             .show_scale(true)
-            .color_bar(ColorBar::new().title(color_label.clone().unwrap_or_default()));
+            .color_bar(
+                ColorBar::new().title(color_label.as_deref().map(escape_hover).unwrap_or_default()),
+            );
     }
 
     let trace = scatter_with_marker(xs, ys, marker, hover);
@@ -3470,7 +3474,10 @@ fn build_map_plot(args: &Args, out_format: OutFormat) -> CliResult<Plot> {
                 .color_array(colors)
                 .color_scale(ColorScale::Palette(ColorScalePalette::Viridis))
                 .show_scale(true)
-                .color_bar(ColorBar::new().title(color_label.unwrap_or_default()));
+                .color_bar(
+                    ColorBar::new()
+                        .title(color_label.as_deref().map(escape_hover).unwrap_or_default()),
+                );
         }
         plot.add_trace(scatter_map_with_marker(lats, lons, marker, hover));
     }
@@ -3701,7 +3708,10 @@ fn build_geo_plot(args: &Args) -> CliResult<Plot> {
                 .color_array(colors)
                 .color_scale(ColorScale::Palette(ColorScalePalette::Viridis))
                 .show_scale(true)
-                .color_bar(ColorBar::new().title(color_label.unwrap_or_default()));
+                .color_bar(
+                    ColorBar::new()
+                        .title(color_label.as_deref().map(escape_hover).unwrap_or_default()),
+                );
         }
         plot.add_trace(scatter_geo_with_marker(lats, lons, marker, hover));
     }
@@ -5468,7 +5478,7 @@ fn build_choropleth_plot(
             .feature_id_key(args.flag_feature_id_key.as_deref().unwrap_or("id"))
             .color_scale(ColorScale::Palette(palette))
             .show_scale(true)
-            .color_bar(ColorBar::new().title(measure_label))
+            .color_bar(ColorBar::new().title(escape_hover(&measure_label)))
             .marker(
                 ChoroplethMarker::new()
                     .line(Line::new().width(0.5))
@@ -5509,7 +5519,7 @@ fn build_choropleth_plot(
             .location_mode(mode)
             .color_scale(ColorScale::Palette(palette))
             .show_scale(true)
-            .color_bar(ColorBar::new().title(measure_label))
+            .color_bar(ColorBar::new().title(escape_hover(&measure_label)))
             .marker(ChoroplethMarker::new().line(Line::new().width(0.5)))
             .hover_text_array(hover_text)
             .hover_info(HoverInfo::Text);
@@ -8815,7 +8825,13 @@ fn build_layout(
     // x-axis: title (explicit flag, else resolved column label) and/or an optional range-slider
     // navigator strip. Emit the axis when either is set so --rangeslider works even without a
     // title.
-    let x_title = args.flag_x_title.clone().or(default_x);
+    // The FALLBACK is a raw CSV header and axis titles render plotly pseudo-HTML, so it is escaped
+    // like every other data-derived axis title (scatter3d 6119, animated bubble 21943). An explicit
+    // --x-title/--y-title is operator-supplied and stays raw, matching --title above.
+    let x_title = args
+        .flag_x_title
+        .clone()
+        .or_else(|| default_x.as_deref().map(escape_hover));
     if x_title.is_some() || args.flag_rangeslider {
         let mut x = Axis::new();
         if let Some(t) = x_title {
@@ -8828,7 +8844,10 @@ fn build_layout(
     }
     // y-axis: title (flag or column label) and/or an explicit --y-range. Only emit the axis
     // when at least one is set, so the default (autoranging, untitled) case is untouched.
-    let y_title = args.flag_y_title.clone().or(default_y);
+    let y_title = args
+        .flag_y_title
+        .clone()
+        .or_else(|| default_y.as_deref().map(escape_hover));
     if y_title.is_some() || args.flag_y_range.is_some() {
         let mut y = Axis::new();
         if let Some(t) = y_title {
@@ -21403,7 +21422,7 @@ fn smart_inline_panel_plot(
                 .feature_id_key(feature_id_key.clone())
                 .color_scale(ColorScale::Palette(ColorScalePalette::Viridis))
                 .show_scale(true)
-                .color_bar(ColorBar::new().title(measure_label.clone()))
+                .color_bar(ColorBar::new().title(escape_hover(measure_label)))
                 .marker(
                     ChoroplethMarker::new()
                         .line(Line::new().width(0.5))
@@ -21469,7 +21488,7 @@ fn smart_inline_panel_plot(
             .location_mode(location_mode.clone())
             .color_scale(ColorScale::Palette(ColorScalePalette::Viridis))
             .show_scale(true)
-            .color_bar(ColorBar::new().title(measure_label.clone()))
+            .color_bar(ColorBar::new().title(escape_hover(measure_label)))
             .marker(ChoroplethMarker::new().line(Line::new().width(0.5)))
             .hover_text_array(hover_text.clone())
             .hover_info(HoverInfo::Text);

--- a/tests/test_viz.rs
+++ b/tests/test_viz.rs
@@ -11133,12 +11133,16 @@ fn viz_axis_and_colorbar_titles_escape_markup_headers_but_not_flags() {
     let out = wrk.output(&mut cmd);
     assert!(out.status.success());
     let html = String::from_utf8_lossy(&out.stdout);
+    // every assertion below is anchored to the distinctive evil host rather than to a bare
+    // `<a href=`, so unrelated document chrome or an uncompressed embedded plotly bundle can
+    // neither satisfy the positive nor trip the negatives.
     assert!(
-        html.contains(r"\u0026lt;a href="),
+        html.contains(r#"\u0026lt;a href=\"https://evil.example\"\u0026gt;Amount"#),
         "the colorbar title must be escaped, not rendered as a live link"
     );
     assert!(
-        !html.contains(r"\u003ca href=") && !html.contains("<a href="),
+        !html.contains(r#"\u003ca href=\"https://evil.example"#)
+            && !html.contains(r#"<a href="https://evil.example"#),
         "raw markup header leaked into the colorbar title"
     );
 }

--- a/tests/test_viz.rs
+++ b/tests/test_viz.rs
@@ -11062,3 +11062,83 @@ fn viz_smart_notes_and_drops_dictionary_with_no_headers() {
         "the dashboard must still render from statistics alone; html: {html}"
     );
 }
+
+// Axis titles go through plotly's pseudo-HTML text renderer, so a CSV header containing markup
+// would render as live markup (a `<a href>` link, a `<b>` bold, a `<span style>` — the same
+// spoofing sink already closed for the panel title and the 3D/animated-bubble axis titles).
+// The standalone chart paths (`build_layout`, and the --slider layout) resolved their axis title
+// from the raw header, so they were the twins that kept the sink open.
+// An explicit --x-title/--y-title is operator-supplied and deliberately stays raw, like --title.
+#[test]
+fn viz_axis_and_colorbar_titles_escape_markup_headers_but_not_flags() {
+    let wrk = Workdir::new("viz_axis_and_colorbar_titles_escape_markup_headers_but_not_flags");
+    wrk.create_from_string(
+        "evil.csv",
+        "<b>Region</b>,<a href=\"https://evil.example\">Amount</a>\nnorth,10\nsouth,20\n",
+    );
+    let x = "<b>Region</b>";
+    let y = "<a href=\"https://evil.example\">Amount</a>";
+
+    let mut cmd = wrk.command("viz");
+    cmd.args(["bar", "evil.csv", "--x", x, "--y", y]);
+    let out = wrk.output(&mut cmd);
+    assert!(out.status.success());
+    let html = String::from_utf8_lossy(&out.stdout);
+
+    // `escape_hover` turns the header into `&lt;b&gt;...`, then plotly's serializer additionally
+    // \u-escapes the `&`, so the axis title reaches the page as literal text -- never a tag.
+    assert!(
+        html.contains(r"\u0026lt;b\u0026gt;Region\u0026lt;/b\u0026gt;"),
+        "the x-axis title must be escaped, not rendered as markup"
+    );
+    assert!(
+        html.contains(r"\u0026lt;a href="),
+        "the y-axis title must be escaped, not rendered as a live link"
+    );
+    // the unescaped header must not survive in either serialized form
+    assert!(
+        !html.contains(r"\u003cb\u003eRegion") && !html.contains("<b>Region"),
+        "raw markup header leaked into an axis title"
+    );
+
+    // an explicit --x-title is operator-supplied and deliberately stays raw, like --title
+    let mut cmd = wrk.command("viz");
+    cmd.args([
+        "bar",
+        "evil.csv",
+        "--x",
+        x,
+        "--y",
+        y,
+        "--x-title",
+        "<b>Mine</b>",
+    ]);
+    let out = wrk.output(&mut cmd);
+    assert!(out.status.success());
+    let html = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        html.contains(r"\u003cb\u003eMine\u003c/b\u003e"),
+        "an explicit --x-title is operator-supplied and must not be escaped"
+    );
+
+    // colorbar titles are the same plotly markup sink, resolved from the same raw headers. The
+    // scatter builder already escaped this very variable for the HOVER text while passing it raw
+    // to the colorbar, so it drew a live link as the scale title.
+    wrk.create_from_string(
+        "cb.csv",
+        "x,y,<a href=\"https://evil.example\">Amount</a>\n1,2,3\n4,5,6\n",
+    );
+    let mut cmd = wrk.command("viz");
+    cmd.args(["scatter", "cb.csv", "--x", "x", "--y", "y", "--color", y]);
+    let out = wrk.output(&mut cmd);
+    assert!(out.status.success());
+    let html = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        html.contains(r"\u0026lt;a href="),
+        "the colorbar title must be escaped, not rendered as a live link"
+    );
+    assert!(
+        !html.contains(r"\u003ca href=") && !html.contains("<a href="),
+        "raw markup header leaked into the colorbar title"
+    );
+}


### PR DESCRIPTION
## Summary

Axis and colorbar titles render plotly pseudo-HTML. The escaping sweep in #4247 fixed the sites it found and left their **standalone twins** unescaped — 11 sites, all resolving their label from `col_label(&headers, ..)`, i.e. a raw CSV header.

A header like `<a href="https://evil.example">Amount</a>` drew a **live clickable link** as the axis or colorbar title. Same spoofing class as the panel-title finding (`display_title_with_icon`) that #4247 *did* fix. Script execution stays blocked by plotly's tag whitelist, so this is spoofing/phishing, not XSS.

| Sink | Already escaped | Was NOT escaped (fixed here) |
|---|---|---|
| Axis title | scatter3d, smart 3D, animated bubble | `build_layout` x/y fallback, `--slider` layout `data.x_label`/`data.y_label` |
| Colorbar title | scatter3d | scatter, map, geo, both choropleth builders, both smart choropleth renderers |

The scatter builder was the clearest tell: it escapes `color_label` for the **hover** text, then passed **that same variable** raw to the colorbar a few lines later. Likewise `choropleth_hover_text` escapes `measure_label` internally while the colorbar title beside it did not.

## Behaviour

Only the **data-derived** label is escaped. An explicit `--x-title`/`--y-title` is operator-supplied and stays raw, matching the existing `--title` behaviour.

## Testing

New `viz_axis_and_colorbar_titles_escape_markup_headers_but_not_flags` pins all three directions (escaped axis title, escaped colorbar title, raw operator flag).

Each half was verified to fail **independently** against the pre-fix code — reverting only the colorbar hunks trips only the colorbar assertion, so neither assertion is riding on the other.

- 230 in-file + 315 `test_viz` integration tests pass
- `cargo clippy --bin qsv -F all_features` clean
- `qsv` and `qsvlite` both build

## Context

This is the **fourth** occurrence of the "fix applied to the smart path but not its standalone twin" pattern on this file. The durable rule: on any viz escaping change, don't fix only the site you found — grep every call site of the *sink* (`.title(`, `.name(`, `hover_template`), because the escaped exemplar and the unescaped twin routinely sit in the same function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)