### PR TITLE
ci: reusable publish job + Windows-only publish, drop --emit=asm

### DIFF
--- a/.github/workflows/docs-drift.yml
+++ b/.github/workflows/docs-drift.yml
@@ -66,6 +66,11 @@ jobs:
       - name: Run docs-drift-check
         run: python3 scripts/docs-drift-check.py
 
+      # docs-drift-check.py is stdlib-only; check-publish-matrix-sync.py parses workflow
+      # YAML, so it needs PyYAML. Installed here rather than hand-rolling a YAML parser.
+      - name: Install PyYAML
+        run: pip install pyyaml
+
       # publish-windows.yml duplicates publish.yml's Windows matrix entries so a
       # Windows-only failure can be retried without rebuilding the other targets. If they
       # drift, the retry ships binaries built with different features than the full run.

--- a/.github/workflows/docs-drift.yml
+++ b/.github/workflows/docs-drift.yml
@@ -38,6 +38,9 @@ on:
       - 'dotenv.template'
       - 'scripts/docs-drift-check.py'
       - '.github/workflows/docs-drift.yml'
+      - '.github/workflows/publish.yml'
+      - '.github/workflows/publish-windows.yml'
+      - 'scripts/check-publish-matrix-sync.py'
   workflow_dispatch:
 
 permissions:
@@ -62,3 +65,9 @@ jobs:
 
       - name: Run docs-drift-check
         run: python3 scripts/docs-drift-check.py
+
+      # publish-windows.yml duplicates publish.yml's Windows matrix entries so a
+      # Windows-only failure can be retried without rebuilding the other targets. If they
+      # drift, the retry ships binaries built with different features than the full run.
+      - name: Check publish matrix sync
+        run: python3 scripts/check-publish-matrix-sync.py

--- a/.github/workflows/publish-target.yml
+++ b/.github/workflows/publish-target.yml
@@ -1,0 +1,220 @@
+name: Publish target (reusable)
+
+# Reusable build-and-publish job for ONE target triple.
+#
+# Callers:
+#   publish.yml          - the full release matrix (all targets)
+#   publish-windows.yml  - Windows only, so a Windows-only failure can be retried
+#                          without rebuilding and re-uploading the other targets
+#
+# Keep the build logic HERE, not in the callers. Before this file existed, publish.yml,
+# publish-portable.yml and publish-qsvpy.yml each carried their own copy of these steps,
+# and they drifted - the viz_static that blew the 6h job cap on Windows (run 31243109948)
+# had to be fixed in three places.
+#
+# NOTE: `timeout-minutes` cannot be set on a job that calls a reusable workflow (the
+# caller may only use name/uses/with/secrets/strategy/needs/if/concurrency/permissions),
+# so the cap lives here and comes in via the `job_timeout` input.
+
+# QSV_KIND must be set HERE, not in the caller: a workflow-level `env` in the calling
+# workflow does NOT propagate into a reusable workflow. Without it build.rs falls back to
+# "compiled" (src/build.rs), which mis-stamps `qsv --version` and breaks the
+# starts_with("prebuilt") check self-update relies on. The PGO step overrides it to
+# prebuilt-pgo at step level.
+env:
+  QSV_KIND: prebuilt
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        description: runner image, e.g. ubuntu-24.04 / windows-latest
+        type: string
+        required: true
+      os_name:
+        description: linux | windows | macos
+        type: string
+        required: true
+      target:
+        description: target triple
+        type: string
+        required: true
+      previous_tag:
+        description: release tag to build and upload to
+        type: string
+        required: true
+      rust:
+        type: string
+        default: stable
+      addl_build_args:
+        description: "--features=... for the qsv binary"
+        type: string
+        default: ''
+      default_features:
+        description: e.g. --no-default-features
+        type: string
+        default: ''
+      addl_qsvlite_features:
+        type: string
+        default: ''
+      addl_qsvdp_features:
+        type: string
+        default: ''
+      addl_rustflags:
+        type: string
+        default: ''
+      musl_prep:
+        type: boolean
+        default: false
+      pgo:
+        description: PGO-optimize the qsv binary (native runners only)
+        type: boolean
+        default: false
+      pgo_train_flags:
+        type: string
+        default: ''
+      pgo_lto:
+        type: string
+        default: ''
+      job_timeout:
+        description: >-
+          Job cap in minutes. Below GitHub's hard 6h limit so a stalled build fails as an
+          explicit timeout instead of an opaque "exceeded the maximum execution time".
+        type: number
+        default: 240
+    secrets:
+      QSV_ZIPSIGN_PRIV_KEY:
+        required: true
+
+jobs:
+  build:
+    name: ${{ inputs.target }}
+    runs-on: ${{ inputs.os }}
+    timeout-minutes: ${{ inputs.job_timeout }}
+    steps:
+    - name: Installing Rust toolchain
+      uses: dtolnay/rust-toolchain@master
+      with:
+        # NOTE: dtolnay/rust-toolchain does NOT support the actions-rs-style
+        # `profile:`/`override:` inputs (they emit "Unexpected input(s)" warnings
+        # and are ignored). It sets `toolchain` as the rustup DEFAULT, which a
+        # leftover per-directory `rustup override` on a self-hosted runner can
+        # silently win over. The PGO step pins RUSTUP_TOOLCHAIN to guard against that.
+        toolchain: ${{ inputs.rust }}
+        target: ${{ inputs.target }}
+    - name: Checkout repository
+      uses: actions/checkout@v7
+      with:
+        ref: ${{ inputs.previous_tag }}
+    - name: apt-get update Ubuntu, libwayland-dev
+      if: ${{ inputs.os_name == 'linux' }}
+      run: |
+        sudo apt-get update
+        sudo apt-get install libwayland-dev
+    - name: build prep for x86_64-unknown-linux-musl
+      if: ${{ inputs.musl_prep }}
+      run: |
+        sudo apt-get install musl-tools musl-dev
+        sudo ln -s /usr/bin/g++ /usr/bin/musl-g++
+    # PGO-optimized qsv build for native-runner targets (issue #1448). build-pgo.sh
+    # runs the instrument -> train -> optimize cycle and leaves the binary in the same
+    # target/<target>/<profile>/ path the "Copy binaries" step globs. QSV_KIND is set to
+    # prebuilt-pgo so `qsv --version` reflects the PGO build (util.rs starts_with("prebuilt")
+    # still treats it as a prebuilt for self-update).
+    - name: Build qsv (PGO)
+      if: ${{ inputs.pgo }}
+      shell: bash
+      env:
+        QSV_KIND: prebuilt-pgo
+        # pin the toolchain for the bare `cargo pgo` invocations in build-pgo.sh;
+        # RUSTUP_TOOLCHAIN beats any leftover per-directory `rustup override` on a
+        # self-hosted runner (which previously forced a stale, sub-MSRV nightly).
+        RUSTUP_TOOLCHAIN: ${{ inputs.rust }}
+        TARGET: ${{ inputs.target }}
+        DEFAULT_FEATURES: ${{ inputs.default_features }}
+        RUSTFLAGS: ${{ inputs.addl_rustflags }}
+        PGO_LTO: ${{ inputs.pgo_lto }}
+        TRAIN_FLAGS: ${{ inputs.pgo_train_flags }}
+        ADDL_BUILD_ARGS: ${{ inputs.addl_build_args }}
+      run: |
+        # strip the leading "--features=" to get the bare comma-separated feature list
+        export QSV_FEATURES="${ADDL_BUILD_ARGS#--features=}"
+        chmod +x scripts/build-pgo.sh scripts/pgo-train.sh
+        ./scripts/build-pgo.sh
+    # actions-rs/cargo is archived/Node20-deprecated (qsv #4002), so invoke cargo directly.
+    # All active targets in this workflow build with plain cargo (no use-cross: true), so the
+    # cross/cargo conditional is unneeded here. `+${{ inputs.rust }}` pins the toolchain to
+    # guard against a stale per-directory rustup override on self-hosted runners (see note above).
+    - name: Build qsv (normal)
+      if: ${{ !inputs.pgo }}
+      env:
+        RUSTFLAGS: ${{ inputs.addl_rustflags }}
+      shell: bash
+      run: cargo +${{ inputs.rust }} build --profile ${{ contains(inputs.addl_build_args, 'luau') && 'release-luau' || 'release' }} --locked --bin qsv --target ${{ inputs.target }} ${{ inputs.addl_build_args }},feature_capable ${{ inputs.default_features }}
+    # NOTE: qsvlite/qsvdp/qsvmcp used to build with RUSTFLAGS=--emit=asm, added in 2022
+    # (f9bc937c4) and later commented out for the qsv step but left on these three.
+    # Nothing consumes the .s files, and with codegen-units=1 + fat LTO it makes rustc
+    # write assembly for the whole crate. On Windows that turned the viz-enabled qsvmcp
+    # build from ~57min (pre-viz baseline) into >190min without finishing, blowing the
+    # job cap in run 31261021249. Do not reintroduce it here; use a local build if you
+    # need the asm.
+    - name: Build qsvlite
+      env:
+        RUSTFLAGS: ${{ inputs.addl_rustflags }}
+      shell: bash
+      run: cargo +${{ inputs.rust }} build --release --locked --bin qsvlite --features=lite,self_update,${{ inputs.addl_qsvlite_features }} --target ${{ inputs.target }} ${{ inputs.default_features }}
+    - name: Build qsvdp
+      # qsvdp (datapusher_plus) is a Linux deployment helper, so only build it for x86_64
+      # Linux. Skip aarch64-unknown-linux-gnu (its Polars fat-LTO link OOM-kills the hosted
+      # ARM runner — qsvmcp is already excluded there too) and all non-Linux targets.
+      if: ${{ inputs.target != 'aarch64-unknown-linux-gnu' && inputs.os_name == 'linux' }}
+      env:
+        RUSTFLAGS: ${{ inputs.addl_rustflags }}
+      shell: bash
+      run: cargo +${{ inputs.rust }} build --release --locked --bin qsvdp --features=datapusher_plus,${{ inputs.addl_qsvdp_features }} --target ${{ inputs.target }} ${{ inputs.default_features }}
+    - name: Build qsvmcp
+      if: ${{ inputs.target != 'x86_64-unknown-linux-musl' && inputs.target != 'aarch64-unknown-linux-gnu' }}
+      env:
+        RUSTFLAGS: ${{ inputs.addl_rustflags }}
+      shell: bash
+      run: cargo +${{ inputs.rust }} build --release --locked --bin qsvmcp ${{ inputs.addl_qsvlite_features != '' && format('--features=qsvmcp,{0}', inputs.addl_qsvlite_features) || '--features=qsvmcp' }} --target ${{ inputs.target }} ${{ inputs.default_features }}
+    - name: Copy binaries to working dir
+      shell: bash
+      run: |
+        mkdir qsv-${{ inputs.previous_tag }}
+        # Ship qsv's license and the third-party notices with every archive:
+        # the vendored MIT/BSD components require their notices to travel with copies.
+        cp LICENSE-MIT COPYING THIRD_PARTY_NOTICES.md qsv-${{ inputs.previous_tag }}/
+        # qsv uses release-luau (panic=unwind, qsv #3937) when built with luau, else release; the other bins use release
+        for d in release-luau release; do
+          rm -f target/${{ inputs.target }}/$d/*.d 2>/dev/null || true
+          cp -v target/${{ inputs.target }}/$d/qsv* qsv-${{ inputs.previous_tag }} 2>/dev/null || true
+        done
+    - name: Create README
+      shell: bash
+      run: |
+        cat docs/publishing_assets/README.txt docs/publishing_assets/qsv-${{ inputs.target }}.txt > qsv-${{ inputs.previous_tag }}/README
+    - name: zip up binaries
+      run: 7z a -tzip qsv-${{ inputs.previous_tag }}-${{ inputs.target }}.zip ./qsv-${{ inputs.previous_tag }}/* -mx=9 -mmt=on
+    - name: install zipsign
+      run: |
+        cargo install zipsign
+    - name: Fetch zipsign private key
+      # replaces mobiledevops/secret-to-file-action (Node20-deprecated, qsv #4002):
+      # decode the base64 secret to qsvpriv.key. bash shell + `base64 -d` work on all
+      # runners (incl. Windows git-bash, macOS/BSD). Secret passed via env, not inlined.
+      shell: bash
+      env:
+        ZIPSIGN_KEY: ${{ secrets.QSV_ZIPSIGN_PRIV_KEY }}
+      run: printf '%s' "$ZIPSIGN_KEY" | base64 -d > qsvpriv.key
+    - name: zipsign binary
+      run: |
+        zipsign sign zip qsv-${{ inputs.previous_tag }}-${{ inputs.target }}.zip qsvpriv.key
+    - name: Upload zipped binaries to release
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: qsv-${{ inputs.previous_tag }}-${{ inputs.target }}.zip
+        asset_name: qsv-${{ inputs.previous_tag }}-${{ inputs.target }}.zip
+        overwrite: true
+        tag: ${{ inputs.previous_tag }}

--- a/.github/workflows/publish-windows.yml
+++ b/.github/workflows/publish-windows.yml
@@ -1,0 +1,117 @@
+name: Publish (Windows only)
+
+# Rebuild and re-upload ONLY the Windows targets for the current release tag.
+#
+# Why this exists: publish.yml rebuilds all five targets, and its upload step runs with
+# overwrite: true. When only Windows fails - which is the common case, since Windows is
+# by far the slowest target - re-running publish.yml also rebuilds and REPLACES the Linux
+# and ARM artifacts that already published successfully. PGO output is not deterministic,
+# so those replacements are not byte-identical to what users may already have downloaded.
+#
+# The two matrix entries below MUST stay identical to publish.yml's Windows entries, or a
+# retry would ship binaries built with different features than the full run would have.
+# scripts/check-publish-matrix-sync.py enforces that and runs in CI - if you edit a Windows
+# entry here or in publish.yml, edit both.
+#
+# Manual dispatch only: a tag push should run the full publish.yml.
+
+# see publish-target.yml - a caller's workflow-level env does NOT reach a reusable
+# workflow, so QSV_KIND is set there, not here.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  analyze-tags:
+    runs-on: ubuntu-22.04
+    outputs:
+      previous-tag: ${{ steps.previoustag.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Get previous tag
+        id: previoustag
+        uses: "WyriHaximus/github-action-get-previous-tag@v2"
+
+  publish:
+    name: Publish for ${{ matrix.job.target }}
+    needs: analyze-tags
+    strategy:
+      # don't cancel the other target build if one fails; each publishes independently
+      fail-fast: false
+      matrix:
+        rust: [stable]
+        job:
+          #### KEEP IN SYNC WITH publish.yml (enforced by check-publish-matrix-sync.py) ####
+          - os: windows-latest
+            os-name: windows
+            target: x86_64-pc-windows-msvc
+            architecture: x86_64
+            use-cross: false
+            # viz_static is deliberately absent: it does not finish a Windows release
+            # build inside the 6h job cap (run 31243109948). See Cargo.toml's viz_static
+            # note. Windows ships interactive HTML dashboards, no static image export.
+            addl-build-args: --features=apply,luau,fetch,self_update,geocode,polars,to,lens,foreach,prompt,magika,color,viz
+            # Windows: jemallocator is not supported on Windows, so we use the system allocator.
+            default-features: --no-default-features
+            addl-qsvlite-features:
+            addl-qsvdp-features:
+            addl-rustflags:
+            # native runner - PGO with --minimal training (benchmarks.sh data prep
+            # does not run natively on Windows; train via git-bash on a synthesized CSV)
+            pgo: true
+            pgo-train-flags: --minimal
+            pgo-lto:
+            # Windows is the slowest target. 330 (not 270) because `qsvmcp` - not `qsv` -
+            # is the most expensive step here: the qsvmcp feature adds get, get_cloud, mcp,
+            # profile and synthesize on top of the polars+viz set this entry builds for
+            # `qsv`. In run 31261021249 the msvc qsv PGO build took 139m and qsvmcp ran
+            # longer still. The old 270 was calibrated on a 3h28m pre-viz baseline that
+            # predates viz being in BOTH builds. If this cap is ever hit, drop `pgo` here
+            # before dropping `viz` - it removes a full qsv build.
+            job-timeout: 330
+          - os: windows-latest
+            os-name: windows
+            target: x86_64-pc-windows-gnu
+            architecture: x86_64
+            use-cross: false
+            # viz_static deliberately absent - see the msvc entry above.
+            addl-build-args: --features=apply,luau,fetch,self_update,geocode,polars,to,lens,foreach,prompt,color,viz
+            # Windows: jemallocator is not supported on Windows, so we use the system allocator.
+            default-features: --no-default-features
+            addl-qsvlite-features:
+            addl-qsvdp-features:
+            addl-rustflags:
+            # PGO disabled for windows-gnu: the msvc host cross-compiles to the gnu
+            # target, but rustup's stable rust-std for x86_64-pc-windows-gnu does not
+            # ship the profiler runtime, so PGO instrumentation fails to build
+            # (error[E0463]: can't find crate for `profiler_builtins`). Supplying it
+            # would require nightly + -Zbuild-std. Fall back to a normal optimized
+            # build; PGO stays enabled for msvc + linux + macOS targets.
+            pgo: false
+            pgo-train-flags: --minimal
+            pgo-lto:
+            # see the msvc entry - Windows is the slowest target.
+            job-timeout: 330
+          #### END KEEP IN SYNC ####
+    uses: ./.github/workflows/publish-target.yml
+    with:
+      os: ${{ matrix.job.os }}
+      os_name: ${{ matrix.job.os-name }}
+      target: ${{ matrix.job.target }}
+      previous_tag: ${{ needs.analyze-tags.outputs.previous-tag }}
+      rust: ${{ matrix.rust }}
+      addl_build_args: ${{ matrix.job.addl-build-args }}
+      default_features: ${{ matrix.job.default-features }}
+      addl_qsvlite_features: ${{ matrix.job.addl-qsvlite-features }}
+      addl_qsvdp_features: ${{ matrix.job.addl-qsvdp-features }}
+      addl_rustflags: ${{ matrix.job.addl-rustflags }}
+      # no musl-prep key on the Windows entries (it is musl-only), so pass the literal
+      musl_prep: false
+      pgo: ${{ matrix.job.pgo || false }}
+      pgo_train_flags: ${{ matrix.job.pgo-train-flags }}
+      pgo_lto: ${{ matrix.job.pgo-lto }}
+      job_timeout: ${{ matrix.job.job-timeout || 240 }}
+    secrets:
+      QSV_ZIPSIGN_PRIV_KEY: ${{ secrets.QSV_ZIPSIGN_PRIV_KEY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,8 +6,10 @@ on:
       - '*'
   workflow_dispatch:
 
-env:
-  QSV_KIND: prebuilt
+# NOTE: QSV_KIND is deliberately NOT set here. The build now happens in the reusable
+# publish-target.yml, and a caller's workflow-level env does NOT propagate into a reusable
+# workflow - setting it here would look effective while build.rs silently fell back to
+# "compiled". It is set in publish-target.yml instead.
 
 jobs:
   analyze-tags:
@@ -29,12 +31,6 @@ jobs:
   publish:
     name: Publish for ${{ matrix.job.target }}
     needs: analyze-tags
-    runs-on: ${{ matrix.job.os }}
-    # Cap each target below GitHub's hard 6h job limit so a stalled build fails as an
-    # explicit timeout instead of an opaque "exceeded the maximum execution time" after
-    # burning the full 6h (run 31243109948 did that twice on Windows). Windows gets 330;
-    # everything else inherits 240 (Linux gnu ran 177m in run 31261021249).
-    timeout-minutes: ${{ matrix.job.job-timeout || 240 }}
     strategy:
       # don't cancel the other target builds if one fails; each platform publishes independently
       fail-fast: false
@@ -205,127 +201,28 @@ jobs:
           #   addl-qsvlite-features:
           #   addl-qsvdp-features:
           #   addl-rustflags:
-
-    steps:
-    - name: Installing Rust toolchain
-      uses: dtolnay/rust-toolchain@master
-      with:
-        # NOTE: dtolnay/rust-toolchain does NOT support the actions-rs-style
-        # `profile:`/`override:` inputs (they emit "Unexpected input(s)" warnings
-        # and are ignored). It sets `toolchain` as the rustup DEFAULT, which a
-        # leftover per-directory `rustup override` on a self-hosted runner can
-        # silently win over. The PGO step pins RUSTUP_TOOLCHAIN to guard against that.
-        toolchain: ${{ matrix.rust }}
-        target: ${{ matrix.job.target }}
-    - name: Checkout repository
-      uses: actions/checkout@v7
-      with:
-        ref: ${{ needs.analyze-tags.outputs.previous-tag }}
-    - name: apt-get update Ubuntu, libwayland-dev
-      if: ${{ matrix.job.os-name == 'linux' }}
-      run: |
-        sudo apt-get update
-        sudo apt-get install libwayland-dev
-    - name: build prep for x86_64-unknown-linux-musl
-      if: ${{ matrix.job.musl-prep }}
-      run: |
-        sudo apt-get install musl-tools musl-dev
-        sudo ln -s /usr/bin/g++ /usr/bin/musl-g++
-    # PGO-optimized qsv build for native-runner targets (issue #1448). build-pgo.sh
-    # runs the instrument -> train -> optimize cycle and leaves the binary in the same
-    # target/<target>/<profile>/ path the "Copy binaries" step globs. QSV_KIND is set to
-    # prebuilt-pgo so `qsv --version` reflects the PGO build (util.rs starts_with("prebuilt")
-    # still treats it as a prebuilt for self-update).
-    - name: Build qsv (PGO)
-      if: ${{ matrix.job.pgo }}
-      shell: bash
-      env:
-        QSV_KIND: prebuilt-pgo
-        # pin the toolchain for the bare `cargo pgo` invocations in build-pgo.sh;
-        # RUSTUP_TOOLCHAIN beats any leftover per-directory `rustup override` on a
-        # self-hosted runner (which previously forced a stale, sub-MSRV nightly).
-        RUSTUP_TOOLCHAIN: ${{ matrix.rust }}
-        TARGET: ${{ matrix.job.target }}
-        DEFAULT_FEATURES: ${{ matrix.job.default-features }}
-        RUSTFLAGS: ${{ matrix.job.addl-rustflags }}
-        PGO_LTO: ${{ matrix.job.pgo-lto }}
-        TRAIN_FLAGS: ${{ matrix.job.pgo-train-flags }}
-        ADDL_BUILD_ARGS: ${{ matrix.job.addl-build-args }}
-      run: |
-        # strip the leading "--features=" to get the bare comma-separated feature list
-        export QSV_FEATURES="${ADDL_BUILD_ARGS#--features=}"
-        chmod +x scripts/build-pgo.sh scripts/pgo-train.sh
-        ./scripts/build-pgo.sh
-    # actions-rs/cargo is archived/Node20-deprecated (qsv #4002), so invoke cargo directly.
-    # All active targets in this workflow build with plain cargo (no use-cross: true), so the
-    # cross/cargo conditional is unneeded here. `+${{ matrix.rust }}` pins the toolchain to
-    # guard against a stale per-directory rustup override on self-hosted runners (see note above).
-    - name: Build qsv (normal)
-      if: ${{ !matrix.job.pgo }}
-      # env:
-      #   RUSTFLAGS: --emit=asm
-      env:
-        RUSTFLAGS: ${{ matrix.job.addl-rustflags }}
-      shell: bash
-      run: cargo +${{ matrix.rust }} build --profile ${{ contains(matrix.job.addl-build-args, 'luau') && 'release-luau' || 'release' }} --locked --bin qsv --target ${{ matrix.job.target }} ${{ matrix.job.addl-build-args }},feature_capable ${{ matrix.job.default-features }}
-    - name: Build qsvlite
-      env:
-        RUSTFLAGS: --emit=asm ${{ matrix.job.addl-rustflags }}
-      shell: bash
-      run: cargo +${{ matrix.rust }} build --release --locked --bin qsvlite --features=lite,self_update,${{ matrix.job.addl-qsvlite-features }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
-    - name: Build qsvdp
-      # qsvdp (datapusher_plus) is a Linux deployment helper, so only build it for x86_64
-      # Linux. Skip aarch64-unknown-linux-gnu (its Polars fat-LTO link OOM-kills the hosted
-      # ARM runner — qsvmcp is already excluded there too) and all non-Linux targets.
-      if: ${{ matrix.job.target != 'aarch64-unknown-linux-gnu' && matrix.job.os-name == 'linux' }}
-      env:
-        RUSTFLAGS: --emit=asm ${{ matrix.job.addl-rustflags }}
-      shell: bash
-      run: cargo +${{ matrix.rust }} build --release --locked --bin qsvdp --features=datapusher_plus,${{ matrix.job.addl-qsvdp-features }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
-    - name: Build qsvmcp
-      if: ${{ matrix.job.target != 'x86_64-unknown-linux-musl' && matrix.job.target != 'aarch64-unknown-linux-gnu' }}
-      env:
-        RUSTFLAGS: --emit=asm ${{ matrix.job.addl-rustflags }}
-      shell: bash
-      run: cargo +${{ matrix.rust }} build --release --locked --bin qsvmcp ${{ matrix.job.addl-qsvlite-features != '' && format('--features=qsvmcp,{0}', matrix.job.addl-qsvlite-features) || '--features=qsvmcp' }} --target ${{ matrix.job.target }} ${{ matrix.job.default-features }}
-    - name: Copy binaries to working dir
-      shell: bash
-      run: |
-        mkdir qsv-${{ needs.analyze-tags.outputs.previous-tag }}
-        # Ship qsv's license and the third-party notices with every archive:
-        # the vendored MIT/BSD components require their notices to travel with copies.
-        cp LICENSE-MIT COPYING THIRD_PARTY_NOTICES.md qsv-${{ needs.analyze-tags.outputs.previous-tag }}/
-        # qsv uses release-luau (panic=unwind, qsv #3937) when built with luau, else release; the other bins use release
-        for d in release-luau release; do
-          rm -f target/${{ matrix.job.target }}/$d/*.d 2>/dev/null || true
-          cp -v target/${{ matrix.job.target }}/$d/qsv* qsv-${{ needs.analyze-tags.outputs.previous-tag }} 2>/dev/null || true
-        done
-    - name: Create README
-      shell: bash
-      run: |
-        cat docs/publishing_assets/README.txt docs/publishing_assets/qsv-${{ matrix.job.target }}.txt > qsv-${{ needs.analyze-tags.outputs.previous-tag }}/README
-    - name: zip up binaries
-      run: 7z a -tzip qsv-${{ needs.analyze-tags.outputs.previous-tag }}-${{ matrix.job.target }}.zip ./qsv-${{ needs.analyze-tags.outputs.previous-tag }}/* -mx=9 -mmt=on
-    - name: install zipsign
-      run: |
-        cargo install zipsign
-    - name: Fetch zipsign private key
-      # replaces mobiledevops/secret-to-file-action (Node20-deprecated, qsv #4002):
-      # decode the base64 secret to qsvpriv.key. bash shell + `base64 -d` work on all
-      # runners (incl. Windows git-bash, macOS/BSD). Secret passed via env, not inlined.
-      shell: bash
-      env:
-        ZIPSIGN_KEY: ${{ secrets.QSV_ZIPSIGN_PRIV_KEY }}
-      run: printf '%s' "$ZIPSIGN_KEY" | base64 -d > qsvpriv.key
-    - name: zipsign binary
-      run: |
-        zipsign sign zip qsv-${{ needs.analyze-tags.outputs.previous-tag }}-${{ matrix.job.target }}.zip qsvpriv.key
-    - name: Upload zipped binaries to release
-      uses: svenstaro/upload-release-action@v2
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: qsv-${{ needs.analyze-tags.outputs.previous-tag }}-${{ matrix.job.target }}.zip
-        asset_name: qsv-${{ needs.analyze-tags.outputs.previous-tag }}-${{ matrix.job.target }}.zip
-        overwrite: true
-        tag: ${{ needs.analyze-tags.outputs.previous-tag }}    
- 
+    # The build steps live in the reusable publish-target.yml so publish-windows.yml can
+    # rebuild ONLY the Windows targets without re-running - and re-uploading - the others.
+    # `timeout-minutes` is not a legal key on a job that calls a reusable workflow, so the
+    # cap is passed as the job_timeout input instead.
+    uses: ./.github/workflows/publish-target.yml
+    with:
+      os: ${{ matrix.job.os }}
+      os_name: ${{ matrix.job.os-name }}
+      target: ${{ matrix.job.target }}
+      previous_tag: ${{ needs.analyze-tags.outputs.previous-tag }}
+      rust: ${{ matrix.rust }}
+      addl_build_args: ${{ matrix.job.addl-build-args }}
+      default_features: ${{ matrix.job.default-features }}
+      addl_qsvlite_features: ${{ matrix.job.addl-qsvlite-features }}
+      addl_qsvdp_features: ${{ matrix.job.addl-qsvdp-features }}
+      addl_rustflags: ${{ matrix.job.addl-rustflags }}
+      # `|| false` / `|| 240`: these keys are absent on most matrix entries, and an empty
+      # string is not a legal value for a typed boolean/number input.
+      musl_prep: ${{ matrix.job.musl-prep || false }}
+      pgo: ${{ matrix.job.pgo || false }}
+      pgo_train_flags: ${{ matrix.job.pgo-train-flags }}
+      pgo_lto: ${{ matrix.job.pgo-lto }}
+      job_timeout: ${{ matrix.job.job-timeout || 240 }}
+    secrets:
+      QSV_ZIPSIGN_PRIV_KEY: ${{ secrets.QSV_ZIPSIGN_PRIV_KEY }}

--- a/scripts/check-publish-matrix-sync.py
+++ b/scripts/check-publish-matrix-sync.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Assert publish-windows.yml's matrix entries match publish.yml's Windows entries.
+
+publish-windows.yml exists so a Windows-only failure can be retried without rebuilding
+and re-uploading the other targets (publish.yml uploads with overwrite: true). That means
+the Windows matrix entries are written twice, and if they drift, a retry ships binaries
+built with different features than the full publish would have produced.
+
+That drift is not hypothetical: `viz_static` sat in three near-duplicate publish workflows
+and blew GitHub's 6h job cap on Windows (run 31243109948) before it was found.
+
+Exits non-zero with a diff if the entries disagree.
+"""
+
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    sys.exit("PyYAML required: pip install pyyaml")
+
+ROOT = Path(__file__).resolve().parent.parent
+FULL = ROOT / ".github/workflows/publish.yml"
+WIN = ROOT / ".github/workflows/publish-windows.yml"
+
+
+def windows_entries(path):
+    doc = yaml.safe_load(path.read_text())
+    jobs = doc.get("jobs", {})
+    if "publish" not in jobs:
+        sys.exit(f"{path.name}: no `publish` job")
+    entries = jobs["publish"].get("strategy", {}).get("matrix", {}).get("job", [])
+    if not isinstance(entries, list):
+        sys.exit(f"{path.name}: `publish` job has no literal matrix list")
+    return {
+        e["target"]: e
+        for e in entries
+        if isinstance(e, dict) and "windows" in str(e.get("target", ""))
+    }
+
+
+def main():
+    full = windows_entries(FULL)
+    win = windows_entries(WIN)
+
+    problems = []
+
+    only_full = sorted(set(full) - set(win))
+    only_win = sorted(set(win) - set(full))
+    if only_full:
+        problems.append(f"in {FULL.name} but not {WIN.name}: {', '.join(only_full)}")
+    if only_win:
+        problems.append(f"in {WIN.name} but not {FULL.name}: {', '.join(only_win)}")
+
+    for target in sorted(set(full) & set(win)):
+        a, b = full[target], win[target]
+        for key in sorted(set(a) | set(b)):
+            av, bv = a.get(key, "<missing>"), b.get(key, "<missing>")
+            if av != bv:
+                problems.append(
+                    f"{target}: `{key}` differs\n"
+                    f"    {FULL.name}: {av!r}\n"
+                    f"    {WIN.name}: {bv!r}"
+                )
+
+    if not full:
+        problems.append(f"{FULL.name}: found no Windows matrix entries — did the matrix move?")
+
+    if problems:
+        print("check-publish-matrix-sync: publish workflows disagree:\n")
+        for p in problems:
+            print(f"  {p}")
+        print(
+            "\nThe Windows entries in publish.yml and publish-windows.yml must be identical.\n"
+            "Edit both, or the Windows-only retry will ship different binaries."
+        )
+        return 1
+
+    print(
+        f"check-publish-matrix-sync: OK — {len(full)} Windows "
+        f"{'entry' if len(full) == 1 else 'entries'} match "
+        f"({', '.join(sorted(full))})."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Follow-up to #4368/#4369. [Run 31261021249](https://github.com/dathere/qsv/actions/runs/31261021249) cleared the `viz_static` wall — msvc built `qsv` in **139m**, gnu in **66m** — but both Windows jobs then died at the 270m cap inside **`Build qsvmcp`**, which hadn't finished after **190m** (gnu) and **117m** (msvc).

## 1. Drop `RUSTFLAGS=--emit=asm` from the qsvlite/qsvdp/qsvmcp steps

Added in 2022 (`f9bc937c4`), later commented out for the `qsv` step but left on the other three. Nothing consumes the `.s` files, and with `codegen-units = 1` + fat LTO rustc writes assembly for the whole crate.

| step | pre-viz (2026-06-08, green) | now | `--emit=asm`? |
|---|---|---|---|
| gnu `qsv` | 54m | 66m (+22%) | no |
| gnu **`qsvmcp`** | **57m** | **>190m (cut)** | **yes** |
| msvc `qsvmcp` | 59m | >117m (cut) | yes |

The step *without* the flag grew 22%; the ones *with* it more than tripled. That asymmetry is why it's the prime suspect — though `qsvmcp` also carries `get`/`get_cloud`/`mcp`/`profile`/`synthesize`, so this is a strong hypothesis rather than a proven cause. Either way the flag is pure overhead in a publish build.

## 2. Extract the build steps into a reusable `publish-target.yml`

`publish.yml` keeps its literal matrix (and its load-bearing comments) and calls the reusable workflow per entry.

Two non-obvious constraints drove the shape:

- **`timeout-minutes` is not a legal key on a job that calls a reusable workflow** (callers may only use `name/uses/with/secrets/strategy/needs/if/concurrency/permissions`), so the cap moves to a `job_timeout` input.
- **A caller's workflow-level `env` does not propagate into a reusable workflow.** `QSV_KIND: prebuilt` had to move *into* `publish-target.yml` — without it `build.rs` falls back to `"compiled"`, which mis-stamps `qsv --version` and breaks the `starts_with("prebuilt")` check self-update relies on. `publish.yml` now carries a comment saying so, since re-adding it there would look effective while silently doing nothing.

## 3. Add `publish-windows.yml` (manual dispatch)

`publish.yml` uploads with `overwrite: true`, so retrying a Windows-only failure also rebuilds and **replaces** the Linux/ARM artifacts that already published successfully. PGO output isn't deterministic, so those replacements aren't byte-identical to what users may already have downloaded.

Its two matrix entries duplicate `publish.yml`'s Windows entries — the same shape of duplication that let `viz_static` rot across three publish workflows. `scripts/check-publish-matrix-sync.py` makes that a CI failure instead, wired into `docs-drift.yml`.

## Verification

- **actionlint: 0 findings** on all four workflows (`publish.yml` was 0 at baseline too, so this holds the bar). It caught one real bug during development — `matrix.job.musl-prep` doesn't exist on the Windows entries.
- **Step-by-step semantic diff** of the extracted job vs. the original: all **16 steps identical** after the `matrix.job.*` → `inputs.*` rename, with exactly the three intended `--emit=asm` removals and no other change.
- **The sync guard was negative-tested** — injecting `viz_static` into `publish-windows.yml`'s msvc entry makes it exit 1 with a diff.

## Follow-up, not in this PR

`publish-portable.yml` and `publish-qsvpy.yml` still carry their own copies of these steps and should move onto `publish-target.yml` too. Out of scope while a release is blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)