### PR TITLE
docs(get/dc): make `Config::new`'s implicit network I/O explicit

### DIFF
--- a/docs/help/get.md
+++ b/docs/help/get.md
@@ -186,7 +186,7 @@ qsv get --help
 |--------|------|-------------|--------|
 | &nbsp;`‑‑name`&nbsp; | string | Logical cache name (the `dc:` handle) for the fetched entry. Defaults to the source's terminal path segment. Ignored when multiple sources are given. |  |
 | &nbsp;`‑‑ttl`&nbsp; | integer | Per-entry time-to-live in seconds. -1 = never expire. Also the value applied by cache-set-ttl. | `2419200` |
-| &nbsp;`‑‑refresh`&nbsp; | string | Staleness policy for `dc:` use: on-stale, always or never. Also the value applied by cache-set-policy. | `on-stale` |
+| &nbsp;`‑‑refresh`&nbsp; | string | Revalidation policy for `dc:` use: on-stale, always or never. A `dc:` input re-fetches only past TTL; `always` does not change that - it only makes that fetch unconditional, skipping If-None-Match/If-Modified-Since revalidation. Also the value applied by cache-set-policy. | `on-stale` |
 | &nbsp;`‑‑compress`&nbsp; | string | Transparent blob compression: zstd or none. | `zstd` |
 | &nbsp;`‑‑force`&nbsp; | flag | Re-fetch even if a fresh cached copy exists. |  |
 | &nbsp;`‑‑sample`&nbsp; | integer | PREVIEW: stream the first N data records of <source> to stdout (or the --output file) WITHOUT caching. No `dc:` entry is created. The sniffed header row is re-attached. Single <source> only. |  |

--- a/src/cmd/get.rs
+++ b/src/cmd/get.rs
@@ -105,7 +105,10 @@ get options:
                            Ignored when multiple sources are given.
     --ttl <secs>           Per-entry time-to-live in seconds. -1 = never expire.
                            Also the value applied by cache-set-ttl. [default: 2419200]
-    --refresh <policy>     Staleness policy for `dc:` use: on-stale, always or never.
+    --refresh <policy>     Revalidation policy for `dc:` use: on-stale, always or never.
+                           A `dc:` input re-fetches only past TTL; `always` does not
+                           change that - it only makes that fetch unconditional,
+                           skipping If-None-Match/If-Modified-Since revalidation.
                            Also the value applied by cache-set-policy. [default: on-stale]
     --compress <algo>      Transparent blob compression: zstd or none.
                            [default: zstd]

--- a/src/config.rs
+++ b/src/config.rs
@@ -189,24 +189,48 @@ impl Config {
     /// - `QSV_RDR_BUFFER_CAPACITY`: Sets read buffer capacity.
     /// - `QSV_WTR_BUFFER_CAPACITY`: Sets write buffer capacity.
     /// - `QSV_SKIP_FORMAT_CHECK`: Set to skip file extension checking.
+    ///
+    /// # This constructor may perform network I/O
+    ///
+    /// A `dc:<name>` input is a handle into the `get` command's disk cache, and it is resolved
+    /// to a concrete path HERE. If the cached entry has reached its TTL (and its refresh policy
+    /// is not `never`), that resolution revalidates the entry against its original source — a
+    /// network round-trip, from inside a constructor that returns `Config` rather than
+    /// `Result`. Surprising, and deliberate; see the bounds below.
+    ///
+    /// - **At most once per run.** `diskcache::DC_RESOLVED` memoizes a resolved handle for the life
+    ///   of the process, so a command that builds many `Config`s cannot multiply that into many
+    ///   fetches, and every consumer in a run sees the SAME materialized CSV. Before that memo,
+    ///   `qsv frequency dc:x` resolved the handle 4 times in one run (issue #4257).
+    /// - **Never fails the constructor.** A failed refresh falls back to the stale cached copy. A
+    ///   handle that cannot be resolved at all is stashed in `format_error` and surfaced at reader
+    ///   construction (`reader`, `reader_file`, `reader_file_stdin`).
+    ///
+    /// Why it stays here (issue #4274): the fetch cannot simply be hoisted to command entry.
+    /// There is no uniform input-token position across commands, `qsv get`'s own subcommands
+    /// take `dc:` names and are contractually offline, several `Args` structs are built without
+    /// argv at all, and 39 commands reach the cache ONLY through this constructor — so hoisting
+    /// would silently stop refreshing for them. The coherent fix is to defer resolution to the
+    /// lazy read path (the `read_input` `OnceLock` / `prepared_for_read` machinery that
+    /// auto-decompression already uses), which is a wider change than the problem warrants.
     pub fn new(path: Option<&String>) -> Config {
-        // Resolve a `dc:<name>` cache reference (the `get` command's disk cache)
-        // to a concrete file path up front, so the rest of Config::new treats it
-        // like an ordinary local file (delimiter detection, indexing, etc.).
-        // Config::new is infallible, so a resolution failure is surfaced later
-        // via `format_error` rather than panicking.
+        // Resolve a `dc:<name>` cache reference (the `get` command's disk cache) to a concrete
+        // file path up front, so the rest of Config::new treats it like an ordinary local file
+        // (delimiter detection, indexing, etc.).
+        //
+        // NOTE: this MAY FETCH. Past TTL, `resolve_dc_path` revalidates against the origin.
+        // It is memoized per run, and Config::new is infallible, so a resolution failure is
+        // surfaced later via `format_error` rather than panicking. See the doc comment above.
         #[cfg(feature = "get")]
         let mut dc_format_error: Option<String> = None;
         #[cfg(feature = "get")]
-        let dc_resolved: Option<String> = match path {
-            Some(s) if s.starts_with("dc:") => {
-                match crate::diskcache::resolve_dc_path(&s["dc:".len()..]) {
-                    Ok(p) => Some(p.to_string_lossy().to_string()),
-                    Err(e) => {
-                        dc_format_error = Some(e.to_string());
-                        None
-                    },
-                }
+        let dc_resolved: Option<String> = match path.and_then(|s| s.strip_prefix("dc:")) {
+            Some(dc_name) => match crate::diskcache::resolve_dc_path(dc_name) {
+                Ok(p) => Some(p.to_string_lossy().to_string()),
+                Err(e) => {
+                    dc_format_error = Some(e.to_string());
+                    None
+                },
             },
             _ => None,
         };

--- a/src/diskcache.rs
+++ b/src/diskcache.rs
@@ -431,7 +431,12 @@ mod rich {
         /// Revalidate only when the entry is older than its TTL (the default).
         #[default]
         OnStale,
-        /// Always re-fetch.
+        /// Fetch unconditionally: skip the conditional `If-None-Match` /
+        /// `If-Modified-Since` revalidation and always re-download the body.
+        ///
+        /// This governs HOW a fetch is made, not WHETHER one happens. A `dc:`
+        /// resolution still fetches only past TTL (see `resolve_dc_uncached`), so
+        /// `always` with an unelapsed TTL never touches the network.
         Always,
         /// Never revalidate; serve the cached copy regardless of age.
         Never,
@@ -2864,9 +2869,17 @@ mod rich {
     ///
     /// Memoized per run (see `DC_RESOLVED`): the first resolution of a handle does the
     /// possibly-refreshing, possibly-networked work and every later one reuses it, so all
-    /// consumers in the run see the SAME materialized CSV. This applies to
-    /// `RefreshPolicy::Always` too — it re-fetches once per run rather than once per
-    /// resolution, since one snapshot per run is the point.
+    /// consumers in the run see the SAME materialized CSV.
+    ///
+    /// The refresh gate is TTL-driven, NOT policy-driven: `resolve_dc_uncached` fetches only
+    /// when the policy is not `Never` AND `ttl_secs >= 0` AND the entry's age has reached its
+    /// TTL. `RefreshPolicy::Always` does not widen that gate — it only makes the fetch, once
+    /// triggered, unconditional. So `--refresh always` on an entry inside its TTL never
+    /// touches the network here.
+    ///
+    /// There is no offline/no-network switch. The only ways to suppress a refresh are
+    /// per-entry persisted state: `qsv get cache-set-policy <name> --refresh=never`,
+    /// `qsv get cache-set-ttl <name> --ttl=-1`, or simply an unelapsed TTL.
     ///
     /// The stats-sidecar sync deliberately runs on EVERY call. It is purely local and is not
     /// idempotent by design: it captures the `.stats.csv.data.jsonl` sidecar into a durable


### PR DESCRIPTION
Closes #4274.

## What this is

#4274 is the deliberate leftover from #4257/#4273: `Config::new` (`src/config.rs`) resolves a `dc:<name>` input by calling `diskcache::resolve_dc_path`, which past TTL performs a **network fetch** — from a constructor that returns `Config`, not `Result`, and is used everywhere as a cheap infallible call.

#4273 fixed the *correctness* problem (a `(cache_dir, name)`-keyed per-run memo means only the first resolution fetches, so every consumer sees one snapshot). What remained was **surprise and discoverability**. The issue itself says "not urgent … a design/ergonomics cleanup … not a bug."

This PR documents the behavior instead of moving it, and corrects a related inaccuracy found along the way. **No behavior change.**

## Why the fetch stays in the constructor

I investigated the issue's own suggested direction (Option 1: resolve once at command entry, rewrite `arg_input`). It is not viable:

1. **No uniform input-token position.** `main.rs`'s dispatch and `util::get_args` are the only two chokepoints and both see untyped argv tokens. Input shapes vary: `Option<String>`, `String` (`excel`, `index`), `Vec<PathBuf>` (`cat`, `headers`, `scoresql`, `sqlp`, `to`, `validate`), `Vec<String>` (`blake3`), `arg_input1`/`arg_input2` (`join`, `joinp`, `exclude`), `arg_input_left`/`_right` (`diff`).
2. **`qsv get`'s own subcommands take cache *names*, not paths, and are contractually offline** — "It is offline: it reads the cached blob directly and never re-fetches the source." `cache-fetch`/`cache-set-ttl`/`cache-set-policy` each strip a `dc:` prefix. A blanket rewrite or an argv-prime pass would break that, and `cache-set-ttl` would refresh *before* retuning the TTL.
3. **Several `Args` structs are built without argv at all** (`stats`, `joinp`, `sniff`, `schema`, `tojsonl`), plus in-place mutation after `get_args` (`frequency`, `stats`, `slice`). An entry-point rewrite misses these, and the failure mode is a silently stale snapshot — the same failure class #4257 killed.
4. **It inverts the codebase's established pattern.** `viz` encodes "raw string for naming, resolved path for data". Rewriting `arg_input` would leak a materialized temp filename into schema field descriptions, describegpt's LLM-facing SQL table name, and `.pschema.json`/`.stats.csv*` sidecar names — and would break `clean`'s stem-based sidecar enumeration.
5. **A refresh-coverage gap of 39 commands.** Of the 47 commands that build a `Config` from `arg_input`, only 20 also reach `util::process_input` or the stats-cache helpers. The other 39 — apply, applydp, behead, color, count, datefmt, dedup, denull, diff, enumerate, explode, extdedup, fetch, fetchpost, fill, fixedwidth, fixlengths, flatten, fmt, foreach, implode, input, luau, partition, pseudo, python, rename, replace, reverse, safenames, search, searchset, select, sort, split, stats, table, template, transpose — reach the cache **only** through this constructor. Making it network-free without a replacement silently stops refreshing for all of them.

The coherent real fix is **lazy resolution inside `Config`**: defer resolution and refresh to the existing `read_input: Arc<OnceLock<…>>` / `prepared_for_read` machinery that auto-decompression already uses. That is a real refactor of the most-shared file in the codebase, disproportionate to a self-declared non-bug — but it is recorded in the doc comment as the shape to reach for if this ever becomes one.

## `RefreshPolicy::Always` was documented wrong

Found while writing the above, and arguably the most useful part of this PR.

`RefreshPolicy::Always`'s enum doc read simply `/// Always re-fetch.`, and `resolve_dc_path`'s doc said it "re-fetches once per run rather than once per resolution" (that phrasing also appears in #4273's merged body). Neither is true for `dc:` resolution — the gate in `resolve_dc_uncached` requires `policy != Never` **and** `ttl_secs >= 0` **and** `age >= ttl_secs` before `get_resource` is called. **With `--refresh always` and an unelapsed TTL, a `dc:` resolve never touches the network.**

What `Always` actually controls is that a fetch, *once triggered*, is unconditional — it suppresses `If-None-Match`/`If-Modified-Since` (see the `let unconditional = opts.force || opts.refresh_policy == RefreshPolicy::Always;` lines in `ingest_cloud`/`ingest_http`).

Corrected in both doc comments **and** in the user-facing `--refresh` help text, since that is the one place a user rather than a maintainer forms the wrong mental model. Also documented: there is no offline/no-network switch; the only suppressors are per-entry persisted state (`cache-set-policy --refresh=never`, `cache-set-ttl --ttl=-1`, an unelapsed TTL).

## Changes

- `src/config.rs` — new "This constructor may perform network I/O" section on `Config::new`, stating the fetch, its two bounds (memoized once per run; never fails the constructor — a failed refresh falls back to the stale copy, an unresolvable handle is stashed in `format_error`), and why it stays. Inline comment now leads with "this MAY FETCH". Also switched the `dc:` prefix strip from `&s["dc:".len()..]` to `strip_prefix`, matching every other `dc:` site in the repo.
- `src/diskcache.rs` — corrected `RefreshPolicy::Always` and `resolve_dc_path` doc comments.
- `src/cmd/get.rs` + `docs/help/get.md` — corrected `--refresh` help text and regenerated.

Deliberately **not** included: renaming `resolve_dc_path` to announce the fetch. The payload would be a suffix across 14 sites, and the warning is now where #4257 was actually missed.

## Verification

- `cargo build --locked --bin qsv -F all_features` and `--bin qsvdp -F datapusher_plus` — clean.
- `cargo clippy --bin qsv -F all_features` — clean (one pre-existing unrelated warning).
- `cargo t get -F all_features` — 55 passed, 0 failed. Behavior is unchanged, so the existing guards are the check: `get_dc_resolves_once_per_run`, `get_dc_stats_cache_for_smart_commands`, `get_dc_works_with_process_input_commands` all pass.
- USAGE edit smoke-tested against the docopt continuation-line trap: `qsv get cache-list` and `qsv get cache-set-policy <name> --refresh=never` both still parse.
- `qsv --generate-help-md` run; the only doc diff is the `--refresh` row in `docs/help/get.md`.
- `cargo +nightly fmt` applied.

No new tests: this changes no behavior, so there is nothing new to assert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
