### PR TITLE
test: read stderr from the run whose status was asserted (#4415, non-viz files)

### DIFF
--- a/tests/test_apply.rs
+++ b/tests/test_apply.rs
@@ -1278,13 +1278,12 @@ fn apply_ops_replace_validation_error() {
         .arg("silver")
         .arg("data.csv");
 
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_error(&mut cmd);
     assert_eq!(
         got,
         "usage error: --comparand (-C) and --replacement (-R) are required for replace \
          operation.\n"
     );
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]
@@ -1383,13 +1382,12 @@ fn apply_ops_regex_replace_validation_error() {
         .arg("(?:\\d{3}-\\d{2}-\\d{4})")
         .arg("data.csv");
 
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_error(&mut cmd);
     assert_eq!(
         got,
         "usage error: --comparand (-C) and --replacement (-R) are required for regex_replace \
          operation.\n"
     );
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]
@@ -1412,9 +1410,7 @@ fn apply_ops_regex_replace_error() {
         .arg("SSN")
         .arg("data.csv");
 
-    wrk.assert_err(&mut cmd);
-
-    let got: String = wrk.output_stderr(&mut cmd);
+    let got: String = wrk.stderr_on_error(&mut cmd);
     // invalid user-supplied regex is an IncorrectUsage error, so stderr is prefixed
     // with "usage error: " (consistent with other validate_operations failures).
     assert!(got.starts_with("usage error: regex_replace expression error"));
@@ -1505,14 +1501,13 @@ fn apply_ops_chain_validation_error() {
         .arg("new_column")
         .arg("data.csv");
 
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_error(&mut cmd);
     assert_eq!(
         got,
         "usage error: you can only use censor(0), copy(0), eudex(0), regex_replace(0), \
          replace(0), sentiment(0), similarity(2), strip(0), and whatlang(0) ONCE per operation \
          series.\n"
     );
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]
@@ -1530,13 +1525,12 @@ fn apply_ops_chain_validation_error_missing_comparand() {
         .arg("new_column")
         .arg("data.csv");
 
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_error(&mut cmd);
     assert_eq!(
         got,
         "usage error: --comparand (-C) and --new-column (-c) are required for similarity \
          operations.\n"
     );
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]
@@ -1556,14 +1550,13 @@ fn apply_ops_multi_column_new_column_rejected() {
         .arg("new")
         .arg("data.csv");
 
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_error(&mut cmd);
     assert_eq!(
         got,
         "usage error: --new-column (-c) requires a single input column. For multi-column \
          operations/emptyreplace, omit --new-column to transform columns in place; optionally use \
          --rename (-r) to rename the transformed columns.\n"
     );
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]
@@ -3114,9 +3107,7 @@ fn apply_empty_selection_without_new_column() {
         .arg("!id")
         .arg("data.csv");
 
-    wrk.assert_err(&mut cmd);
-
-    let got: String = wrk.output_stderr(&mut cmd);
+    let got: String = wrk.stderr_on_error(&mut cmd);
     let expected = "usage error: No columns selected. Column selection is empty.\n";
     assert_eq!(got, expected);
 }
@@ -3325,8 +3316,7 @@ fn apply_summarize_no_headers_error() {
         .arg("--no-cache")
         .arg("data.csv");
 
-    wrk.assert_err(&mut cmd);
-    let got: String = wrk.output_stderr(&mut cmd);
+    let got: String = wrk.stderr_on_error(&mut cmd);
     assert!(got.contains("requires headers"), "got: {got}");
 }
 

--- a/tests/test_applydp.rs
+++ b/tests/test_applydp.rs
@@ -321,13 +321,12 @@ fn applydp_ops_replace_validation_error() {
         .arg("silver")
         .arg("data.csv");
 
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_error(&mut cmd);
     assert_eq!(
         got,
         "usage error: --comparand (-C) and --replacement (-R) are required for replace \
          operation.\n"
     );
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]
@@ -455,13 +454,12 @@ fn applydp_ops_regex_replace_validation_error() {
         .arg("(?:\\d{3}-\\d{2}-\\d{4})")
         .arg("data.csv");
 
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_error(&mut cmd);
     assert_eq!(
         got,
         "usage error: --comparand (-C) and --replacement (-R) are required for regex_replace \
          operation.\n"
     );
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]
@@ -484,9 +482,7 @@ fn applydp_ops_regex_replace_error() {
         .arg("SSN")
         .arg("data.csv");
 
-    wrk.assert_err(&mut cmd);
-
-    let got: String = wrk.output_stderr(&mut cmd);
+    let got: String = wrk.stderr_on_error(&mut cmd);
     // invalid user-supplied regex is an IncorrectUsage error, so stderr is prefixed
     // with "usage error: " (consistent with other validate_operations failures).
     assert!(got.starts_with("usage error: regex_replace expression error"));
@@ -656,13 +652,12 @@ fn applydp_ops_chain_validation_error() {
         .arg("new_column")
         .arg("data.csv");
 
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_error(&mut cmd);
     assert_eq!(
         got,
         "usage error: you can only use copy(0), regex_replace(0), replace(0), and strip(2) ONCE \
          per operation series.\n"
     );
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]
@@ -680,12 +675,11 @@ fn applydp_ops_chain_validation_error_missing_comparand() {
         .arg("new_column")
         .arg("data.csv");
 
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_error(&mut cmd);
     assert_eq!(
         got,
         "usage error: --comparand (-C) is required for strip operations.\n"
     );
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]
@@ -705,14 +699,13 @@ fn applydp_ops_multi_column_new_column_rejected() {
         .arg("new")
         .arg("data.csv");
 
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_error(&mut cmd);
     assert_eq!(
         got,
         "usage error: --new-column (-c) requires a single input column. For multi-column \
          operations/emptyreplace, omit --new-column to transform columns in place; optionally use \
          --rename (-r) to rename the transformed columns.\n"
     );
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]

--- a/tests/test_denull.rs
+++ b/tests/test_denull.rs
@@ -477,9 +477,8 @@ fn denull_apply_refuses_to_overwrite_its_own_input() {
 
     let mut cmd = wrk.command("denull");
     cmd.arg("--apply").arg("d.csv").args(["-o", "d.csv"]);
-    wrk.assert_err(&mut cmd);
     assert!(
-        wrk.output_stderr(&mut cmd)
+        wrk.stderr_on_error(&mut cmd)
             .contains("cannot write to its own input"),
         "expected same-path refusal"
     );
@@ -519,9 +518,8 @@ fn denull_apply_refuses_dash_stdin() {
 
     let mut cmd = wrk.command("denull");
     cmd.arg("--apply").arg("-");
-    wrk.assert_err(&mut cmd);
     assert!(
-        wrk.output_stderr(&mut cmd)
+        wrk.stderr_on_error(&mut cmd)
             .contains("stdin is not supported"),
         "expected stdin refusal for \"-\""
     );

--- a/tests/test_describegpt.rs
+++ b/tests/test_describegpt.rs
@@ -1630,8 +1630,7 @@ p_fewshot_examples = ""
         .arg("--all")
         .arg("--no-cache");
 
-    wrk.assert_err(&mut cmd);
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_error(&mut cmd);
     assert!(
         got.contains("QSV_LLM_APIKEY") || got.to_lowercase().contains("api"),
         "Remote prompt-file URL must trigger the missing-API-key error.\nGot: {}",

--- a/tests/test_diff.rs
+++ b/tests/test_diff.rs
@@ -403,12 +403,11 @@ fn diff_key_by_column_name_columns_have_different_order_error() {
     let mut cmd = wrk.command("diff");
     cmd.args(["left.csv", "right.csv", "--key", "h1"]);
 
-    wrk.assert_err(&mut cmd);
     let expected = "usage error: Column names on left and right CSVs do not match.\nUse `qsv \
                     select` to reorder the columns on the right CSV to match the order of the \
                     left CSV.\nThe key column indices on the left CSV are in index \
                     locations:\n[0]\nand on the right CSV are:\n[1]\n";
-    assert_eq!(wrk.output_stderr(&mut cmd), expected);
+    assert_eq!(wrk.stderr_on_error(&mut cmd), expected);
 }
 
 #[test]
@@ -432,12 +431,11 @@ fn diff_sort_by_column_name_columns_have_different_order_error() {
     let mut cmd = wrk.command("diff");
     cmd.args(["left.csv", "right.csv", "--sort-columns", "h1"]);
 
-    wrk.assert_err(&mut cmd);
     let expected = "usage error: Column names on left and right CSVs do not match.\nUse `qsv \
                     select` to reorder the columns on the right CSV to match the order of the \
                     left CSV.\nThe sort column indices on the left CSV are in index \
                     locations:\n[0]\nand on the right CSV are:\n[1]\n";
-    assert_eq!(wrk.output_stderr(&mut cmd), expected);
+    assert_eq!(wrk.stderr_on_error(&mut cmd), expected);
 }
 
 #[test]

--- a/tests/test_excel.rs
+++ b/tests/test_excel.rs
@@ -134,9 +134,8 @@ fn excel_open_xlsx_readpassword() {
     let mut cmd = wrk.command("excel");
     cmd.arg(xlsx_file);
 
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_error(&mut cmd);
     assert_eq!(got, "Xlsx error: Workbook is password protected\n");
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]
@@ -148,9 +147,8 @@ fn excel_open_ods_readpassword() {
     let mut cmd = wrk.command("excel");
     cmd.arg(ods_file);
 
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_error(&mut cmd);
     assert_eq!(got, "Ods error: Workbook is password protected\n");
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]
@@ -441,10 +439,9 @@ fn excel_invalid_sheet_index() {
     let mut cmd = wrk.command("excel");
     cmd.arg("--sheet").arg("100").arg(xls_file);
 
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_error(&mut cmd);
     let expected = "usage error: sheet index 100 is greater than number of sheets 8\n".to_string();
     assert_eq!(got, expected);
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]
@@ -456,10 +453,9 @@ fn excel_invalid_sheet_neg_index() {
     let mut cmd = wrk.command("excel");
     cmd.arg("--sheet").arg("-100").arg(xls_file);
 
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_error(&mut cmd);
     let expected = "usage error: negative sheet index -100 is out of range for 8 sheets\n";
     assert_eq!(got, expected);
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]
@@ -1444,9 +1440,8 @@ fn excel_empty_sheet2_message() {
     let mut cmd = wrk.command("excel");
     cmd.arg("--sheet").arg("Sheet1").arg(xls_file);
 
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_error(&mut cmd);
     assert_eq!(got, "\"Sheet: Sheet1 \"is empty.\n");
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]
@@ -1657,12 +1652,11 @@ fn excel_range_empty_sheet() {
     cmd.arg("-s").arg("Sheet2");
 
     assert!(
-        wrk.output_stderr(&mut cmd)
+        wrk.stderr_on_error(&mut cmd)
             .matches("sheet is empty")
             .min()
             .is_some()
     );
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]

--- a/tests/test_fetch.rs
+++ b/tests/test_fetch.rs
@@ -490,10 +490,8 @@ fn fetch_jaq_jaqfile_error() {
         .arg(r#"."places"[0]."place name""#)
         .arg("data.csv");
 
-    let got: String = wrk.output_stderr(&mut cmd);
+    let got: String = wrk.stderr_on_error(&mut cmd);
     assert!(got.starts_with("Invalid arguments."));
-
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]
@@ -609,10 +607,8 @@ fn fetch_custom_invalid_header_error() {
         .arg("X-Api-\tSecret :ABC123XYZ") // embedded tab is not valid
         .arg("data.csv");
 
-    let got: String = wrk.output_stderr(&mut cmd);
+    let got: String = wrk.stderr_on_error(&mut cmd);
     assert!(got.starts_with("usage error: Invalid header name"));
-
-    wrk.assert_err(&mut cmd);
 }
 #[test]
 fn fetch_custom_invalid_user_agent_error() {
@@ -628,10 +624,8 @@ fn fetch_custom_invalid_user_agent_error() {
         .arg("Mðzilla/5.0\n (platform; rv:geckoversion) Gecko/geckotrail Firefox/firefoxvèrsion")
         .arg("data.csv");
 
-    let got: String = wrk.output_stderr(&mut cmd);
+    let got: String = wrk.stderr_on_error(&mut cmd);
     assert!(got.starts_with("usage error: Invalid user-agent"));
-
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]
@@ -688,10 +682,8 @@ fn fetch_custom_invalid_value_error() {
         .arg("X-Api-Secret :ABC123\r\nXYZ") // non-visible ascii not valid
         .arg("data.csv");
 
-    let got: String = wrk.output_stderr(&mut cmd);
+    let got: String = wrk.stderr_on_error(&mut cmd);
     assert!(got.starts_with("usage error: Invalid header value"));
-
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]
@@ -712,10 +704,8 @@ fn fetchpost_custom_invalid_header_error() {
         .arg("X-Api-\tSecret :ABC123XYZ") // non-visible ascii not valid
         .arg("data.csv");
 
-    let got: String = wrk.output_stderr(&mut cmd);
+    let got: String = wrk.stderr_on_error(&mut cmd);
     assert!(got.starts_with("usage error: Invalid header name"));
-
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]
@@ -736,10 +726,8 @@ fn fetchpost_custom_invalid_value_error() {
         .arg("X-Api-Secret :ABC123\r\nXYZ") // non-visible ascii not valid
         .arg("data.csv");
 
-    let got: String = wrk.output_stderr(&mut cmd);
+    let got: String = wrk.stderr_on_error(&mut cmd);
     assert!(got.starts_with("usage error: Invalid header value"));
-
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]
@@ -761,10 +749,8 @@ fn fetchpost_custom_invalid_user_agent_error() {
         .arg("Mðzilla/5.0\n (platform; rv:geckoversion) Gecko/geckotrail Firefox/firefoxvèrsion")
         .arg("data.csv");
 
-    let got: String = wrk.output_stderr(&mut cmd);
+    let got: String = wrk.stderr_on_error(&mut cmd);
     assert!(got.starts_with("usage error: Invalid user-agent"));
-
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]

--- a/tests/test_geoconvert.rs
+++ b/tests/test_geoconvert.rs
@@ -154,12 +154,11 @@ fn geoconvert_csv_partial_latlon_flag_errors() {
         .arg("geojson")
         .args(["--latitude", "lat"]);
 
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_error(&mut cmd);
     assert!(
         got.contains("--latitude and --longitude must be used together"),
         "expected partial-flag error, got: {got}"
     );
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]

--- a/tests/test_joinp.rs
+++ b/tests/test_joinp.rs
@@ -2777,8 +2777,7 @@ fn joinp_decimal_comma_validation_with_tsv_files() {
     cmd.args(["id", "left.tsv", "id", "right.tsv"])
         .arg("--decimal-comma");
 
-    wrk.assert_err(&mut cmd);
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_error(&mut cmd);
     assert!(got.contains("Using --decimal-comma with a comma separator is invalid"));
 }
 
@@ -3210,8 +3209,7 @@ fn joinp_manytomany_validate_rejected() {
     cmd.args(["id", "left.csv", "id", "right.csv"])
         .args(["--validate", "manytomany"]);
 
-    let stderr = wrk.output_stderr(&mut cmd);
-    wrk.assert_err(&mut cmd);
+    let stderr = wrk.stderr_on_error(&mut cmd);
     assert!(stderr.contains("Invalid join validation"));
 }
 

--- a/tests/test_json.rs
+++ b/tests/test_json.rs
@@ -35,9 +35,7 @@ fn json_array_empty() {
     let mut cmd = wrk.command("json");
     cmd.arg("data.json");
 
-    wrk.assert_err(&mut cmd);
-
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_error(&mut cmd);
     let expected = "Expected an array of objects in JSON\n".to_string();
 
     assert_eq!(got, expected);
@@ -51,9 +49,7 @@ fn json_array_first_object_empty() {
     let mut cmd = wrk.command("json");
     cmd.arg("data.json");
 
-    wrk.assert_err(&mut cmd);
-
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_error(&mut cmd);
     let expected = "Expected a non-empty JSON object\n".to_string();
 
     assert_eq!(got, expected);
@@ -67,9 +63,7 @@ fn json_random() {
     let mut cmd = wrk.command("json");
     cmd.arg("data.json");
 
-    wrk.assert_err(&mut cmd);
-
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_error(&mut cmd);
     let expected =
         "Failed to parse JSON from file: expected value at line 1 column 1\n".to_string();
 
@@ -154,9 +148,7 @@ fn json_object_empty() {
     let mut cmd = wrk.command("json");
     cmd.arg("data.json");
 
-    wrk.assert_err(&mut cmd);
-
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_error(&mut cmd);
     let expected = "Expected a non-empty JSON object\n".to_string();
 
     assert_eq!(got, expected);
@@ -425,9 +417,7 @@ fn json_flatten_key_collision() {
     let mut cmd = wrk.command("json");
     cmd.arg("data.json");
 
-    wrk.assert_err(&mut cmd);
-
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_error(&mut cmd);
     assert!(
         got.contains("Flattening Key Collision error"),
         "unexpected stderr: {got}"
@@ -575,8 +565,7 @@ fn json_jaq_runtime_error_surfaced() {
     cmd.arg("data.json");
     cmd.args(vec!["--jaq", r#"error("custom_runtime_err")"#]);
 
-    wrk.assert_err(&mut cmd);
-    let got_stderr = wrk.output_stderr(&mut cmd);
+    let got_stderr = wrk.stderr_on_error(&mut cmd);
     assert!(
         got_stderr.contains("jaq query returned no results"),
         "stderr did not mention 'no results': {got_stderr}"

--- a/tests/test_jsonl.rs
+++ b/tests/test_jsonl.rs
@@ -161,13 +161,11 @@ fn jsonl_error_line_number() {
     let mut cmd = wrk.command("jsonl");
     cmd.arg("data.jsonl");
 
-    let stderr = wrk.output_stderr(&mut cmd);
+    let stderr = wrk.stderr_on_error(&mut cmd);
     assert!(
         stderr.contains("Could not parse input line 4 as JSON"),
         "expected stderr to reference input line 4, got: {stderr}"
     );
-
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]

--- a/tests/test_luau.rs
+++ b/tests/test_luau.rs
@@ -272,7 +272,6 @@ BEGIN {
     end
 }!
 
-
 -- this is the MAIN script loop, which is executed for each row
 -- note how we use the _IDX special variable to get the row index
 amount_array[_IDX] = Amount;
@@ -282,7 +281,6 @@ adjusted_array[_IDX] = Amount + margin(Amount, 0.25);
 
 -- running_total is the value we "map" to the "Running Total" column of each row
 return running_total;
-
 
 END {
     -- and this is the END block, which is executed once at the end
@@ -384,7 +382,6 @@ BEGIN {
     _INDEX = _LASTROW;
 }!
 
-
 ----------------------------------------------------------------------------
 -- this is the MAIN script, which is executed for the row specified by _INDEX
 -- As we are doing random access, to exit this loop, we need to set 
@@ -402,7 +399,6 @@ _INDEX = _INDEX - 1;
 
 -- running_total is the value we "map" to the "Running Total" column of each row
 return running_total;
-
 
 ----------------------------------------------------------------------------
 END {
@@ -521,7 +517,6 @@ BEGIN {
     _INDEX = _LASTROW;
 }!
 
-
 ----------------------------------------------------------------------------
 -- this is the MAIN script, which is executed for the row specified by _INDEX
 -- As we are doing random access, to exit this loop, we need to set 
@@ -539,7 +534,6 @@ _INDEX = _INDEX - 1;
 
 -- running_total is the value we "map" to the "Running Total" column of each row
 return running_total;
-
 
 ----------------------------------------------------------------------------
 END {
@@ -620,7 +614,6 @@ BEGIN {
     _INDEX = _LASTROW;
 }!
 
-
 ----------------------------------------------------------------------------
 -- this is the MAIN script, which is executed for the row specified by _INDEX
 -- As we are doing random access, to exit this loop, we need to set 
@@ -638,7 +631,6 @@ _INDEX = _INDEX - 1;
 
 -- running_total is the value we "map" to the "Running Total" column of each row
 return running_total;
-
 
 ----------------------------------------------------------------------------
 END {
@@ -750,13 +742,11 @@ END {
         .arg("https://data.boston.gov/api/3/action")
         .arg("data.csv");
 
-    let end = wrk.output_stderr(&mut cmd);
+    let end = wrk.stderr_on_success(&mut cmd);
     let expected_end = "previous_day_score,previous_month_score,previous_quarter_score,\
                         previous_week_score,score_calculated_ts,score_day_name,\
                         score_final_table_ts,\n";
     assert!(end.ends_with(expected_end));
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1126,13 +1116,11 @@ END {
         .arg("file:testqsvcmd.luau")
         .arg("data.csv");
 
-    let output_stderr = wrk.output_stderr(&mut cmd);
+    let output_stderr = wrk.stderr_on_success(&mut cmd);
     assert!(
         output_stderr.starts_with("<ERROR>")
             && output_stderr.contains("runtime error: Invalid shell command: \"rm\".")
     );
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1519,7 +1507,6 @@ BEGIN {
     _INDEX = _LASTROW;
 }!
 
-
 ----------------------------------------------------------------------------
 -- this is the MAIN script, which is executed for the row specified by _INDEX
 -- As we are doing random access, to exit this loop, we need to set 
@@ -1537,7 +1524,6 @@ _INDEX = _INDEX - 1;
 
 -- running_total is the value we "map" to the "Running Total" column of each row
 return running_total;
-
 
 ----------------------------------------------------------------------------
 END {
@@ -1609,7 +1595,6 @@ BEGIN {
     _INDEX = _LASTROW;
 }!
 
-
 ----------------------------------------------------------------------------
 -- this is the MAIN script loop, which is executed for the row specified by _INDEX
 -- As we are doing random access, to exit this loop, we need to set 
@@ -1629,7 +1614,6 @@ _INDEX = _INDEX - 1;
 -- Note that the CURRENT row is still the _INDEX value when we entered this loop iteration,
 -- not _INDEX - 1 which will become the next CURRENT row AFTER this loop iteration
 return running_total;
-
 
 ----------------------------------------------------------------------------
 END {
@@ -1698,7 +1682,6 @@ BEGIN {
     _INDEX = _LASTROW;
 }!
 
-
 ----------------------------------------------------------------------------
 -- this is the MAIN script, which is executed for the row specified by _INDEX
 -- As we are doing random access, to exit this loop, we need to set 
@@ -1716,7 +1699,6 @@ _INDEX = _INDEX - 1;
 
 -- running_total is the value we "map" to the "Running Total" column of each row
 return {running_total, running_total + (running_total * 0.1)};
-
 
 ----------------------------------------------------------------------------
 END {
@@ -1955,8 +1937,7 @@ fn luau_map_error() {
         .arg("math.dancefloor(number / 2)")
         .arg("data.csv");
 
-    wrk.assert_err(&mut cmd);
-    let stderr_string = wrk.output_stderr(&mut cmd);
+    let stderr_string = wrk.stderr_on_error(&mut cmd);
     assert!(stderr_string.ends_with("Luau errors encountered: 4\n"));
 }
 
@@ -3311,8 +3292,7 @@ fn luau_cumsum_overflow() {
         .arg(r#"qsv_cumsum(value)"#)
         .arg("data.csv");
 
-    wrk.assert_err(&mut cmd);
-    let stderr = wrk.output_stderr(&mut cmd);
+    let stderr = wrk.stderr_on_error(&mut cmd);
     let expected = "Luau errors encountered: 1\n";
     assert_eq!(stderr, expected);
 }
@@ -3336,8 +3316,7 @@ return "ok"
         )
         .arg("data.csv");
 
-    wrk.assert_err(&mut cmd);
-    let stderr = wrk.output_stderr(&mut cmd);
+    let stderr = wrk.stderr_on_error(&mut cmd);
     assert!(stderr.contains("Invalid shell command"));
 }
 

--- a/tests/test_moarstats.rs
+++ b/tests/test_moarstats.rs
@@ -5681,8 +5681,7 @@ fn moarstats_bivariate_index_auto_creation() {
     // Run moarstats with --bivariate (should auto-create index)
     let mut cmd = wrk.command("moarstats");
     cmd.arg("--bivariate").arg("test.csv");
-    let output = wrk.output_stderr(&mut cmd);
-    wrk.assert_success(&mut cmd);
+    let output = wrk.stderr_on_success(&mut cmd);
 
     // Verify index was auto-created or message was logged
     assert!(

--- a/tests/test_pivotp.rs
+++ b/tests/test_pivotp.rs
@@ -348,8 +348,7 @@ pivotp_test!(
             "q@-0.1",
             "sales.csv",
         ]);
-        wrk.assert_err(&mut cmd_2);
-        let stderr2 = wrk.output_stderr(&mut cmd_2);
+        let stderr2 = wrk.stderr_on_error(&mut cmd_2);
         assert!(
             stderr2.contains("Invalid quantile probability"),
             "expected 'Invalid quantile probability' in stderr, got: {stderr2}"
@@ -367,8 +366,7 @@ pivotp_test!(
             "quantile@abc",
             "sales.csv",
         ]);
-        wrk.assert_err(&mut cmd3);
-        let stderr3 = wrk.output_stderr(&mut cmd3);
+        let stderr3 = wrk.stderr_on_error(&mut cmd3);
         assert!(
             stderr3.contains("Invalid quantile probability"),
             "expected 'Invalid quantile probability' in stderr, got: {stderr3}"
@@ -892,9 +890,8 @@ fn pivotp_smart_no_moarstats() {
         "smart",
         "normal.csv",
     ]);
-    wrk.assert_success(&mut cmd);
 
-    let stderr = wrk.output_stderr(&mut cmd);
+    let stderr = wrk.stderr_on_success(&mut cmd);
     // Existing behavior: CV > 1% triggers Median, and no moarstats checks fire
     // (because moarstats hasn't been run, so all moarstats fields are None)
     assert!(
@@ -947,9 +944,8 @@ fn pivotp_smart_moarstats_high_kurtosis() {
         "smart",
         "kurtosis.csv",
     ]);
-    wrk.assert_success(&mut cmd);
 
-    let stderr = wrk.output_stderr(&mut cmd);
+    let stderr = wrk.stderr_on_success(&mut cmd);
     // Should use Median due to moarstats detecting heavy tails or outliers
     assert!(
         stderr.contains("Median"),
@@ -1000,9 +996,8 @@ fn pivotp_smart_moarstats_bimodal() {
         "smart",
         "bimodal.csv",
     ]);
-    wrk.assert_success(&mut cmd);
 
-    let stderr = wrk.output_stderr(&mut cmd);
+    let stderr = wrk.stderr_on_success(&mut cmd);
     // Bimodal data: moarstats --advanced computes bimodality_coefficient >= 0.555,
     // the bimodal branch fires first and picks Len (central tendency is misleading).
     // If other checks fire first (e.g., high CV or outlier fraction), Median is also valid.
@@ -1054,9 +1049,8 @@ fn pivotp_smart_moarstats_outliers() {
         "smart",
         "outliers.csv",
     ]);
-    wrk.assert_success(&mut cmd);
 
-    let stderr = wrk.output_stderr(&mut cmd);
+    let stderr = wrk.stderr_on_success(&mut cmd);
     // Should use Median due to outlier contamination
     assert!(
         stderr.contains("Median"),
@@ -1106,9 +1100,8 @@ fn pivotp_smart_moarstats_mad_stddev_ratio() {
         "smart",
         "mad_stddev.csv",
     ]);
-    wrk.assert_success(&mut cmd);
 
-    let stderr = wrk.output_stderr(&mut cmd);
+    let stderr = wrk.stderr_on_success(&mut cmd);
     // Should use Median — outliers inflate stddev but MAD stays robust
     assert!(
         stderr.contains("Median"),
@@ -1160,9 +1153,8 @@ fn pivotp_smart_moarstats_median_mean_divergence() {
         "smart",
         "median_mean.csv",
     ]);
-    wrk.assert_success(&mut cmd);
 
-    let stderr = wrk.output_stderr(&mut cmd);
+    let stderr = wrk.stderr_on_success(&mut cmd);
     // Should use Median — mean and median diverge significantly
     assert!(
         stderr.contains("Median"),
@@ -1200,9 +1192,8 @@ fn pivotp_smart_moarstats_quartile_dispersion() {
     cmd.args([
         "group", "--index", "category", "--values", "value", "--agg", "smart", "qcd.csv",
     ]);
-    wrk.assert_success(&mut cmd);
 
-    let stderr = wrk.output_stderr(&mut cmd);
+    let stderr = wrk.stderr_on_success(&mut cmd);
     // Should use Median — high quartile-based dispersion
     assert!(
         stderr.contains("Median"),
@@ -1248,9 +1239,8 @@ fn pivotp_smart_mixed_sign() {
         "smart",
         "mixed_sign.csv",
     ]);
-    wrk.assert_success(&mut cmd);
 
-    let stderr = wrk.output_stderr(&mut cmd);
+    let stderr = wrk.stderr_on_success(&mut cmd);
     // Should use Mean — mixed-sign data makes Sum cancel out
     assert!(
         stderr.contains("Mean") || stderr.contains("Mixed-sign"),
@@ -1301,9 +1291,8 @@ fn pivotp_smart_multimodal() {
         "smart",
         "multimodal.csv",
     ]);
-    wrk.assert_success(&mut cmd);
 
-    let stderr = wrk.output_stderr(&mut cmd);
+    let stderr = wrk.stderr_on_success(&mut cmd);
     // Should use Len — too many modes means central tendency is misleading
     assert!(
         stderr.contains("Len") || stderr.contains("modes"),
@@ -1353,9 +1342,8 @@ fn pivotp_smart_date_sparse() {
         "--try-parsedates",
         "date_sparse.csv",
     ]);
-    wrk.assert_success(&mut cmd);
 
-    let stderr = wrk.output_stderr(&mut cmd);
+    let stderr = wrk.stderr_on_success(&mut cmd);
     // Should use Len — >50% NULLs in date column
     assert!(
         stderr.contains("Len") || stderr.contains("NULL"),

--- a/tests/test_py.rs
+++ b/tests/test_py.rs
@@ -187,7 +187,6 @@ def fibonacci(input):
     else:
         return fibonacci(n-1) + fibonacci(n-2)
 
-
 def celsius_to_fahrenheit(celsius):
     try:
         float(celsius)
@@ -273,7 +272,6 @@ def fibonacci(input):
         return 1
     else:
         return fibonacci(n-1) + fibonacci(n-2)
-
 
 def celsius_to_fahrenheit(celsius):
     try:
@@ -656,8 +654,7 @@ fn py_map_jagged_rows_error() {
     let mut cmd = wrk.command("py");
     cmd.arg("map").arg("x").arg("a").arg("data.csv");
 
-    wrk.assert_err(&mut cmd);
-    let stderr = wrk.output_stderr(&mut cmd);
+    let stderr = wrk.stderr_on_error(&mut cmd);
     assert!(
         stderr.contains("Error reading file") && stderr.contains("fields"),
         "expected csv reader error about field count, got: {stderr}"

--- a/tests/test_safenames.rs
+++ b/tests/test_safenames.rs
@@ -129,14 +129,12 @@ fn safenames_verify() {
     let mut cmd = wrk.command("safenames");
     cmd.arg("--mode").arg("verify").arg("in.csv");
 
-    let changed_headers = wrk.output_stderr(&mut cmd);
+    let changed_headers = wrk.stderr_on_success(&mut cmd);
     // 8 unsafe = 4 distinct invalid headers + 2 duplicate `col1` slots
     // (renamed col1_2, col1_3) + 2 duplicate empty slots (renamed unsafe__2,
     // unsafe__3). Matches always-mode's changed_count for the same input.
     let expected_count = "8\n";
     assert_eq!(changed_headers, expected_count);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -169,7 +167,7 @@ fn safenames_verify_verbose() {
     let mut cmd = wrk.command("safenames");
     cmd.arg("--mode").arg("V").arg("in.csv");
 
-    let got_stderr = wrk.output_stderr(&mut cmd);
+    let got_stderr = wrk.stderr_on_success(&mut cmd);
 
     let expected_stderr = r#"13 header/s
 2 duplicate/s: ":4, col1:5"
@@ -178,8 +176,6 @@ fn safenames_verify_verbose() {
 "#;
 
     assert_eq!(got_stderr, expected_stderr);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]

--- a/tests/test_search.rs
+++ b/tests/test_search.rs
@@ -304,8 +304,7 @@ fn search_indexed_parallel_quick() {
         .arg("--jobs")
         .arg("1")
         .arg("data.csv");
-    let seq_err = wrk.output_stderr(&mut seq_cmd);
-    wrk.assert_success(&mut seq_cmd);
+    let seq_err = wrk.stderr_on_success(&mut seq_cmd);
 
     // parallel run
     let mut par_cmd = wrk.command("search");

--- a/tests/test_searchset.rs
+++ b/tests/test_searchset.rs
@@ -150,8 +150,7 @@ fn searchset_indexed_parallel_quick() {
         .arg("--jobs")
         .arg("1")
         .arg("data.csv");
-    let seq_err = wrk.output_stderr(&mut seq_cmd);
-    wrk.assert_success(&mut seq_cmd);
+    let seq_err = wrk.stderr_on_success(&mut seq_cmd);
 
     // parallel run
     let mut par_cmd = wrk.command("searchset");
@@ -196,8 +195,7 @@ fn searchset_indexed_parallel_quick_json() {
         .arg("--jobs")
         .arg("4")
         .arg("data.csv");
-    let stderr = wrk.output_stderr(&mut cmd);
-    wrk.assert_success(&mut cmd);
+    let stderr = wrk.stderr_on_success(&mut cmd);
 
     // stderr must be a JSON summary, not a single row number
     let json: serde_json::Value = serde_json::from_str(stderr.trim())

--- a/tests/test_stats.rs
+++ b/tests/test_stats.rs
@@ -6689,8 +6689,7 @@ fn stats_jsonl_conflicts_with_pretty_json() {
 
     let mut cmd = wrk.command("stats");
     cmd.arg("--jsonl").arg("--pretty-json").arg("data.csv");
-    wrk.assert_err(&mut cmd);
-    let stderr = wrk.output_stderr(&mut cmd);
+    let stderr = wrk.stderr_on_error(&mut cmd);
     assert!(
         stderr.contains("cannot be combined"),
         "expected mutual-exclusivity error, got: {stderr}"
@@ -6704,8 +6703,7 @@ fn stats_jsonl_conflicts_with_stats_jsonl() {
 
     let mut cmd = wrk.command("stats");
     cmd.arg("--jsonl").arg("--stats-jsonl").arg("data.csv");
-    wrk.assert_err(&mut cmd);
-    let stderr = wrk.output_stderr(&mut cmd);
+    let stderr = wrk.stderr_on_error(&mut cmd);
     assert!(
         stderr.contains("cannot be combined"),
         "expected mutual-exclusivity error, got: {stderr}"

--- a/tests/test_template.rs
+++ b/tests/test_template.rs
@@ -541,8 +541,7 @@ fn template_render_error() {
         .arg("Hello {{name}, invalid syntax!")
         .arg("data.csv");
 
-    wrk.assert_err(&mut cmd);
-    let got: String = wrk.output_stderr(&mut cmd);
+    let got: String = wrk.stderr_on_error(&mut cmd);
     let expected = "syntax error: unexpected `}`, expected end of variable block (in template:1)\n";
     assert_eq!(got, expected);
 }
@@ -1065,9 +1064,7 @@ fn template_lookup_register_errors() {
         ))
         .arg("data.csv");
 
-    wrk.assert_err(&mut cmd);
-
-    let got: String = wrk.output_stderr(&mut cmd);
+    let got: String = wrk.stderr_on_error(&mut cmd);
     assert!(got.contains(
         r#"invalid operation: failed to load lookup table "test": failed to open nonexistent.csv:"#
     ));

--- a/tests/test_transpose.rs
+++ b/tests/test_transpose.rs
@@ -161,11 +161,8 @@ fn transpose_long_multipass_mutually_exclusive() {
     let mut cmd = wrk.command("transpose");
     cmd.args(["--long", "1"]).arg("--multipass").arg("in.csv");
 
-    // Should fail with an error
-    wrk.assert_err(&mut cmd);
-
     // Verify the error message mentions mutual exclusivity
-    let stderr: String = wrk.output_stderr(&mut cmd);
+    let stderr: String = wrk.stderr_on_error(&mut cmd);
     assert!(
         stderr.contains("mutually exclusive") || stderr.contains("mutually-exclusive"),
         "Expected error message about mutual exclusivity, got: {}",
@@ -453,11 +450,8 @@ fn transpose_long_format_no_columns_selected() {
     let mut cmd = wrk.command("transpose");
     cmd.args(["--long", "/^nonexistent/"]).arg("in.csv"); // Regex that matches nothing
 
-    // Should fail with an error
-    wrk.assert_err(&mut cmd);
-
     // Verify the error message mentions no columns selected
-    let stderr: String = wrk.output_stderr(&mut cmd);
+    let stderr: String = wrk.stderr_on_error(&mut cmd);
     let expected = "--long selection error: Selector regex '^nonexistent' does not match any \
                     columns in the CSV header.\n";
     assert_eq!(stderr, expected);
@@ -741,11 +735,8 @@ fn transpose_select_empty_result() {
     let mut cmd = wrk.command("transpose");
     cmd.args(["--select", "/^nonexistent/"]).arg("in.csv"); // Regex matching nothing
 
-    // Should fail with an error
-    wrk.assert_err(&mut cmd);
-
     // Verify the error message
-    let stderr: String = wrk.output_stderr(&mut cmd);
+    let stderr: String = wrk.stderr_on_error(&mut cmd);
     assert!(
         stderr.contains("does not match any columns"),
         "Expected error about no columns selected, got: {}",

--- a/tests/test_validate.rs
+++ b/tests/test_validate.rs
@@ -2202,14 +2202,14 @@ fn validate_with_no_format_validation_success() {
         .arg("data.csv")
         .arg("schema.json");
 
+    let got: String = wrk.stderr_on_success(&mut cmd_no_format);
+    let expected = "All 2 records valid.\n";
+    assert_eq!(got, expected);
+
     // Should not create any error files since all records are valid
     // when format validation is disabled
     assert!(!wrk.path("data.csv.invalid").exists());
     assert!(!wrk.path("data.csv.validation-errors.tsv").exists());
-
-    let got: String = wrk.stderr_on_success(&mut cmd_no_format);
-    let expected = "All 2 records valid.\n";
-    assert_eq!(got, expected);
 }
 
 #[test]

--- a/tests/test_validate.rs
+++ b/tests/test_validate.rs
@@ -138,13 +138,11 @@ fn validate_bad_csv() {
     let mut cmd = wrk.command("validate");
     cmd.arg("data.csv");
 
-    let got: String = wrk.output_stderr(&mut cmd);
+    let got: String = wrk.stderr_on_error(&mut cmd);
     let expected = r#"Validation error: CSV error: record 2 (line: 3, byte: 36): found record with 2 fields, but the previous record has 3 fields.
 Use `qsv fixlengths` to fix record length issues.
 "#;
     assert_eq!(got, expected);
-
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]
@@ -162,13 +160,11 @@ fn validate_bad_csv_first_record() {
     let mut cmd = wrk.command("validate");
     cmd.arg("data.csv");
 
-    let got: String = wrk.output_stderr(&mut cmd);
+    let got: String = wrk.stderr_on_error(&mut cmd);
     let expected = r#"Validation error: CSV error: record 1 (line: 2, byte: 15): found record with 2 fields, but the previous record has 3 fields.
 Use `qsv fixlengths` to fix record length issues.
 "#;
     assert_eq!(got, expected);
-
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]
@@ -186,13 +182,11 @@ fn validate_bad_csv_last_record() {
     let mut cmd = wrk.command("validate");
     cmd.arg("data.csv");
 
-    let got: String = wrk.output_stderr(&mut cmd);
+    let got: String = wrk.stderr_on_error(&mut cmd);
     let expected = r#"Validation error: CSV error: record 3 (line: 4, byte: 54): found record with 4 fields, but the previous record has 3 fields.
 Use `qsv fixlengths` to fix record length issues.
 "#;
     assert_eq!(got, expected);
-
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]
@@ -392,8 +386,7 @@ fn validate_split_ragged_aborts_on_bad_utf8() {
     let mut cmd = wrk.command("validate");
     cmd.arg("--split-ragged").arg("data.csv");
 
-    wrk.assert_err(&mut cmd);
-    let stderr = wrk.output_stderr(&mut cmd);
+    let stderr = wrk.stderr_on_error(&mut cmd);
     assert!(stderr.contains("non-utf8"), "stderr was: {stderr}");
 }
 
@@ -542,7 +535,7 @@ fn validate_bad_csv_prettyjson() {
     let mut cmd = wrk.command("validate");
     cmd.arg("--pretty-json").arg("data.csv");
 
-    let got: String = wrk.output_stderr(&mut cmd);
+    let got: String = wrk.stderr_on_error(&mut cmd);
     let expected = r#"{
   "errors": [
     {
@@ -556,8 +549,6 @@ fn validate_bad_csv_prettyjson() {
 }
 "#;
     assert_eq!(got, expected);
-
-    wrk.assert_err(&mut cmd);
 }
 
 fn adur_errors() -> &'static str {
@@ -672,11 +663,9 @@ fn validate_with_schema_noheader() {
         .arg("--no-headers")
         .args(["--valid-output", "-"]);
 
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_error(&mut cmd);
     let expected = "Cannot validate CSV without headers against a JSON Schema.\n".to_string();
     assert_eq!(got, expected);
-
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]
@@ -885,15 +874,13 @@ fn validate_dynenum_with_invalid_column() {
     cmd.arg("data.csv").arg("schema.json");
 
     // Check error output
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_error(&mut cmd);
     // Both lite and non-lite share the same helper (`load_dynenum_set`) and emit the
     // same error wording.
     assert!(got.ends_with(
         "Cannot compile JSONschema. error: Column 'nonexistent_column' not found in lookup \
          table\nTry running `qsv validate schema schema.json` to check the JSON Schema file.\n"
     ));
-
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]
@@ -1629,11 +1616,9 @@ fn validate_dynenum_with_invalid_uri() {
     cmd.arg("data.csv").arg("schema.json");
 
     // Check error output
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_error(&mut cmd);
 
     assert!(got.starts_with("Cannot compile JSONschema."));
-
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]
@@ -2025,9 +2010,7 @@ fn validate_schema_subcommand_valid_schema() {
     let mut cmd = wrk.command("validate");
     cmd.arg("schema").arg("schema.json");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.output_stderr(&mut cmd);
+    let got: String = wrk.stderr_on_success(&mut cmd);
     let expected = "Valid JSON Schema.\n";
     assert_eq!(got, expected);
 }
@@ -2053,9 +2036,7 @@ fn validate_schema_subcommand_invalid_schema() {
     let mut cmd = wrk.command("validate");
     cmd.arg("schema").arg("schema.json");
 
-    wrk.assert_err(&mut cmd);
-
-    let got: String = wrk.output_stderr(&mut cmd);
+    let got: String = wrk.stderr_on_error(&mut cmd);
     let expected = "JSON Schema Meta-Reference Error: \"invalid_type\" is not valid under any of \
                     the schemas listed in the 'anyOf' keyword\n";
     assert_eq!(got, expected);
@@ -2081,9 +2062,7 @@ fn validate_schema_subcommand_invalid_draft() {
     let mut cmd = wrk.command("validate");
     cmd.arg("schema").arg("schema.json");
 
-    wrk.assert_err(&mut cmd);
-
-    let got: String = wrk.output_stderr(&mut cmd);
+    let got: String = wrk.stderr_on_error(&mut cmd);
     // reqwest >=0.13.4 appends " for url (<url>)" to body-decoding errors; match the
     // stable prefix only so we don't re-couple to reqwest's exact wording.
     let expected_prefix =
@@ -2105,9 +2084,7 @@ fn validate_schema_subcommand_no_schema_file() {
     let mut cmd = wrk.command("validate");
     cmd.arg("schema");
 
-    wrk.assert_err(&mut cmd);
-
-    let got: String = wrk.output_stderr(&mut cmd);
+    let got: String = wrk.stderr_on_error(&mut cmd);
     let expected = "No JSON Schema file supplied.\n";
     assert_eq!(got, expected);
 }
@@ -2146,9 +2123,7 @@ fn validate_schema_subcommand_with_no_format_validation() {
         .arg("--no-format-validation")
         .arg("schema.json");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.output_stderr(&mut cmd);
+    let got: String = wrk.stderr_on_success(&mut cmd);
     let expected = "Valid JSON Schema.\n";
     assert_eq!(got, expected);
 }
@@ -2227,14 +2202,12 @@ fn validate_with_no_format_validation_success() {
         .arg("data.csv")
         .arg("schema.json");
 
-    wrk.assert_success(&mut cmd_no_format);
-
     // Should not create any error files since all records are valid
     // when format validation is disabled
     assert!(!wrk.path("data.csv.invalid").exists());
     assert!(!wrk.path("data.csv.validation-errors.tsv").exists());
 
-    let got: String = wrk.output_stderr(&mut cmd_no_format);
+    let got: String = wrk.stderr_on_success(&mut cmd_no_format);
     let expected = "All 2 records valid.\n";
     assert_eq!(got, expected);
 }
@@ -2360,9 +2333,7 @@ fn validate_schema_subcommand_with_invalid_format_validation() {
         .arg("--no-format-validation")
         .arg("schema.json");
 
-    wrk.assert_success(&mut cmd_no_format);
-
-    let got: String = wrk.output_stderr(&mut cmd_no_format);
+    let got: String = wrk.stderr_on_success(&mut cmd_no_format);
     let expected = "Valid JSON Schema.\n";
     assert_eq!(got, expected);
 }
@@ -2376,9 +2347,7 @@ fn validate_schema_subcommand_with_url_schema() {
     cmd.arg("schema")
         .arg("https://raw.githubusercontent.com/dathere/qsv/master/resources/test/public-toilets-schema.json");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.output_stderr(&mut cmd);
+    let got: String = wrk.stderr_on_success(&mut cmd);
     let expected = "Valid JSON Schema.\n";
     assert_eq!(got, expected);
 }
@@ -2392,9 +2361,7 @@ fn validate_schema_subcommand_with_invalid_url_schema() {
     cmd.arg("schema")
         .arg("https://raw.githubusercontent.com/dathere/qsv/master/nonexistent-schema.json");
 
-    wrk.assert_err(&mut cmd);
-
-    let got: String = wrk.output_stderr(&mut cmd);
+    let got: String = wrk.stderr_on_error(&mut cmd);
     assert!(
         got.contains("Cannot compile JSONschema")
             || got.contains("io error")
@@ -2531,9 +2498,7 @@ fn validate_multiple_files_rfc4180() {
     let mut cmd = wrk.command("validate");
     cmd.arg("file1.csv").arg("file2.csv").arg("file3.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.output_stderr(&mut cmd);
+    let got: String = wrk.stderr_on_success(&mut cmd);
 
     // The Extended Input Support should work and show a summary
     assert!(got.contains("✅ All 3 files are valid."));
@@ -2563,9 +2528,7 @@ fn validate_multiple_files_with_invalid() {
     let mut cmd = wrk.command("validate");
     cmd.arg("valid.csv").arg("invalid.csv");
 
-    wrk.assert_err(&mut cmd);
-
-    let got: String = wrk.output_stderr(&mut cmd);
+    let got: String = wrk.stderr_on_error(&mut cmd);
 
     // The output should contain error information and summary
     assert!(got.contains("❌ 1 out of 2 files are invalid."));
@@ -2597,9 +2560,7 @@ fn validate_directory() {
     let mut cmd = wrk.command("validate");
     cmd.arg("data");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.output_stderr(&mut cmd);
+    let got: String = wrk.stderr_on_success(&mut cmd);
     // The Extended Input Support should work for directories
     assert!(got.contains("✅ All 2 files are valid."));
 }
@@ -2633,9 +2594,7 @@ fn validate_infile_list() {
     let mut cmd = wrk.command("validate");
     cmd.arg("filelist.infile-list");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.output_stderr(&mut cmd);
+    let got: String = wrk.stderr_on_success(&mut cmd);
     assert!(got.contains("✅ All 2 files are valid."));
 }
 
@@ -2768,9 +2727,7 @@ fn validate_multiple_files_with_mixed_delimiters() {
     let mut cmd = wrk.command("validate");
     cmd.arg("comma.csv").arg("tab.tsv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.output_stderr(&mut cmd);
+    let got: String = wrk.stderr_on_success(&mut cmd);
     assert!(got.contains("✅ All 2 files are valid."));
 }
 
@@ -2796,9 +2753,7 @@ fn validate_multiple_files_no_headers() {
     let mut cmd = wrk.command("validate");
     cmd.arg("--no-headers").arg("file1.csv").arg("file2.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.output_stderr(&mut cmd);
+    let got: String = wrk.stderr_on_success(&mut cmd);
     assert!(got.contains("✅ All 2 files are valid."));
 }
 
@@ -2853,9 +2808,7 @@ fn validate_single_file_error_backward_compatibility() {
     let mut cmd = wrk.command("validate");
     cmd.arg("data.csv");
 
-    wrk.assert_err(&mut cmd);
-
-    let got: String = wrk.output_stderr(&mut cmd);
+    let got: String = wrk.stderr_on_error(&mut cmd);
     // The exact byte position may vary, so we check for key components
     assert!(got.contains("Validation error: CSV error: record 2 (line: 3, byte:"));
     assert!(got.contains("found record with 2 fields, but the previous record has 3 fields."));
@@ -2894,9 +2847,7 @@ fn validate_json_schema_still_single_file() {
     let mut cmd = wrk.command("validate");
     cmd.arg("data.csv").arg("schema.json");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.output_stderr(&mut cmd);
+    let got: String = wrk.stderr_on_success(&mut cmd);
     let expected = "All 2 records valid.\n";
     assert_eq!(got, expected);
 }
@@ -2927,9 +2878,7 @@ fn validate_json_schema_rejects_multiple_files() {
     let mut cmd = wrk.command("validate");
     cmd.arg("file1.csv").arg("file2.csv").arg("schema.json");
 
-    wrk.assert_err(&mut cmd);
-
-    let got: String = wrk.output_stderr(&mut cmd);
+    let got: String = wrk.stderr_on_error(&mut cmd);
     let expected = "JSON Schema validation only supports a single input file. Use RFC 4180 \
                     validation mode for multiple files.\n";
     assert_eq!(got, expected);

--- a/tests/workdir.rs
+++ b/tests/workdir.rs
@@ -223,6 +223,33 @@ impl Workdir {
         String::from_utf8_lossy(&o.stderr).to_string()
     }
 
+    /// Run `cmd`, assert it exited with a NON-zero status, and return its
+    /// stderr as a `String`. The failure-path twin of `stderr_on_success`: use
+    /// it instead of `assert_err` followed by `output_stderr`, which executes
+    /// `cmd` twice — the run whose exit status is asserted is then a different
+    /// run from the one whose stderr is inspected, so a command that failed for
+    /// an unrelated reason (or succeeded on the second run) can still satisfy
+    /// both assertions.
+    pub fn stderr_on_error(&self, cmd: &mut process::Command) -> String {
+        {
+            // ensures stderr has been flushed before we run our cmd
+            let mut _stderr = io::stderr();
+            _stderr.flush().unwrap();
+        }
+        let o = cmd.output().unwrap();
+        assert!(
+            !o.status.success(),
+            "\n\n===== {:?} =====\ncommand succeeded but expected an error!\n\ncwd: {}\n\nstatus: \
+             {}\n\nstdout: {}\n\nstderr: {}\n\n=====\n",
+            cmd,
+            self.dir.display(),
+            o.status,
+            String::from_utf8_lossy(&o.stdout),
+            String::from_utf8_lossy(&o.stderr)
+        );
+        String::from_utf8_lossy(&o.stderr).to_string()
+    }
+
     /// Run `cmd`, assert it exited successfully, and return its stdout parsed
     /// as `T`. Unlike calling `assert_success` then `stdout` (which executes the
     /// command twice and only asserts success on the first run), this captures a


### PR DESCRIPTION
Follow-up to #4422, which fixed `tests/test_viz.rs`. Same defect, the rest of the suite. Refs #4415.

## Problem

`Workdir::output_stderr` runs the command a second time, so:

```rust
wrk.assert_err(&mut cmd);               // run #1 -> exit status
let got = wrk.output_stderr(&mut cmd);  // run #2 -> stderr
```

asserts the exit status and inspects stderr across **two different executions**. A command that failed for an unrelated reason — or that behaved differently on the second run — still satisfies both assertions.

## Change

Adds **`Workdir::stderr_on_error`**, the failure-path twin of the existing `stderr_on_success`: one run, asserts a non-zero exit, returns that run's stderr with the same rich panic message (cmd, cwd, status, stdout, stderr).

**99 sites across 22 files** collapse from two runs to one:

| shape | sites | becomes |
|---|---|---|
| `assert_err` + `output_stderr` | 70 | `stderr_on_error` (new) |
| `assert_success` + `output_stderr` | 29 | `stderr_on_success` (existing) |

## Safety of the sweep

A site was converted only if the command variable has **exactly one** runner call and **one** `output_stderr` call, with **no** `.arg`/`.args`/`.env`/`.env_remove`/`.current_dir`/`.stdin` mutation anywhere in the line range between them — so no two intentionally different commands were merged into one. Everything else was left alone and re-verified afterwards.

Tests whose assertions depend on `output_stderr`'s `"No error"` sentinel (`test_combos.rs:91`, `test_search.rs:278`, `test_validate.rs:2740`, `:2831`) were excluded — the new helpers return raw stderr, so those need per-test judgment.

## Verification

Each converted file was run on its own, so a failure would be attributable to one file's conversion:

`validate` 74, `pivotp` 62, `apply` 81, `fetch` 27, `excel` 61, `json` 25, `jsonl` 8, `luau` 77, `denull` 26, `describegpt` 100, `diff` 32, `geoconvert` 4, `joinp` 88, `moarstats` 88, `safenames` 24, `search` 52, `searchset` 31, `stats` 685, `template` 56, `transpose` 34 — **all passed, 0 failed**.

The two feature-gated modules do not compile under `all_features`, so they were run under their own features: `test_applydp` (`-F datapusher_plus`) 32 passed, `test_py` (`-F all_features,python`) 19 passed.

Also builds clean under `-F lite`; `cargo +nightly fmt` applied.

**No assertion needed adjusting.** As in #4422, that the assertions still hold with the second execution removed is direct evidence the two runs agreed — the failure mode was latent, not active.

## Deliberately left for a follow-up

- **83 sites**, of which **72** run the same command *again* for its stdout (`read_stdout` / `stdout`, e.g. `test_luau` 18, `test_search` 16, `test_joinp` 8). Reading both streams from one `Output` needs a tuple-returning helper plus per-site rewriting of how stdout is parsed — a restructuring, not a swap. The other 11: 10 where the command variable is run three or more times (mostly `test_validate`), and 1 (`validate_multiple_files_quiet_mode`) whose assertion is `got.is_empty() || got == "No error"` — it depends on the sentinel and must be rewritten, not swapped.
- **66 `output_stderr` calls that are the only execution in their test.** Those are correct as-is; `output_stderr` itself is unchanged and still used.


## One behavioral nuance

`output_stderr` substitutes the string `"No error"` for empty stderr on a successful run, so an `assert!(!stderr.is_empty())` could previously pass on genuinely empty stderr. Two converted sites assert non-emptiness (`search_indexed_parallel_quick`, `searchset_indexed_parallel_quick`); with `stderr_on_success` returning raw stderr, that assertion now means what it says. Both still pass, so the stderr is genuinely non-empty — the change strengthens the check rather than altering a result.
