### PR TITLE
chore(viz): refresh the 5 example dashboards #4295 left on the old chrome

### DIFF
--- a/examples/viz/smart_dict_sunburst.html
+++ b/examples/viz/smart_dict_sunburst.html
@@ -10,7 +10,12 @@
   h1.qsv-viz-title { font-size: 20px; font-weight: 600; text-align: center; margin: 8px 0 20px; }
   .qsv-viz-geo-meta { font-size: 13px; color: var(--qsv-geo-meta); text-align: center; padding: 8px 4px 4px; }
   .qsv-viz-dict-link { font-size: 13px; text-align: center; margin: -12px 0 16px; }
-  .qsv-viz-dict-link a { color: var(--qsv-geo-meta); }
+  /* A bordered pill rather than the muted caption color the geo meta line uses: this is the only
+     way into the dictionary, and as plain --qsv-geo-meta text it read as a caption, not a link. */
+  .qsv-viz-dict-link a, .qsv-viz-dict-link a:visited { display: inline-flex; align-items: center; gap: 6px; padding: 3px 12px; border: 1px solid var(--qsv-link); border-radius: 999px; color: var(--qsv-link); font-weight: 600; text-decoration: none; }
+  .qsv-viz-dict-link a:hover, .qsv-viz-dict-link a:focus-visible { color: var(--qsv-link-hover); border-color: var(--qsv-link-hover); background: color-mix(in srgb, var(--qsv-link) 14%, transparent); }
+  /* sized in em so each glyph tracks the font-size of the link it suffixes */
+  .qsv-link-icon { width: 1.05em; height: 1.05em; flex: none; vertical-align: -0.15em; }
   table.qsv-viz-meta { margin: 0 auto 20px; border-collapse: collapse; font-size: 13px; }
   table.qsv-viz-meta td { padding: 2px 10px; vertical-align: top; }
   table.qsv-viz-meta td.qsv-viz-meta-k { color: var(--qsv-geo-meta); text-align: right; white-space: nowrap; }
@@ -25,8 +30,8 @@
   body.qsv-dark #qsv-logo .qsv-logo-light { display: none; }
   body.qsv-dark #qsv-logo .qsv-logo-dark { display: block; }
   body.qsv-dark #qsv-logo img { filter: drop-shadow(0 0 2px rgba(255, 255, 255, 0.6)) drop-shadow(0 0 1px rgba(255, 255, 255, 0.45)); }
-  :root { --qsv-page-bg: #FFFFFF; --qsv-page-ink: #2A3F5F; --qsv-geo-meta: #4b5563; }
-  body.qsv-dark { --qsv-page-bg: #111111; --qsv-page-ink: #f2f5fa; --qsv-geo-meta: #9aa4b2; }
+  :root { --qsv-page-bg: #FFFFFF; --qsv-page-ink: #2A3F5F; --qsv-geo-meta: #4b5563; --qsv-link: #0a5fb4; --qsv-link-hover: #084b8f; }
+  body.qsv-dark { --qsv-page-bg: #111111; --qsv-page-ink: #f2f5fa; --qsv-geo-meta: #9aa4b2; --qsv-link: #6cb6ff; --qsv-link-hover: #9ecbff; }
   /* Bottom-right, stacked just above the #qsv-logo: keeps the toggle clear of the Plotly modebar
      (always top-right, and hover-revealed) — which would otherwise overlap and block the modebar's
      rightmost buttons, including the fullscreen toggle — and of the geo extent menus (top-left). */
@@ -45,10 +50,10 @@
 <h1 class="qsv-viz-title">sales_sample.csv — data overview</h1>
 
 <table class="qsv-viz-meta">
-<tr><td class="qsv-viz-meta-k">Rows:</td><td>500 <a href="#" class="qsv-data-link" onclick="return qsvOpenData()">(Explore)</a></td></tr>
+<tr><td class="qsv-viz-meta-k">Rows:</td><td>500 <a href="#" class="qsv-data-link" onclick="return qsvOpenData()">(Explore)<svg class="qsv-link-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><rect x="1.7" y="2.6" width="12.6" height="10.8" rx="1.4"/><path d="M1.7 6.2h12.6M1.7 9.8h12.6M6.2 6.2v7.2M10.2 6.2v7.2"/></svg></a></td></tr>
 <tr><td class="qsv-viz-meta-k">Columns:</td><td>13</td></tr>
 <tr><td class="qsv-viz-meta-k">Completeness:</td><td>100.0%</td></tr>
-<tr><td class="qsv-viz-meta-k">Compiled:</td><td>2026-07-28 00:27 UTC</td></tr>
+<tr><td class="qsv-viz-meta-k">Compiled:</td><td>2026-07-28 02:25 UTC</td></tr>
 </table>
 <div class="qsv-viz-grid">
     <div class="qsv-viz-cell full-width">
@@ -683,7 +688,10 @@
      and `fixed` is not an option — Responsive picks what to collapse by measuring natural
      column widths, which fixed layout flattens. */
   #qsv-data-table td, #qsv-data-table thead th { overflow-wrap: anywhere; }
-  .qsv-viz-meta a.qsv-data-link { font-size: 0.9em; }
+  /* theme-aware: left to the UA default this is #0000EE, then #551A8B once visited — both
+     unreadable on dark paper, and href="#" means one click marks it visited forever */
+  .qsv-viz-meta a.qsv-data-link, .qsv-viz-meta a.qsv-data-link:visited { font-size: 0.9em; font-weight: 600; color: var(--qsv-link, #0a5fb4); text-decoration: none; display: inline-flex; align-items: center; gap: 4px; }
+  .qsv-viz-meta a.qsv-data-link:hover, .qsv-viz-meta a.qsv-data-link:focus-visible { color: var(--qsv-link-hover, #084b8f); text-decoration: underline; }
 </style>
 <script>
 (function () {

--- a/examples/viz/smart_dict_treemap.html
+++ b/examples/viz/smart_dict_treemap.html
@@ -10,7 +10,12 @@
   h1.qsv-viz-title { font-size: 20px; font-weight: 600; text-align: center; margin: 8px 0 20px; }
   .qsv-viz-geo-meta { font-size: 13px; color: var(--qsv-geo-meta); text-align: center; padding: 8px 4px 4px; }
   .qsv-viz-dict-link { font-size: 13px; text-align: center; margin: -12px 0 16px; }
-  .qsv-viz-dict-link a { color: var(--qsv-geo-meta); }
+  /* A bordered pill rather than the muted caption color the geo meta line uses: this is the only
+     way into the dictionary, and as plain --qsv-geo-meta text it read as a caption, not a link. */
+  .qsv-viz-dict-link a, .qsv-viz-dict-link a:visited { display: inline-flex; align-items: center; gap: 6px; padding: 3px 12px; border: 1px solid var(--qsv-link); border-radius: 999px; color: var(--qsv-link); font-weight: 600; text-decoration: none; }
+  .qsv-viz-dict-link a:hover, .qsv-viz-dict-link a:focus-visible { color: var(--qsv-link-hover); border-color: var(--qsv-link-hover); background: color-mix(in srgb, var(--qsv-link) 14%, transparent); }
+  /* sized in em so each glyph tracks the font-size of the link it suffixes */
+  .qsv-link-icon { width: 1.05em; height: 1.05em; flex: none; vertical-align: -0.15em; }
   table.qsv-viz-meta { margin: 0 auto 20px; border-collapse: collapse; font-size: 13px; }
   table.qsv-viz-meta td { padding: 2px 10px; vertical-align: top; }
   table.qsv-viz-meta td.qsv-viz-meta-k { color: var(--qsv-geo-meta); text-align: right; white-space: nowrap; }
@@ -25,8 +30,8 @@
   body.qsv-dark #qsv-logo .qsv-logo-light { display: none; }
   body.qsv-dark #qsv-logo .qsv-logo-dark { display: block; }
   body.qsv-dark #qsv-logo img { filter: drop-shadow(0 0 2px rgba(255, 255, 255, 0.6)) drop-shadow(0 0 1px rgba(255, 255, 255, 0.45)); }
-  :root { --qsv-page-bg: #FFFFFF; --qsv-page-ink: #2A3F5F; --qsv-geo-meta: #4b5563; }
-  body.qsv-dark { --qsv-page-bg: #111111; --qsv-page-ink: #f2f5fa; --qsv-geo-meta: #9aa4b2; }
+  :root { --qsv-page-bg: #FFFFFF; --qsv-page-ink: #2A3F5F; --qsv-geo-meta: #4b5563; --qsv-link: #0a5fb4; --qsv-link-hover: #084b8f; }
+  body.qsv-dark { --qsv-page-bg: #111111; --qsv-page-ink: #f2f5fa; --qsv-geo-meta: #9aa4b2; --qsv-link: #6cb6ff; --qsv-link-hover: #9ecbff; }
   /* Bottom-right, stacked just above the #qsv-logo: keeps the toggle clear of the Plotly modebar
      (always top-right, and hover-revealed) — which would otherwise overlap and block the modebar's
      rightmost buttons, including the fullscreen toggle — and of the geo extent menus (top-left). */
@@ -45,10 +50,10 @@
 <h1 class="qsv-viz-title">customer_spend.csv — data overview</h1>
 
 <table class="qsv-viz-meta">
-<tr><td class="qsv-viz-meta-k">Rows:</td><td>300 <a href="#" class="qsv-data-link" onclick="return qsvOpenData()">(Explore)</a></td></tr>
+<tr><td class="qsv-viz-meta-k">Rows:</td><td>300 <a href="#" class="qsv-data-link" onclick="return qsvOpenData()">(Explore)<svg class="qsv-link-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><rect x="1.7" y="2.6" width="12.6" height="10.8" rx="1.4"/><path d="M1.7 6.2h12.6M1.7 9.8h12.6M6.2 6.2v7.2M10.2 6.2v7.2"/></svg></a></td></tr>
 <tr><td class="qsv-viz-meta-k">Columns:</td><td>5</td></tr>
 <tr><td class="qsv-viz-meta-k">Completeness:</td><td>100.0%</td></tr>
-<tr><td class="qsv-viz-meta-k">Compiled:</td><td>2026-07-28 00:23 UTC</td></tr>
+<tr><td class="qsv-viz-meta-k">Compiled:</td><td>2026-07-28 02:25 UTC</td></tr>
 </table>
 <div class="qsv-viz-grid">
     <div class="qsv-viz-cell full-width">
@@ -619,7 +624,10 @@
      and `fixed` is not an option — Responsive picks what to collapse by measuring natural
      column widths, which fixed layout flattens. */
   #qsv-data-table td, #qsv-data-table thead th { overflow-wrap: anywhere; }
-  .qsv-viz-meta a.qsv-data-link { font-size: 0.9em; }
+  /* theme-aware: left to the UA default this is #0000EE, then #551A8B once visited — both
+     unreadable on dark paper, and href="#" means one click marks it visited forever */
+  .qsv-viz-meta a.qsv-data-link, .qsv-viz-meta a.qsv-data-link:visited { font-size: 0.9em; font-weight: 600; color: var(--qsv-link, #0a5fb4); text-decoration: none; display: inline-flex; align-items: center; gap: 4px; }
+  .qsv-viz-meta a.qsv-data-link:hover, .qsv-viz-meta a.qsv-data-link:focus-visible { color: var(--qsv-link-hover, #084b8f); text-decoration: underline; }
 </style>
 <script>
 (function () {

--- a/examples/viz/smart_geospatial.html
+++ b/examples/viz/smart_geospatial.html
@@ -10,7 +10,12 @@
   h1.qsv-viz-title { font-size: 20px; font-weight: 600; text-align: center; margin: 8px 0 20px; }
   .qsv-viz-geo-meta { font-size: 13px; color: var(--qsv-geo-meta); text-align: center; padding: 8px 4px 4px; }
   .qsv-viz-dict-link { font-size: 13px; text-align: center; margin: -12px 0 16px; }
-  .qsv-viz-dict-link a { color: var(--qsv-geo-meta); }
+  /* A bordered pill rather than the muted caption color the geo meta line uses: this is the only
+     way into the dictionary, and as plain --qsv-geo-meta text it read as a caption, not a link. */
+  .qsv-viz-dict-link a, .qsv-viz-dict-link a:visited { display: inline-flex; align-items: center; gap: 6px; padding: 3px 12px; border: 1px solid var(--qsv-link); border-radius: 999px; color: var(--qsv-link); font-weight: 600; text-decoration: none; }
+  .qsv-viz-dict-link a:hover, .qsv-viz-dict-link a:focus-visible { color: var(--qsv-link-hover); border-color: var(--qsv-link-hover); background: color-mix(in srgb, var(--qsv-link) 14%, transparent); }
+  /* sized in em so each glyph tracks the font-size of the link it suffixes */
+  .qsv-link-icon { width: 1.05em; height: 1.05em; flex: none; vertical-align: -0.15em; }
   table.qsv-viz-meta { margin: 0 auto 20px; border-collapse: collapse; font-size: 13px; }
   table.qsv-viz-meta td { padding: 2px 10px; vertical-align: top; }
   table.qsv-viz-meta td.qsv-viz-meta-k { color: var(--qsv-geo-meta); text-align: right; white-space: nowrap; }
@@ -25,8 +30,8 @@
   body.qsv-dark #qsv-logo .qsv-logo-light { display: none; }
   body.qsv-dark #qsv-logo .qsv-logo-dark { display: block; }
   body.qsv-dark #qsv-logo img { filter: drop-shadow(0 0 2px rgba(255, 255, 255, 0.6)) drop-shadow(0 0 1px rgba(255, 255, 255, 0.45)); }
-  :root { --qsv-page-bg: #111111; --qsv-page-ink: #f2f5fa; --qsv-geo-meta: #9aa4b2; }
-  body.qsv-dark { --qsv-page-bg: #111111; --qsv-page-ink: #f2f5fa; --qsv-geo-meta: #9aa4b2; }
+  :root { --qsv-page-bg: #111111; --qsv-page-ink: #f2f5fa; --qsv-geo-meta: #9aa4b2; --qsv-link: #6cb6ff; --qsv-link-hover: #9ecbff; }
+  body.qsv-dark { --qsv-page-bg: #111111; --qsv-page-ink: #f2f5fa; --qsv-geo-meta: #9aa4b2; --qsv-link: #6cb6ff; --qsv-link-hover: #9ecbff; }
   /* Bottom-right, stacked just above the #qsv-logo: keeps the toggle clear of the Plotly modebar
      (always top-right, and hover-revealed) — which would otherwise overlap and block the modebar's
      rightmost buttons, including the fullscreen toggle — and of the geo extent menus (top-left). */
@@ -45,10 +50,10 @@
 <h1 class="qsv-viz-title">seismic_events.csv — data overview</h1>
 
 <table class="qsv-viz-meta">
-<tr><td class="qsv-viz-meta-k">Rows:</td><td>417 <a href="#" class="qsv-data-link" onclick="return qsvOpenData()">(Explore)</a></td></tr>
+<tr><td class="qsv-viz-meta-k">Rows:</td><td>417 <a href="#" class="qsv-data-link" onclick="return qsvOpenData()">(Explore)<svg class="qsv-link-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><rect x="1.7" y="2.6" width="12.6" height="10.8" rx="1.4"/><path d="M1.7 6.2h12.6M1.7 9.8h12.6M6.2 6.2v7.2M10.2 6.2v7.2"/></svg></a></td></tr>
 <tr><td class="qsv-viz-meta-k">Columns:</td><td>9</td></tr>
 <tr><td class="qsv-viz-meta-k">Completeness:</td><td>100.0%</td></tr>
-<tr><td class="qsv-viz-meta-k">Compiled:</td><td>2026-07-28 00:19 UTC</td></tr>
+<tr><td class="qsv-viz-meta-k">Compiled:</td><td>2026-07-28 02:25 UTC</td></tr>
 </table>
 <div class="qsv-viz-grid">
     <div class="qsv-viz-cell full-width">
@@ -684,7 +689,10 @@
      and `fixed` is not an option — Responsive picks what to collapse by measuring natural
      column widths, which fixed layout flattens. */
   #qsv-data-table td, #qsv-data-table thead th { overflow-wrap: anywhere; }
-  .qsv-viz-meta a.qsv-data-link { font-size: 0.9em; }
+  /* theme-aware: left to the UA default this is #0000EE, then #551A8B once visited — both
+     unreadable on dark paper, and href="#" means one click marks it visited forever */
+  .qsv-viz-meta a.qsv-data-link, .qsv-viz-meta a.qsv-data-link:visited { font-size: 0.9em; font-weight: 600; color: var(--qsv-link, #0a5fb4); text-decoration: none; display: inline-flex; align-items: center; gap: 4px; }
+  .qsv-viz-meta a.qsv-data-link:hover, .qsv-viz-meta a.qsv-data-link:focus-visible { color: var(--qsv-link-hover, #084b8f); text-decoration: underline; }
 </style>
 <script>
 (function () {

--- a/examples/viz/smart_world_choropleth.html
+++ b/examples/viz/smart_world_choropleth.html
@@ -10,7 +10,12 @@
   h1.qsv-viz-title { font-size: 20px; font-weight: 600; text-align: center; margin: 8px 0 20px; }
   .qsv-viz-geo-meta { font-size: 13px; color: var(--qsv-geo-meta); text-align: center; padding: 8px 4px 4px; }
   .qsv-viz-dict-link { font-size: 13px; text-align: center; margin: -12px 0 16px; }
-  .qsv-viz-dict-link a { color: var(--qsv-geo-meta); }
+  /* A bordered pill rather than the muted caption color the geo meta line uses: this is the only
+     way into the dictionary, and as plain --qsv-geo-meta text it read as a caption, not a link. */
+  .qsv-viz-dict-link a, .qsv-viz-dict-link a:visited { display: inline-flex; align-items: center; gap: 6px; padding: 3px 12px; border: 1px solid var(--qsv-link); border-radius: 999px; color: var(--qsv-link); font-weight: 600; text-decoration: none; }
+  .qsv-viz-dict-link a:hover, .qsv-viz-dict-link a:focus-visible { color: var(--qsv-link-hover); border-color: var(--qsv-link-hover); background: color-mix(in srgb, var(--qsv-link) 14%, transparent); }
+  /* sized in em so each glyph tracks the font-size of the link it suffixes */
+  .qsv-link-icon { width: 1.05em; height: 1.05em; flex: none; vertical-align: -0.15em; }
   table.qsv-viz-meta { margin: 0 auto 20px; border-collapse: collapse; font-size: 13px; }
   table.qsv-viz-meta td { padding: 2px 10px; vertical-align: top; }
   table.qsv-viz-meta td.qsv-viz-meta-k { color: var(--qsv-geo-meta); text-align: right; white-space: nowrap; }
@@ -25,8 +30,8 @@
   body.qsv-dark #qsv-logo .qsv-logo-light { display: none; }
   body.qsv-dark #qsv-logo .qsv-logo-dark { display: block; }
   body.qsv-dark #qsv-logo img { filter: drop-shadow(0 0 2px rgba(255, 255, 255, 0.6)) drop-shadow(0 0 1px rgba(255, 255, 255, 0.45)); }
-  :root { --qsv-page-bg: #FFFFFF; --qsv-page-ink: #2A3F5F; --qsv-geo-meta: #4b5563; }
-  body.qsv-dark { --qsv-page-bg: #111111; --qsv-page-ink: #f2f5fa; --qsv-geo-meta: #9aa4b2; }
+  :root { --qsv-page-bg: #FFFFFF; --qsv-page-ink: #2A3F5F; --qsv-geo-meta: #4b5563; --qsv-link: #0a5fb4; --qsv-link-hover: #084b8f; }
+  body.qsv-dark { --qsv-page-bg: #111111; --qsv-page-ink: #f2f5fa; --qsv-geo-meta: #9aa4b2; --qsv-link: #6cb6ff; --qsv-link-hover: #9ecbff; }
   /* Bottom-right, stacked just above the #qsv-logo: keeps the toggle clear of the Plotly modebar
      (always top-right, and hover-revealed) — which would otherwise overlap and block the modebar's
      rightmost buttons, including the fullscreen toggle — and of the geo extent menus (top-left). */
@@ -45,10 +50,10 @@
 <h1 class="qsv-viz-title">world_cities.csv — data overview</h1>
 
 <table class="qsv-viz-meta">
-<tr><td class="qsv-viz-meta-k">Rows:</td><td>1,179 <a href="#" class="qsv-data-link" onclick="return qsvOpenData()">(Preview)</a></td></tr>
+<tr><td class="qsv-viz-meta-k">Rows:</td><td>1,179 <a href="#" class="qsv-data-link" onclick="return qsvOpenData()">(Preview)<svg class="qsv-link-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><rect x="1.7" y="2.6" width="12.6" height="10.8" rx="1.4"/><path d="M1.7 6.2h12.6M1.7 9.8h12.6M6.2 6.2v7.2M10.2 6.2v7.2"/></svg></a></td></tr>
 <tr><td class="qsv-viz-meta-k">Columns:</td><td>8</td></tr>
 <tr><td class="qsv-viz-meta-k">Completeness:</td><td>100.0%</td></tr>
-<tr><td class="qsv-viz-meta-k">Compiled:</td><td>2026-07-28 00:30 UTC</td></tr>
+<tr><td class="qsv-viz-meta-k">Compiled:</td><td>2026-07-28 02:25 UTC</td></tr>
 </table>
 <div class="qsv-viz-grid">
     <div class="qsv-viz-cell full-width">
@@ -651,7 +656,10 @@
      and `fixed` is not an option — Responsive picks what to collapse by measuring natural
      column widths, which fixed layout flattens. */
   #qsv-data-table td, #qsv-data-table thead th { overflow-wrap: anywhere; }
-  .qsv-viz-meta a.qsv-data-link { font-size: 0.9em; }
+  /* theme-aware: left to the UA default this is #0000EE, then #551A8B once visited — both
+     unreadable on dark paper, and href="#" means one click marks it visited forever */
+  .qsv-viz-meta a.qsv-data-link, .qsv-viz-meta a.qsv-data-link:visited { font-size: 0.9em; font-weight: 600; color: var(--qsv-link, #0a5fb4); text-decoration: none; display: inline-flex; align-items: center; gap: 4px; }
+  .qsv-viz-meta a.qsv-data-link:hover, .qsv-viz-meta a.qsv-data-link:focus-visible { color: var(--qsv-link-hover, #084b8f); text-decoration: underline; }
 </style>
 <script>
 (function () {


### PR DESCRIPTION
Follow-up to #4295. Five committed example dashboards were still rendering the pre-#4295 link styling.

## Why they were missed

- **Four `--dictionary infer` dashboards** (`smart_dict_treemap`, `smart_dict_sunburst`, `smart_world_choropleth`, `smart_geospatial`) are in `gen_gallery.py`'s `PREGENERATED` set, so a normal run *reuses* their committed HTML rather than rebuilding it — that's what keeps a plain regen LLM-free and deterministic.
- **`smart_boston_311_2025`** was missed for a different reason: its gallery entry carries only a documentation `cmd` string with no `args`, so the generator never rebuilds it at all.

## No LLM was contacted

Regenerated the four with `QSV_VIZ_REGEN_LLM=1`. Level 1 *cannot* reach the LLM — `viz smart --dictionary infer` reuses the existing `<stem>.schema.json` sidecar, and `cleanup_sidecars()` sweeps only stats/idx caches, never the schema sidecars. Verified by md5ing all four sidecars before and after; byte-identical.

Level 2 is the one that deletes sidecars and exports `QSV_VIZ_DICT_FRESH=1` to force genuine re-inference. Deliberately not used: only the rendering changed, not the dictionaries. (Its own comment says as much — *"=1 remains right when only the dashboard rendering changed"*.)

## Boston was patched in place

Its source (`boston311-2025.tsv`, 267,187 rows, plus `boston_neighborhood_boundaries.json`) isn't in the repo, so regeneration isn't possible here. Instead the six replacement strings were lifted **verbatim** from freshly generated dashboards — CSS from `smart_dict_treemap` (same default theme, so the `:root`/`body.qsv-dark` lines match exactly), link markup from `smart_allegheny_dogs` (has both a dict link and a `(Preview)` link) — with each anchor asserted unique before substitution, so a partial or duplicated match would abort rather than corrupt a 21.5 MB file.

Post-checks: all six new strings appear exactly once and byte-match the reference, no stale rule survives, `<svg>`/`</svg>` balance 2/2. The resulting diff is **14 added / 6 removed**, identical in shape to the four genuinely regenerated dashboards.

Its `Compiled:` timestamp is deliberately left alone — the data wasn't recompiled, only the chrome restyled.

## Diff hygiene

The other 13 dashboards were regenerated too, then reverted: their only diff was the `Compiled:` timestamp — and for the two with an embedded stats sidecar, `date_generated`/`compute_duration_ms` inside the base64 plus the content-hash window key, which I decoded to confirm. Not worth committing.

## Verification

Loaded the full 21.5 MB Boston page in-browser: both maps draw, the Data Dictionary drawer and the data drawer (`first 50,000 of 267,187 rows`) both open, pill and grid icon render, and a post-click computed-color read confirms `:visited` holds. All 18 `smart_*.html` now carry `qsv-link-icon`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)