### PR TITLE
ci: raise the Windows publish cap 270 -> 330

### DIFF
--- a/.github/workflows/publish-portable.yml
+++ b/.github/workflows/publish-portable.yml
@@ -78,7 +78,7 @@ jobs:
             addl-qsvlite-features:
             addl-qsvdp-features:
             addl-rustflags:
-            job-timeout: 270
+            job-timeout: 330
           # - os: windows-latest
           #   os-name: windows
           #   target: i686-pc-windows-msvc
@@ -101,7 +101,7 @@ jobs:
             addl-qsvlite-features:
             addl-qsvdp-features:
             addl-rustflags:
-            job-timeout: 270
+            job-timeout: 330
           # - os: macos-12
           #   os-name: macos
           #   target: x86_64-apple-darwin

--- a/.github/workflows/publish-qsvpy.yml
+++ b/.github/workflows/publish-qsvpy.yml
@@ -59,7 +59,7 @@ jobs:
             addl-qsvlite-features:
             addl-qsvdp-features:
             addl-rustflags: -C target-feature=+fxsr,+sse,+sse2,+sse3,+sse4.1,+sse4.2
-            job-timeout: 270
+            job-timeout: 330
           # - os: windows-latest
           #   os-name: windows
           #   target: x86_64-pc-windows-gnu

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,9 +32,8 @@ jobs:
     runs-on: ${{ matrix.job.os }}
     # Cap each target below GitHub's hard 6h job limit so a stalled build fails as an
     # explicit timeout instead of an opaque "exceeded the maximum execution time" after
-    # burning the full 6h (run 31243109948 did that twice on Windows). Windows gets 270
-    # (its best-known green run is 3h28m); everything else inherits 240 (Linux gnu's
-    # worst observed run is 3h01m).
+    # burning the full 6h (run 31243109948 did that twice on Windows). Windows gets 330;
+    # everything else inherits 240 (Linux gnu ran 177m in run 31261021249).
     timeout-minutes: ${{ matrix.job.job-timeout || 240 }}
     strategy:
       # don't cancel the other target builds if one fails; each platform publishes independently
@@ -100,9 +99,14 @@ jobs:
             pgo: true
             pgo-train-flags: --minimal
             pgo-lto:
-            # Windows is the slowest target: best-known green run is 3h28m. If this cap
-            # is hit, drop `pgo` here before dropping `viz` - it removes a full qsv build.
-            job-timeout: 270
+            # Windows is the slowest target. 330 (not 270) because `qsvmcp` - not `qsv` -
+            # is the most expensive step here: the qsvmcp feature adds get, get_cloud, mcp,
+            # profile and synthesize on top of the polars+viz set this entry builds for
+            # `qsv`. In run 31261021249 the msvc qsv PGO build took 139m and qsvmcp ran
+            # longer still. The old 270 was calibrated on a 3h28m pre-viz baseline that
+            # predates viz being in BOTH builds. If this cap is ever hit, drop `pgo` here
+            # before dropping `viz` - it removes a full qsv build.
+            job-timeout: 330
           # - os: windows-latest
           #   os-name: windows
           #   target: i686-pc-windows-msvc
@@ -135,7 +139,7 @@ jobs:
             pgo-train-flags: --minimal
             pgo-lto:
             # see the msvc entry - Windows is the slowest target.
-            job-timeout: 270
+            job-timeout: 330
           # - os: macos-12
           #   os-name: macos
           #   target: x86_64-apple-darwin


### PR DESCRIPTION
Follow-up to #4368. Pre-staged so a re-dispatch is one command rather than a commit-then-dispatch round trip.

## Why

The `270` in #4368 was calibrated on the **3h28m pre-viz baseline** from 21.1.0. That baseline is stale — it predates `viz` being enabled in **both** the `qsv` and `qsvmcp` builds.

[Run 31261021249](https://github.com/dathere/qsv/actions/runs/31261021249) shows where the time actually goes on Windows:

| step | windows-gnu | windows-msvc |
|---|---|---|
| qsv build | 66m (`normal`) | **139m** (`PGO`: instrument + train + optimize) |
| qsvlite | 14m | ~13m |
| **qsvmcp** | **>100m** | in flight |

`qsvmcp` is the **most expensive step in the job**, not the cheap tail it looks like — the `qsvmcp` feature adds `get`, `get_cloud`, `mcp`, `profile` and `synthesize` on top of the polars+viz set the Windows entries build for `qsv`.

At 270, a *healthy* msvc run was projected to land with only ~15 minutes of slack. The guard was close to false-failing a build that had already cleared the `viz_static` wall it exists to catch — which would have been the worst outcome: a 4.5h burn plus a misleading signal.

## What this does not change

330 is still 30 minutes under GitHub's hard 6h limit, so a genuine hang is still reported as an explicit job timeout rather than "exceeded the maximum execution time". The diagnostic value is retained; only the false-positive risk drops.

Linux keeps the 240 default — `x86_64-unknown-linux-gnu` ran **177m** in the same run (26% headroom).

Applied to all five Windows entries across `publish.yml`, `publish-portable.yml` and `publish-qsvpy.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)