### PR TITLE
ci: let a Windows retry build a ref other than the release tag

### DIFF
--- a/.github/workflows/publish-target.yml
+++ b/.github/workflows/publish-target.yml
@@ -50,6 +50,31 @@ on:
         description: release tag to build and upload to
         type: string
         required: true
+      source_ref:
+        # Normally the source IS the tag, and that is what a real release must do.
+        #
+        # The escape hatch exists because the workflow YAML and the source come from
+        # DIFFERENT refs: GitHub reads the workflow from the ref that triggered the run,
+        # but these jobs check out `previous_tag`. So a CI fix expressed in the matrix
+        # (e.g. dropping viz_static from addl-build-args) takes effect on a retry, while
+        # an identical fix expressed in Cargo.toml does NOT - the tag checkout reverts it.
+        #
+        # That asymmetry is exactly why Windows could not publish 22.0.0/22.0.1: qsv's
+        # viz_static removal lived in the matrix and worked, while qsvmcp's lived in the
+        # `qsvmcp` feature in Cargo.toml and was silently undone on every run. `qsvmcp`
+        # gained viz_static in 2f83bcd8e (viz, #4019) between 21.1.0 and 22.0.0, and
+        # Windows shipped binaries for 21.1.0 and nothing for either release after it.
+        #
+        # Setting this builds from a ref that HAS the Cargo.toml fix while still naming
+        # and uploading assets under `previous_tag`. The binaries then differ from that
+        # tag's source - only use it for a retry where the tag itself cannot build, and
+        # never for the initial publish of a release.
+        description: >-
+          ref to BUILD from when it must differ from previous_tag (retry escape hatch).
+          Empty (default) builds previous_tag, which is what a real release does.
+        type: string
+        required: false
+        default: ''
       rust:
         type: string
         default: stable
@@ -186,9 +211,11 @@ jobs:
         toolchain: ${{ inputs.rust }}
         target: ${{ inputs.target }}
     - name: Checkout repository
+      # keep this ref IDENTICAL to the package job's - package ships THIRD_PARTY_NOTICES.md
+      # and docs/publishing_assets/qsv-<target>.txt, which describe these binaries.
       uses: actions/checkout@v7
       with:
-        ref: ${{ inputs.previous_tag }}
+        ref: ${{ inputs.source_ref != '' && inputs.source_ref || inputs.previous_tag }}
     - name: apt-get update Ubuntu, libwayland-dev
       if: ${{ inputs.os_name == 'linux' }}
       run: |
@@ -319,9 +346,10 @@ jobs:
         toolchain: ${{ inputs.rust }}
     - name: Checkout repository
       # for LICENSE-MIT / COPYING / THIRD_PARTY_NOTICES.md and docs/publishing_assets/
+      # same ref as the build job - see the note there
       uses: actions/checkout@v7
       with:
-        ref: ${{ inputs.previous_tag }}
+        ref: ${{ inputs.source_ref != '' && inputs.source_ref || inputs.previous_tag }}
     - name: Download binaries
       uses: actions/download-artifact@v8
       with:

--- a/.github/workflows/publish-windows.yml
+++ b/.github/workflows/publish-windows.yml
@@ -20,19 +20,61 @@ name: Publish (Windows only)
 
 on:
   workflow_dispatch:
+    inputs:
+      source_ref:
+        description: >-
+          Ref to BUILD from. Default (empty) = the dispatched commit, NOT the release tag -
+          see the source_ref note below. Assets are always named with the release tag.
+        type: string
+        required: false
+        default: ''
+      release_tag:
+        description: >-
+          Release tag to upload to. Empty = auto-detect (see the analyze-tags guard).
+        type: string
+        required: false
+        default: ''
 
 jobs:
   analyze-tags:
     runs-on: ubuntu-22.04
     outputs:
-      previous-tag: ${{ steps.previoustag.outputs.tag }}
+      previous-tag: ${{ steps.resolve.outputs.tag }}
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Get previous tag
         id: previoustag
+        if: ${{ inputs.release_tag == '' }}
         uses: "WyriHaximus/github-action-get-previous-tag@v2"
+      # This workflow is dispatched from an UNTAGGED master, whereas publish.yml runs with
+      # HEAD at the tag - so tag auto-detection is not exercised the same way here, and it
+      # has never actually reached the upload step. The repo also carries non-version tags
+      # (`git tag --sort=-version:refname | head -1` returns `rkyv`), so a wrong resolution
+      # is plausible, and svenstaro/upload-release-action runs with overwrite: true. Assert
+      # the shape before anything spends hours building.
+      - name: Resolve and validate release tag
+        id: resolve
+        shell: bash
+        env:
+          OVERRIDE: ${{ inputs.release_tag }}
+          DETECTED: ${{ steps.previoustag.outputs.tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${OVERRIDE:-$DETECTED}"
+          echo "override='$OVERRIDE' detected='$DETECTED' -> resolved='$TAG'"
+          if [[ ! "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::resolved release tag '$TAG' is not MAJOR.MINOR.PATCH." \
+                 "Re-dispatch with release_tag set explicitly."
+            exit 1
+          fi
+          if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "::error::release '$TAG' does not exist - refusing to create one from a" \
+                 "Windows-only retry."
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
   publish:
     name: Publish for ${{ matrix.job.target }}
@@ -123,6 +165,19 @@ jobs:
       os_name: ${{ matrix.job.os-name }}
       target: ${{ matrix.job.target }}
       previous_tag: ${{ needs.analyze-tags.outputs.previous-tag }}
+      # Build the DISPATCHED COMMIT by default, not the release tag - the opposite of
+      # publish.yml, and deliberate. This workflow only runs when a Windows publish has
+      # already failed, and the fixes for such a failure routinely live in Cargo.toml
+      # (feature tables), which a tag checkout would revert while the matrix-level fixes
+      # in this same file silently took effect. That split is what kept 22.0.0 and 22.0.1
+      # from ever shipping Windows binaries. Pinned to the SHA, not a branch name, so a
+      # push mid-run cannot change what is being built.
+      #
+      # The tradeoff is real: the uploaded zip is named for the release tag but built from
+      # a later commit, so it can differ from that tag's other platforms. For 22.0.1 that
+      # is unavoidable - its qsvmcp pulls viz_static, which does not finish on Windows.
+      # If you want every platform on one source, cut a new release instead.
+      source_ref: ${{ inputs.source_ref != '' && inputs.source_ref || github.sha }}
       rust: ${{ matrix.rust }}
       addl_build_args: ${{ matrix.job.addl-build-args }}
       default_features: ${{ matrix.job.default-features }}


### PR DESCRIPTION
## Why Windows could not publish

`publish-target.yml` takes its **workflow YAML from the ref that triggered the run**, but
checks out **`previous_tag`** for the source. A CI fix written in the matrix therefore takes
effect on a retry, while the identical fix written in `Cargo.toml` is silently reverted by
the tag checkout.

That asymmetry is why 22.0.1 shipped no Windows binaries:

| binary | where its `viz_static` removal lives | effect on a retry |
|---|---|---|
| `qsv` | `addl-build-args` in the matrix | applied → built fine (52m / 97m PGO) |
| `qsvmcp` | the `qsvmcp` feature in `Cargo.toml` | **reverted → never finished, in any run** |

`qsvmcp` gained `viz_static` in 2f83bcd8e (`viz`, #4019). 21.1.0 — the last release whose
`qsvmcp` had no `viz_static` — shipped Windows binaries; 22.0.1 did not, across three
capped runs (31243109948, 31261021249, 31287336214), each ≥218m with `Build qsvmcp` never
completing once.

A consequence worth flagging: every earlier attempt to explain the `qsvmcp` build time
(crate counts, polars feature counts, LOC) was measured against **master's** `Cargo.toml`,
and so described a build CI never performed.

## Proof

Run [31303175743](https://github.com/dathere/qsv/actions/runs/31303175743) — success.

| job | total | steps |
|---|---|---|
| msvc `[main]` | 107m | qsv PGO 97m, qsvlite 9m |
| msvc `[mcp]` | **46m** | qsvmcp 46m |
| gnu `[main]` | 61m | qsv 52m, qsvlite 8m |
| gnu `[mcp]` | **47m** | qsvmcp 47m |
| `[package]` ×2 | 3m / 4m | |

`Build qsvmcp` went from ≥268m-and-never-finishing to **under 47 minutes**. Both zips are
now on the 22.0.1 release (msvc 142.0 MB, gnu 118.7 MB), each verified to contain
`qsv.exe`, `qsvlite.exe`, `qsvmcp.exe` and the license/notice files. The six pre-existing
release assets kept their original timestamps.

## What this changes

- **`publish-target.yml`**: new optional `source_ref`. Empty (the default) builds
  `previous_tag`, so **`publish.yml` — the real release path — is unchanged**. Used by the
  build *and* package jobs alike, so the shipped `THIRD_PARTY_NOTICES.md` and per-target
  README keep describing the binaries beside them.
- **`publish-windows.yml`**: defaults `source_ref` to the dispatched commit, pinned to the
  SHA so a mid-run push cannot change what is built. This is the opposite of `publish.yml`
  and deliberate — this workflow only runs after a Windows publish has already failed,
  which is exactly when the fix is on master and not in the tag.
- **Release-tag guard.** This workflow is dispatched from an untagged master, so tag
  auto-detection is not exercised the way `publish.yml` exercises it; the repo carries a
  non-version tag (`git tag --sort=-version:refname | head -1` returns `rkyv`); and the
  upload runs with `overwrite: true`. The guard asserts `MAJOR.MINOR.PATCH` and that the
  release exists, with a `release_tag` input to override. It logged
  `override='' detected='22.0.1' -> resolved='22.0.1'`.

**The next release will not need `source_ref`** — master's `Cargo.toml` already has
`qsvmcp` without `viz_static`, so a new tag carries the fix. This is a retry escape hatch,
not a new default.

## Provenance

The shipped Windows 22.0.1 assets were built from **`2a0feb607`** on this branch, **not**
from the 22.0.1 tag. Recorded here so the source stays findable if the branch is deleted.
`qsv --version` still reports `22.0.1`: the string comes from `CARGO_PKG_VERSION`
(`util.rs:140`/`:284`), and `Cargo.toml`'s `version` is unchanged on this branch.
Self-update detection is intact — `util.rs:1623` gates on `QSV_KIND.starts_with("prebuilt")`,
satisfied by both `prebuilt` and the PGO step's `prebuilt-pgo`.

## Note on the commit message

The commit body carries a 3-row table including `22.0.0 / viz_static / no Windows assets`.
There is no release object for 22.0.0 (tag only), so that row is literally true but
misleading as evidence — it shipped nothing at all, for unrelated reasons. The claim rests
on the 21.1.0-vs-22.0.1 contrast and, more directly, on the ≥268m → 46m before/after above.

## Follow-ups (not in this PR)

- **#4374** (breaking: drop `get`/`get_cloud` from `qsvmcp`) was adopted for a build-time
  problem it did not cause; measured impact was 2 crates. Worth revisiting on its own merits.
- **#4369** (cap 270 → 330) is now unnecessary — the slowest job is 107m.
- #4373's `lto: thin` + `codegen-units: 16` should **not** be reverted casually: they are
  the settings these successful builds ran under, and fat LTO + `codegen-units=1` has never
  completed for `qsvmcp` on Windows.
- `cargo-timings-*` artifacts for all four legs are attached to the run (14-day retention) —
  the first real Windows build-time data.

Validated with `actionlint` (0 findings) and `scripts/check-publish-matrix-sync.py` (OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)