### PR TITLE
fix(PGO): bound moarstats --bivariate training data to stop runner OOM

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -152,7 +152,13 @@ jobs:
             addl-rustflags:
             # native ARM runner - PGO the qsv binary. The PGO optimize build is one more
             # fat-LTO link of the same qsv that already builds here, so memory use matches
-            # today's working build. If it ever OOMs, set pgo-lto: thin as the escape hatch.
+            # today's working build. If the OPTIMIZE/LINK step OOMs, set pgo-lto: thin as
+            # the escape hatch.
+            # NOTE: pgo-lto does NOT help a TRAIN-step OOM. Training runs the instrumented
+            # binary over the 1M-row NYC 311 file, and a training command that needs more
+            # than the runner's ~15.5 GiB kills the runner VM (exit 143, "runner has
+            # received a shutdown signal") - it looks like a link failure but is not.
+            # See the moarstats --bivariate note in scripts/pgo-train.sh.
             pgo: true
             pgo-train-flags:
             pgo-lto:

--- a/scripts/pgo-train.sh
+++ b/scripts/pgo-train.sh
@@ -211,20 +211,35 @@ t moarstats --advanced "$data"
 #      25,000 rows ->  3.03 GiB                      15,000 -> 2.35 GiB
 # 50k keeps the parallel path (5x PARALLEL_THRESHOLD) at ~26% of a hosted runner's RAM.
 biv_data="$data"
+biv_bounded=0
 if [[ "$minimal" -eq 0 ]]; then
   biv_slice=pgo_train_bivariate.csv
   if "$qsv_bin" slice --len 50000 "$data" --output "$biv_slice" >/dev/null 2>&1; then
     # index so the bivariate parallel path (not the sequential fallback) gets trained
     "$qsv_bin" index "$biv_slice" >/dev/null 2>&1 || true
     biv_data="$biv_slice"
+    biv_bounded=1
   else
-    echo "    (bivariate slice failed; falling back to full training data)"
+    echo "    (bivariate slice failed; skipping the --bivariate-stats all variants)"
   fi
+else
+  # minimal-mode data is already tiny (20k rows x 6 cols = 15 pairs), so it is bounded
+  biv_bounded=1
 fi
+
+# Default --bivariate-stats (fast = pearson + covariance) streams and is safe even on the
+# full file: in run 31069999861 aarch64 ran this over all 1M rows in 41s and survived.
 t moarstats --bivariate "$biv_data"
-t moarstats --bivariate --bivariate-stats all "$biv_data"
 t moarstats --advanced --bivariate "$biv_data"
-t moarstats --advanced --bivariate --bivariate-stats all "$biv_data"
+
+# The "all" variants are the OOM risk, so run them ONLY against bounded input. Do NOT fall
+# back to the full file when the slice is unavailable - `t` tolerates a SKIPPED command
+# (harmless), but running this on 1M rows re-arms the 23 GiB workload that kills the runner
+# outright, taking the rest of training with it.
+if [[ "$biv_bounded" -eq 1 ]]; then
+  t moarstats --bivariate --bivariate-stats all "$biv_data"
+  t moarstats --advanced --bivariate --bivariate-stats all "$biv_data"
+fi
 t blake3 "$data"
 t luau map newcol "1 + 1" "$data"
 t profile "$data"

--- a/scripts/pgo-train.sh
+++ b/scripts/pgo-train.sh
@@ -180,10 +180,51 @@ t snappy validate pgo_train.snappy
 t validate "$data"
 t moarstats "$data"
 t moarstats --advanced "$data"
-t moarstats --bivariate "$data"
-t moarstats --bivariate --bivariate-stats all "$data"
-t moarstats --advanced --bivariate "$data"
-t moarstats --advanced --bivariate --bivariate-stats all "$data"
+
+# `--bivariate-stats all` is the memory bomb, not `--bivariate` itself. The default
+# (--bivariate-stats fast = pearson + covariance) uses streaming algorithms and stays cheap,
+# which is why plain `--bivariate` finishes in ~40s. Passing "all" additionally enables
+# mi/nmi/u, and those make EVERY field pair accumulate a joint-frequency
+# HashMap<(String, String), u64> keyed by owned strings: on the 1M-row/41-column training
+# file that is 780 pairs x up to 1M distinct (String, String) keys. (spearman/kendall also
+# keep Vec<f64> value vectors, but x_values.push only fires when both sides parse numeric,
+# so that covers just the ~36 numeric/date pairs - a minor term next to the hashmaps.)
+# The -C/--cardinality-threshold guard that would skip MI for high-cardinality fields
+# defaults to 1000000 - exactly the row count here - so it never engages.
+#
+# Measured peak RSS: 23.0 GiB. A GitHub hosted runner has 15.57 GiB, so this OOM-kills the runner
+# VM outright; the agent dies, the `t` helper below never sees an exit code, and training
+# just stops. This is not arch-specific - in run 31069999861 BOTH full-training targets
+# died on this exact command with "runner has received a shutdown signal" / exit 143:
+# aarch64-unknown-linux-gnu (job 92515824811) and x86_64-unknown-linux-gnu (job
+# 92515824877). Windows escapes it only because it trains with --minimal.
+#
+# Train these paths on a bounded slice instead. PGO records WHICH branches execute, not how
+# many rows flow through them, so a slice buys the same profile coverage. The slice is
+# indexed on purpose: compute_all_bivariatestats() only takes the parallel chunked path
+# when an index exists and the row count clears PARALLEL_THRESHOLD (10_000 in
+# src/cmd/moarstats.rs), and that parallel path is the one worth profiling.
+#
+# Peak RSS does NOT scale linearly with rows - 780 pairs x 16 chunks of hashmaps is a large
+# fixed cost - so the slice size was picked by measurement, not arithmetic:
+#   1,000,000 rows -> 23.00 GiB (OOMs the runner)   100,000 -> 7.20 GiB   50,000 -> 4.12 GiB
+#      25,000 rows ->  3.03 GiB                      15,000 -> 2.35 GiB
+# 50k keeps the parallel path (5x PARALLEL_THRESHOLD) at ~26% of a hosted runner's RAM.
+biv_data="$data"
+if [[ "$minimal" -eq 0 ]]; then
+  biv_slice=pgo_train_bivariate.csv
+  if "$qsv_bin" slice --len 50000 "$data" --output "$biv_slice" >/dev/null 2>&1; then
+    # index so the bivariate parallel path (not the sequential fallback) gets trained
+    "$qsv_bin" index "$biv_slice" >/dev/null 2>&1 || true
+    biv_data="$biv_slice"
+  else
+    echo "    (bivariate slice failed; falling back to full training data)"
+  fi
+fi
+t moarstats --bivariate "$biv_data"
+t moarstats --bivariate --bivariate-stats all "$biv_data"
+t moarstats --advanced --bivariate "$biv_data"
+t moarstats --advanced --bivariate --bivariate-stats all "$biv_data"
 t blake3 "$data"
 t luau map newcol "1 + 1" "$data"
 t profile "$data"


### PR DESCRIPTION
## Problem

The 22.0.0 publish run ([31069999861](https://github.com/dathere/qsv/actions/runs/31069999861)) died on **both** full-training PGO targets, at the same training command:

```
qsv moarstats --bivariate --bivariate-stats all <1M-row NYC 311 file>
```

| target | job | died after |
|---|---|---|
| `aarch64-unknown-linux-gnu` | [92515824811](https://github.com/dathere/qsv/actions/runs/31069999861/job/92515824811) | 3m49s |
| `x86_64-unknown-linux-gnu` | [92515824877](https://github.com/dathere/qsv/actions/runs/31069999861/job/92515824877) | 7m31s |

Both reported `The runner has received a shutdown signal` / **exit 143**. That reads like a build or link failure but isn't — the command OOM-kills the runner VM. Because the *runner agent itself* dies, `pgo-train.sh`'s `t` helper never sees an exit code and training simply stops mid-list, with nothing memory-related in the log.

This is **not arch-specific**. Windows escaped only because it trains with `--minimal`; musl doesn't PGO at all. Those four are the entire matrix, so every target that does full training was affected.

## Diagnosis

Reproduced locally on the same training file: **peak RSS 23.0 GiB**. A GitHub hosted runner has **15.57 GiB**.

The cost is not `--bivariate` itself. `--bivariate-stats` defaults to `fast` (pearson + covariance), which streams — that's why plain `--bivariate` finishes in ~40s. Passing `all` additionally enables `mi`/`nmi`/`u`, and those make **every field pair** accumulate a joint-frequency `HashMap<(String, String), u64>` keyed by owned strings — **780 pairs** on this 41-column file.

`spearman`/`kendall` also keep `Vec<f64>` value vectors, but `x_values.push` only fires when both sides parse numeric, so that covers just the ~36 numeric/date pairs — a minor term next to the hashmaps.

Note also that the `-C/--cardinality-threshold` guard that would skip MI for high-cardinality fields **defaults to `1000000` — exactly the row count here — so it never engages.**

## Fix

Train the four bivariate variants on a bounded, indexed 50k-row slice. PGO records *which* branches execute, not how many rows flow through them, so profile coverage is preserved. The slice is indexed deliberately: `compute_all_bivariatestats()` only takes the parallel chunked path when an index exists and the row count clears `PARALLEL_THRESHOLD` (10_000), and that parallel path is the one worth profiling — verified present at every size tested.

Peak RSS does **not** scale linearly with rows, so the size was picked by measurement, not arithmetic:

| rows | peak RSS |
|---|---|
| 1,000,000 | 23.00 GiB (OOMs) |
| 100,000 | 7.20 GiB |
| **50,000** | **4.12 GiB** |
| 25,000 | 3.03 GiB |
| 15,000 | 2.35 GiB |

The heaviest of the four variants now peaks at **4.07 GiB**, ~26% of a hosted runner's RAM.

Univariate `moarstats` / `--advanced` stay on the full file — they complete in 20s/32s and are the realistic hot path worth profiling at scale.

### Second commit: don't fall back to the full file

The first commit's slice-failure path set `biv_data` back to the full file and still ran the `all` variants, re-arming the exact workload being removed (caught in review). The `t` helper tolerates a **skipped** command because skipping is harmless; falling back to the full file is not tolerating a failure — it kills the runner and takes the rest of training with it.

The `all` variants are now gated on a `biv_bounded` flag and run only against bounded input (the 50k slice, or minimal mode's 20k x 6-column file). The two default-stats variants still run on the full file — that subset is proven safe, since aarch64 completed `moarstats --bivariate` over all 1M rows in 41s before the `all` variant killed it.

## Also

Corrects the aarch64 comment in `publish.yml`, which offered `pgo-lto: thin` as the escape hatch for an OOM. That applies to the **optimize/link** step and would not have helped here. Without the note, this failure gets misdiagnosed next time.

## Verification

- All three paths emit the intended command sets: slice ok → all four on the slice; slice fails → the two safe variants only; minimal → all four on the tiny file.
- `bash -n` and `shellcheck -S warning` clean.
- No qsv source is touched — only the training harness and a CI comment.

⚠️ **Local measurements do not prove the CI fix.** They were taken on a 16-core / 64 GiB machine; the runners are 4-core / 15.57 GiB and the chunk count differs. **The first `publish.yml` run after this merges is the real verification** — watch the `Build qsv (PGO)` step on both linux-gnu targets specifically.

## Related

- #4356 — the underlying `moarstats` memory problem this works around (23 GiB on a benchmark-sized file; proposes dictionary-encoding the joint-frequency maps for a projected 6-8x reduction). This PR is a training-harness workaround, not a fix for that.
- #4355 — `extdedup`'s on-disk table, found while investigating this. Same missing discipline: no bound check between an accumulating structure and available memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
