### PR TITLE
fix(stats): keep the `field` key for empty column names (#4410)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `stats`: **a CSV with an empty column name no longer breaks every stats-cache consumer.** The CSV→JSON conversion behind the stats cache omitted any key whose cell was empty, so a column with an empty *name* lost its `field` key entirely - and `StatsData.field` was the only non-`Option`/non-`#[serde(default)]` string in the struct, so the cache then failed to deserialize with ``missing field `field` ``. Reported against `tojsonl`, but `schema` and `frequency` failed identically; independently, `stats --jsonl` and `--pretty-json` silently emitted records that no downstream consumer could attribute to a column. `field` is now always emitted - keyed by name rather than position, so a future reordering of the stats columns cannot silently reintroduce the bug - and `StatsData.field` is marked `#[serde(default)]` so the poisoned caches the failing run had already written to disk, which still pass mtime validation after an upgrade, keep loading ([#4410](https://github.com/dathere/qsv/issues/4410), [#4412](https://github.com/dathere/qsv/pull/4412)).
+
 ## [22.0.1] - 2026-08-09 📐 The "Data Schematic" Release 📊
 
 qsv's biggest release ever with 580+ commits since v21.1.0. The headliner is **`viz`** - an entirely new command that turns a CSV into interactive [plotly](https://plotly.com/javascript/) charts and maps, with `viz smart` auto-designing a **Data Schematic** while bundling a [DataTables](https://datatables.net/) viewer as well. Schematics are **self-contained, offline-capable HTML** with static PNG/SVG/PDF export via `viz_static`. See the [gallery](https://dathere.github.io/qsv/gallery.html).

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -644,6 +644,13 @@ impl StatsArgs {
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Default, Debug)]
 pub struct StatsData {
+    // NOT dead code, even though the writer now always emits `field`: stats caches
+    // written by qsv 22.0.1 and earlier dropped the `field` key entirely for a column
+    // whose name is empty (issue #4410), and those caches stay on disk and still pass
+    // mtime validation after an upgrade. This default is their migration path - keep it
+    // until such caches can no longer plausibly be in circulation. The key was dropped
+    // precisely because the value was empty, so "" reconstructs the original name exactly.
+    #[serde(default)]
     pub field: String,
     // type is a reserved keyword in Rust
     // so we escape it as r#type

--- a/src/util.rs
+++ b/src/util.rs
@@ -3834,7 +3834,8 @@ pub fn csv_to_jsonl(
 
 // Build a `serde_json::Map` from a CSV record, coercing each cell to the JSON type
 // declared in `csv_types` (defaulting to String for unknown keys). Empty cells are
-// skipped entirely (no key is emitted), matching the JSONL sidecar behavior.
+// skipped entirely (no key is emitted), matching the JSONL sidecar behavior - with the
+// sole exception of `field`, which is always emitted (see below).
 fn csv_record_to_json_map(
     record: &csv::StringRecord,
     key_vec: &[String],
@@ -3849,6 +3850,14 @@ fn csv_record_to_json_map(
         };
         let data_type = csv_types.get(key.as_str()).unwrap_or(&JsonTypes::String);
         let value = if val.is_empty() {
+            // `field` carries the column's identity. Dropping it makes the record
+            // unattributable to a column and breaks StatsData deserialization when the
+            // column name is itself empty (issue #4410). Keyed by name rather than by
+            // position so a future reordering of the stats columns can't silently
+            // reintroduce the bug. All other empty cells are still skipped.
+            if key == "field" {
+                json_object.insert(key.to_string(), serde_json::Value::String(String::new()));
+            }
             continue;
         } else {
             match *data_type {

--- a/tests/test_stats.rs
+++ b/tests/test_stats.rs
@@ -6530,6 +6530,65 @@ fn stats_pretty_json_stdout() {
 }
 
 #[test]
+fn stats_json_empty_column_name_keeps_field_key() {
+    // issue #4410: an empty column name means an empty `field` cell, and the CSV->JSON
+    // conversion used to drop empty cells wholesale - so the record lost its `field` key
+    // and became unattributable to a column (and unparseable as StatsData downstream).
+    let wrk = Workdir::new("stats_json_empty_column_name_keeps_field_key");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["a", "", "c"],
+            svec!["1", "2", "3"],
+            svec!["4", "5", "6"],
+        ],
+    );
+
+    let mut cmd = wrk.command("stats");
+    cmd.arg("--cache-threshold")
+        .arg("0")
+        .arg("--jsonl")
+        .arg("data.csv");
+    let got: String = wrk.stdout(&mut cmd);
+
+    let fields: Vec<String> = got
+        .lines()
+        .map(|line| {
+            let v: serde_json::Value = serde_json::from_str(line)
+                .unwrap_or_else(|_| panic!("each line should be valid JSON: {line}"));
+            v.get("field")
+                .unwrap_or_else(|| panic!("every record must carry a `field` key: {line}"))
+                .as_str()
+                .unwrap()
+                .to_string()
+        })
+        .collect();
+    assert_eq!(fields, vec!["a", "", "c"]);
+
+    // same guarantee for the --pretty-json array output
+    let mut pretty_cmd = wrk.command("stats");
+    pretty_cmd
+        .arg("--cache-threshold")
+        .arg("0")
+        .arg("--pretty-json")
+        .arg("data.csv");
+    let pretty_got: String = wrk.stdout(&mut pretty_cmd);
+    let arr: serde_json::Value = serde_json::from_str(&pretty_got).unwrap();
+    let pretty_fields: Vec<&str> = arr
+        .as_array()
+        .expect("output should be a JSON array")
+        .iter()
+        .map(|v| {
+            v.get("field")
+                .expect("every object must carry a `field` key")
+                .as_str()
+                .unwrap()
+        })
+        .collect();
+    assert_eq!(pretty_fields, vec!["a", "", "c"]);
+}
+
+#[test]
 fn stats_jsonl_matches_stats_jsonl_sidecar() {
     // --jsonl stdout must be byte-identical to what --stats-jsonl writes to its sidecar.
     let wrk = Workdir::new("stats_jsonl_matches_sidecar");

--- a/tests/test_tojsonl.rs
+++ b/tests/test_tojsonl.rs
@@ -637,6 +637,33 @@ fn tojsonl_number_nan_infinity_literal_is_null() {
 
 #[test]
 #[serial]
+fn tojsonl_4410() {
+    // issue #4410: a CSV with an empty column name failed with
+    // `error parsing stats: Serde("missing field `field`")`, because the stats cache
+    // JSONL dropped the `field` key for the empty-named column.
+    let wrk = Workdir::new("tojsonl_4410");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec!["a", "", "c"],
+            svec!["1", "2", "3"],
+            svec!["4", "5", "6"],
+        ],
+    );
+
+    let mut cmd = wrk.command("tojsonl");
+    cmd.arg("in.csv");
+
+    wrk.assert_success(&mut cmd);
+
+    let got: String = wrk.stdout(&mut cmd);
+    let expected = r#"{"a":1,"":2,"c":3}
+{"a":4,"":5,"c":6}"#;
+    assert_eq!(got, expected);
+}
+
+#[test]
+#[serial]
 fn tojsonl_duplicate_headers_warns() {
     // Duplicate column names collapse into a single JSON key; warn the user.
     let wrk = Workdir::new("tojsonl_duplicate_headers_warns");

--- a/tests/test_tojsonl.rs
+++ b/tests/test_tojsonl.rs
@@ -669,6 +669,8 @@ fn tojsonl_4410_legacy_cache_missing_field_key() {
     // the `field` key entirely for an empty-named column. Such caches stay on disk and
     // still pass mtime validation after an upgrade, which is why `StatsData.field` is
     // `#[serde(default)]`. Without that default this fails with `missing field `field``.
+    use filetime::{FileTime, set_file_mtime};
+
     let wrk = Workdir::new("tojsonl_4410_legacy_cache_missing_field_key");
     wrk.create(
         "in.csv",
@@ -678,6 +680,14 @@ fn tojsonl_4410_legacy_cache_missing_field_key() {
             svec!["4", "5", "6"],
         ],
     );
+
+    // Cache reuse requires `cache_mtime > input_mtime` (strict). On coarse (1s)
+    // filesystem timestamp resolution the input and the cache written moments later can
+    // land in the same tick, forcing a regeneration that would trip the reuse assertion
+    // below - the same hazard documented in test_profile.rs. Backdate the input so it is
+    // unambiguously older, which is deterministic and costs no wall-clock time.
+    let past = FileTime::from_unix_time(FileTime::now().unix_seconds() - 3600, 0);
+    set_file_mtime(wrk.path("in.csv"), past).unwrap();
 
     // prime a valid stats cache, then rewrite it the way a pre-fix qsv would have
     let mut prime = wrk.command("tojsonl");

--- a/tests/test_tojsonl.rs
+++ b/tests/test_tojsonl.rs
@@ -664,6 +664,68 @@ fn tojsonl_4410() {
 
 #[test]
 #[serial]
+fn tojsonl_4410_legacy_cache_missing_field_key() {
+    // issue #4410 migration path: stats caches written by qsv 22.0.1 and earlier dropped
+    // the `field` key entirely for an empty-named column. Such caches stay on disk and
+    // still pass mtime validation after an upgrade, which is why `StatsData.field` is
+    // `#[serde(default)]`. Without that default this fails with `missing field `field``.
+    let wrk = Workdir::new("tojsonl_4410_legacy_cache_missing_field_key");
+    wrk.create(
+        "in.csv",
+        vec![
+            svec!["a", "", "c"],
+            svec!["1", "2", "3"],
+            svec!["4", "5", "6"],
+        ],
+    );
+
+    // prime a valid stats cache, then rewrite it the way a pre-fix qsv would have
+    let mut prime = wrk.command("tojsonl");
+    prime.arg("in.csv");
+    wrk.assert_success(&mut prime);
+
+    let cache_path = wrk.path("in.stats.csv.data.jsonl");
+    let cache = std::fs::read_to_string(&cache_path).unwrap();
+    let downgraded: Vec<String> = cache
+        .lines()
+        .map(|line| {
+            let mut v: serde_json::Value = serde_json::from_str(line)
+                .unwrap_or_else(|_| panic!("cache line should be valid JSON: {line}"));
+            let obj = v.as_object_mut().expect("each cache line is a JSON object");
+            if obj.get("field").and_then(serde_json::Value::as_str) == Some("") {
+                obj.remove("field");
+            }
+            serde_json::to_string(&v).unwrap()
+        })
+        .collect();
+    assert!(
+        downgraded.iter().any(|l| !l.contains("\"field\"")),
+        "setup failed: no record ended up missing its `field` key"
+    );
+    std::fs::write(&cache_path, downgraded.join("\n") + "\n").unwrap();
+
+    // the consumer must load that cache and still map the empty header correctly
+    let mut cmd = wrk.command("tojsonl");
+    cmd.arg("in.csv");
+    wrk.assert_success(&mut cmd);
+
+    let got: String = wrk.stdout(&mut cmd);
+    let expected = r#"{"a":1,"":2,"c":3}
+{"a":4,"":5,"c":6}"#;
+    assert_eq!(got, expected);
+
+    // the run must have REUSED the downgraded cache rather than regenerating it -
+    // otherwise this test would pass even with the serde default removed
+    let after = std::fs::read_to_string(&cache_path).unwrap();
+    assert!(
+        after.lines().any(|l| !l.contains("\"field\"")),
+        "cache was regenerated instead of reused, so this no longer guards the migration path: \
+         {after}"
+    );
+}
+
+#[test]
+#[serial]
 fn tojsonl_duplicate_headers_warns() {
     // Duplicate column names collapse into a single JSON key; warn the user.
     let wrk = Workdir::new("tojsonl_duplicate_headers_warns");


### PR DESCRIPTION
Fixes #4410.

## The bug

```bash
printf 'a,,c\n1,2,3\n4,5,6\n' > empty-header.csv
qsv tojsonl empty-header.csv
# Failed to infer field types: error parsing stats: Serde("missing field `field`") at character 0
```

`qsv stats` itself was fine — its CSV output has a correct row with an empty `field` cell. The break was in the CSV→JSON conversion behind the stats cache: `csv_record_to_json_map` omitted any key whose cell was empty, so a column with an empty *name* lost its `field` key entirely:

```json
{"field":"a","type":"Integer",...}
{"type":"Integer",...}              <-- no "field"
{"field":"c","type":"Integer",...}
```

`StatsData.field` was the only non-`Option`, non-`#[serde(default)]` string in the struct, so the cache then failed to deserialize.

## Wider than reported

Reported against `tojsonl`, but **every** stats-cache consumer failed identically — confirmed for `schema` and `frequency`. Independently, `stats --jsonl` and `stats --pretty-json` silently emitted records that no downstream consumer could attribute to a column.

## The fix — both layers

- **`src/util.rs`** always emits `field`, keyed by name rather than position so a future reordering of the stats columns can't silently reintroduce the bug. All other empty cells are still skipped. This single change covers the JSONL sidecar, the `--jsonl`/`--pretty-json` stdout modes, and the `moarstats` cache, since they all route through this function.
- **`src/cmd/stats.rs`** marks `StatsData.field` `#[serde(default)]`. This is the migration path, not just defense-in-depth: **the failing run writes the poisoned cache before it errors**, so affected users already have one on disk that still passes mtime validation after upgrading. Without this, the very users who hit the bug stay broken until they touch the CSV or run `qsv clean`.

## Tests

- `stats_json_empty_column_name_keeps_field_key` — asserts `--jsonl` and `--pretty-json` both emit `"field":""`. Guards the writer.
- `tojsonl_4410` — the issue's exact repro, end to end.
- `tojsonl_4410_legacy_cache_missing_field_key` — primes a valid stats cache, strips the `field` key the way a pre-fix qsv would have, and asserts a consumer still loads it. Guards the reader/migration path, which the other two do not. It also asserts the cache was *reused* rather than regenerated, so it can't quietly go vacuous, and it backdates the input with `filetime` so cache-freshness holds at 1s filesystem timestamp resolution (same hazard documented in `test_profile.rs`).

Each layer was mutation-verified: reverting the `util.rs` change fails the stats test, and removing `#[serde(default)]` fails the legacy-cache test.

## Scoped out after checking

- The **frequency cache is unaffected** — it serializes a typed struct, so it always emits every key (verified: it writes `{"field":"",...}` correctly).
- **Not** hardening the other non-default fields (`type`, `nullcount`, `cardinality`): the only way to reach the deserializer without them is a `--typesonly` cache, and those are rejected for lacking the companion `.stats.csv.json`. Verified empirically — such a cache is discarded and regenerated.
- **Duplicate empty headers** (`a,,,c`) collapse onto one JSON key exactly like any other duplicate name, and the existing warning does fire (as `Duplicate column name(s) detected ()`). Pre-existing behavior, unchanged here.

## Verification

`cargo test -F all_features` — tojsonl 28, stats 831, schema 63, frequency 186, all green. Clippy clean (the only warnings are pre-existing in `viz.rs`/`viz_i18n.rs`).