### PR TITLE
fix(mcp): honor QSV_NO_COWORK_SETUP in the MCP-server auto-deploy path

### DIFF
--- a/.claude/skills/src/mcp-server.ts
+++ b/.claude/skills/src/mcp-server.ts
@@ -1160,6 +1160,12 @@ class QsvMcpServer {
    * Only runs in plugin mode. Silently skips if the file already exists or on any error.
    */
   private async deployWorkflowGuide(): Promise<void> {
+    // Honor the QSV_NO_COWORK_SETUP=1 opt-out, matching the cowork-setup.cjs
+    // SessionStart hook this path replaces in Cowork.
+    if (process.env.QSV_NO_COWORK_SETUP === "1") {
+      console.error("[Deploy] QSV_NO_COWORK_SETUP=1 — skipping workflow guide deployment");
+      return;
+    }
     try {
       const workingDir = this.executor.getWorkingDirectory();
 


### PR DESCRIPTION
`QSV_NO_COWORK_SETUP=1` is documented as the opt-out for the automatic `CLAUDE.md` workflow-guide deployment, and `.claude/skills/scripts/cowork-setup.cjs` honors it (line 234). But `QsvMcpServer.deployWorkflowGuide()` — the path that **replaces** that SessionStart hook when running in Cowork — never checked it, so a user who set the variable still got `CLAUDE.md` deployed.

This adds the same guard, using the same `=== "1"` comparison as the hook.

## Where the variable is documented (all already on master)

- `docs/ENVIRONMENT_VARIABLES.md`
- `.claude/skills/cowork-CLAUDE.md` — *"To disable auto-deployment, set `QSV_NO_COWORK_SETUP=1` in your shell environment before launching Claude Code."*
- `.claude/skills/scripts/cowork-setup.cjs:234` — honors it

So this is documented-behavior drift rather than a new feature: the escape hatch worked through one entry point and was silently ignored through the other.

## Provenance

The fix was written on 2026-06-20 (`2a5874e60`) and never merged. Cherry-picked onto current master rather than opened from the five-week-old base; it applied cleanly, and `npx tsc --noEmit -p tsconfig.json` in `.claude/skills` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LdPPPTPY4yp1jHBQe9RQr