### PR TITLE
test: finish the single-execution stderr sweep — 0 double-run sites left

### DIFF
--- a/tests/test_denull.rs
+++ b/tests/test_denull.rs
@@ -463,9 +463,9 @@ fn denull_apply_passes_data_through_when_nothing_is_confirmed() {
 
     let mut cmd = wrk.command("denull");
     cmd.arg("--apply").arg("d.csv");
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, stderr): (Vec<Vec<String>>, String) = wrk.read_stdout_and_stderr(&mut cmd);
     assert_eq!(got, vec![vec!["a", "b"], vec!["x", "y"], vec!["z", "w"]]);
-    assert!(wrk.output_stderr(&mut cmd).contains("no column confirmed"));
+    assert!(stderr.contains("no column confirmed"));
 }
 
 #[test]
@@ -502,9 +502,9 @@ fn denull_apply_leaves_rejected_columns_untouched() {
 
     let mut cmd = wrk.command("denull");
     cmd.arg("--apply").arg("d.csv");
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, stderr): (Vec<Vec<String>>, String) = wrk.read_stdout_and_stderr(&mut cmd);
     assert_eq!(got.iter().skip(1).filter(|r| r[0] == "NULL").count(), 10);
-    assert!(wrk.output_stderr(&mut cmd).contains("rejected:off-vocab"));
+    assert!(stderr.contains("rejected:off-vocab"));
 }
 
 #[test]

--- a/tests/test_denull.rs
+++ b/tests/test_denull.rs
@@ -444,7 +444,7 @@ fn denull_apply_sends_the_report_to_stderr() {
 
     let mut cmd = wrk.command("denull");
     cmd.arg("--apply").arg("d.csv");
-    let stderr = wrk.output_stderr(&mut cmd);
+    let (got, stderr): (Vec<Vec<String>>, String) = wrk.read_stdout_and_stderr(&mut cmd);
     assert!(stderr.contains("confirmed"), "report missing: {stderr}");
     assert!(
         stderr.contains("blanked 10 cell(s)"),
@@ -452,7 +452,6 @@ fn denull_apply_sends_the_report_to_stderr() {
     );
 
     // ...and stdout carries the DATA, not the report
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     assert_eq!(got[0], vec!["depth"]);
     assert!(!got.iter().any(|r| r[0] == "confirmed"));
 }

--- a/tests/test_edit.rs
+++ b/tests/test_edit.rs
@@ -172,11 +172,10 @@ fn edit_row_out_of_range_warns_on_stdout() {
     cmd.arg("99");
     cmd.arg("3");
 
-    let got_stderr = wrk.output_stderr(&mut cmd);
+    let (got, got_stderr): (String, String) = wrk.stdout_and_stderr(&mut cmd);
     assert!(got_stderr.contains("row 99 not found"));
     assert!(got_stderr.contains("input passed through unchanged"));
 
-    let got: String = wrk.stdout(&mut cmd);
     let expected = "letter,number\na,1\nb,2".to_string();
     assert_eq!(got, expected);
 }

--- a/tests/test_joinp.rs
+++ b/tests/test_joinp.rs
@@ -488,12 +488,11 @@ joinp_test!(
     joinp_outer_left_validate_manytoone,
     |wrk: Workdir, mut cmd: process::Command| {
         cmd.arg("--left").args(["--validate", "manytoone"]);
-        let got: String = wrk.output_stderr(&mut cmd);
+        let got: String = wrk.stderr_on_error(&mut cmd);
         assert_eq!(
             got,
             "Polars error: ComputeError(ErrString(\"join keys did not fulfill m:1 validation\"))\n"
         );
-        wrk.assert_err(&mut cmd);
     }
 );
 
@@ -501,12 +500,11 @@ joinp_test!(
     joinp_outer_invalid_validation,
     |wrk: Workdir, mut cmd: process::Command| {
         cmd.arg("--left").args(["--validate", "manytoeveryone"]);
-        let got: String = wrk.output_stderr(&mut cmd);
+        let got: String = wrk.stderr_on_error(&mut cmd);
         assert_eq!(
             got,
             "usage error: Invalid join validation: manytoeveryone\n"
         );
-        wrk.assert_err(&mut cmd);
     }
 );
 
@@ -514,9 +512,8 @@ joinp_test!(
     joinp_outer_left_validate_onetomany,
     |wrk: Workdir, mut cmd: process::Command| {
         cmd.arg("--left").args(["--validate", "OneToMany"]);
-        let got: String = wrk.output_stderr(&mut cmd);
+        let got: String = wrk.stderr_on_success(&mut cmd);
         assert_eq!(got, "(5, 3)\n");
-        wrk.assert_success(&mut cmd);
     }
 );
 
@@ -524,12 +521,11 @@ joinp_test!(
     joinp_outer_left_validate_onetoone,
     |wrk: Workdir, mut cmd: process::Command| {
         cmd.arg("--left").args(["--validate", "OneToone"]);
-        let got: String = wrk.output_stderr(&mut cmd);
+        let got: String = wrk.stderr_on_error(&mut cmd);
         assert_eq!(
             got,
             "Polars error: ComputeError(ErrString(\"join keys did not fulfill 1:1 validation\"))\n"
         );
-        wrk.assert_err(&mut cmd);
     }
 );
 

--- a/tests/test_joinp.rs
+++ b/tests/test_joinp.rs
@@ -2705,8 +2705,7 @@ fn joinp_decimal_comma_validation() {
     cmd.args(["id", "left.csv", "id", "right.csv"])
         .arg("--decimal-comma");
 
-    wrk.assert_err(&mut cmd);
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_error(&mut cmd);
     assert!(got.contains("Using --decimal-comma with a comma separator is invalid"));
 
     // Test 2: --decimal-comma with semicolon delimiter should succeed
@@ -2803,8 +2802,7 @@ fn joinp_decimal_comma_validation_with_ssv_files() {
     cmd.args(["id", "left.ssv", "id", "right.ssv"])
         .arg("--decimal-comma");
 
-    wrk.assert_err(&mut cmd);
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_error(&mut cmd);
     assert!(got.contains("Using --decimal-comma with a comma separator is invalid"));
 
     // Test 2: --decimal-comma with SSV files (semicolon delimiter) should succeed
@@ -2855,8 +2853,7 @@ fn joinp_decimal_comma_validation_with_output_file() {
         .arg("--decimal-comma")
         .args(["--output", "output.csv"]);
 
-    wrk.assert_err(&mut cmd);
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_error(&mut cmd);
     assert!(got.contains("Using --decimal-comma with a comma separator is invalid"));
 }
 
@@ -2940,8 +2937,7 @@ fn joinp_decimal_comma_validation_with_cross_join() {
         .args(["left.ssv", "right.ssv"])
         .arg("--decimal-comma");
 
-    wrk.assert_err(&mut cmd);
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_error(&mut cmd);
     assert!(got.contains("Using --decimal-comma with a comma separator is invalid"));
 
     // Test: --decimal-comma with cross join and semicolon delimiter should succeed
@@ -2983,8 +2979,7 @@ fn joinp_decimal_comma_validation_with_non_equi_join() {
         .args(["left.csv", "right.csv"])
         .arg("--decimal-comma");
 
-    wrk.assert_err(&mut cmd);
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_error(&mut cmd);
     assert!(got.contains("Using --decimal-comma with a comma separator is invalid"));
 
     // Test: --decimal-comma with non-equi join and semicolon delimiter should succeed
@@ -3031,8 +3026,7 @@ fn joinp_decimal_comma_validation_with_asof_join() {
         .args(["date", "left.csv", "date", "right.csv"])
         .arg("--decimal-comma");
 
-    wrk.assert_err(&mut cmd);
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_error(&mut cmd);
     assert!(got.contains("Using --decimal-comma with a comma separator is invalid"));
 
     // Test: --decimal-comma with asof join and pipe delimiter should succeed
@@ -3071,8 +3065,7 @@ fn joinp_decimal_comma_validation_with_sql_filter() {
         .arg("--sql-filter")
         .arg("select id, value from join_result where value > 150");
 
-    wrk.assert_err(&mut cmd);
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_error(&mut cmd);
     assert!(got.contains("Using --decimal-comma with a comma separator is invalid"));
 
     // Test: --decimal-comma with SQL filter and semicolon delimiter should succeed

--- a/tests/test_luau.rs
+++ b/tests/test_luau.rs
@@ -540,12 +540,12 @@ END {
         .arg("file:testlookup.luau")
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    // Add a delay or ensure the file is closed properly
+    // Add a delay or ensure the file is closed properly. Kept ahead of the single
+    // run below: it guarded the registered lookup file's handle being released on
+    // Windows, which is a concern before the command runs, not between runs.
     std::thread::sleep(std::time::Duration::from_millis(500));
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, end): (Vec<Vec<String>>, String) = wrk.read_stdout_and_stderr_on_success(&mut cmd);
     let expected = vec![
         svec!["letter", "Amount", "Running Total"],
         svec!["d", "7", "7.28"],
@@ -555,11 +555,8 @@ END {
     ];
     assert_eq!(got, expected);
 
-    let end = wrk.output_stderr(&mut cmd);
     let expected_end = "Min/Max: 7.28/74.88 Grand total of 4 rows: 120.64\n";
     assert!(end.ends_with(expected_end));
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -637,9 +634,7 @@ END {
         .arg("file:testlookup.luau")
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, end): (Vec<Vec<String>>, String) = wrk.read_stdout_and_stderr_on_success(&mut cmd);
     let expected = vec![
         svec!["letter", "Amount", "Running Total"],
         svec!["d", "7", "7.28"],
@@ -649,11 +644,8 @@ END {
     ];
     assert_eq!(got, expected);
 
-    let end = wrk.output_stderr(&mut cmd);
     let expected_end = "Min/Max: 7.28/74.88 Grand total of 4 rows: 120.64\n";
     assert!(end.ends_with(expected_end));
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]

--- a/tests/test_luau.rs
+++ b/tests/test_luau.rs
@@ -175,7 +175,7 @@ fn luau_aggregation_with_begin_end() {
         .arg(r#"return ("Min/Max: " .. math.min(unpack(amt_array)) .. "/" .. math.max(unpack(amt_array)) .. " Grand total of " .. _ROWCOUNT .. " rows: " .. gtotal)"#)
         .arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, end): (Vec<Vec<String>>, String) = wrk.read_stdout_and_stderr_on_success(&mut cmd);
     let expected = vec![
         svec!["letter", "Amount", "Total"],
         svec!["a", "13", "13"],
@@ -185,11 +185,8 @@ fn luau_aggregation_with_begin_end() {
     ];
     assert_eq!(got, expected);
 
-    let end = wrk.output_stderr(&mut cmd);
     let expected_end = "Min/Max: 7/72 Grand total of 4 rows: 275\n".to_string();
     assert_eq!(end, expected_end);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -216,7 +213,7 @@ fn luau_aggregation_with_embedded_begin_end() {
         )
         .arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, end): (Vec<Vec<String>>, String) = wrk.read_stdout_and_stderr_on_success(&mut cmd);
     let expected = vec![
         svec!["letter", "Amount", "Total"],
         svec!["a", "13", "13"],
@@ -226,11 +223,8 @@ fn luau_aggregation_with_embedded_begin_end() {
     ];
     assert_eq!(got, expected);
 
-    let end = wrk.output_stderr(&mut cmd);
     let expected_end = "Min/Max: 7/72 Grand total of 4 rows: 275\n".to_string();
     assert_eq!(end, expected_end);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -302,7 +296,7 @@ END {
         .arg("file:testbeginend.luau")
         .arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, end): (Vec<Vec<String>>, String) = wrk.read_stdout_and_stderr_on_success(&mut cmd);
     let expected = vec![
         svec!["letter", "Amount", "Running Total"],
         svec!["a", "13", "13"],
@@ -312,11 +306,8 @@ END {
     ];
     assert_eq!(got, expected);
 
-    let end = wrk.output_stderr(&mut cmd);
     let expected_end = "Min/Max: 7/72 Grand total of 4 rows: 116 adjusted: 145\n".to_string();
     assert_eq!(end, expected_end);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -417,7 +408,7 @@ END {
         .arg("file:testlookup.luau")
         .arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, end): (Vec<Vec<String>>, String) = wrk.read_stdout_and_stderr_on_success(&mut cmd);
     let expected = vec![
         svec!["letter", "Amount", "Running Total"],
         svec!["d", "7", "7.28"],
@@ -427,11 +418,8 @@ END {
     ];
     assert_eq!(got, expected);
 
-    let end = wrk.output_stderr(&mut cmd);
     let expected_end = "Min/Max: 7.28/74.88 Grand total of 4 rows: 120.64\n";
     assert!(end.ends_with(expected_end));
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[cfg(feature = "polars")]
@@ -834,7 +822,7 @@ END {
         .arg("testbreak.lua")
         .arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, end): (Vec<Vec<String>>, String) = wrk.read_stdout_and_stderr_on_success(&mut cmd);
     let expected = vec![
         svec!["letter", "Amount", "Running Total"],
         svec!["a", "13", "13"],
@@ -842,12 +830,9 @@ END {
     ];
     assert_eq!(got, expected);
 
-    let end = wrk.output_stderr(&mut cmd);
     let expected_end =
         "This is the break msg.\nMin/Max: 13/24 Grand total of 2 rows: 50\n".to_string();
     assert_eq!(end, expected_end);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -904,7 +889,7 @@ END {
         .arg("testbreak.LUAU")
         .arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, end): (Vec<Vec<String>>, String) = wrk.read_stdout_and_stderr_on_success(&mut cmd);
     let expected = vec![
         svec!["letter", "Amount", "Running Total"],
         svec!["a", "13", "13"],
@@ -913,11 +898,8 @@ END {
     ];
     assert_eq!(got, expected);
 
-    let end = wrk.output_stderr(&mut cmd);
     let expected_end = "Min/Max: 0/24 Grand total of 3 rows: 94\n".to_string();
     assert_eq!(end, expected_end);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -970,7 +952,7 @@ END {
         .arg("test_loadcsv.LUAU")
         .arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, end): (Vec<Vec<String>>, String) = wrk.read_stdout_and_stderr_on_success(&mut cmd);
     let expected = vec![
         svec!["letter", "Amount", "description"],
         svec!["a", "13", "alpha"],
@@ -980,11 +962,8 @@ END {
     ];
     assert_eq!(got, expected);
 
-    let end = wrk.output_stderr(&mut cmd);
     let expected_end = "4 rows\n".to_string();
     assert_eq!(end, expected_end);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1041,7 +1020,7 @@ END {
         .arg("testqsvcmd.Lua")
         .arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, end): (Vec<Vec<String>>, String) = wrk.read_stdout_and_stderr_on_success(&mut cmd);
     let expected = vec![
         svec!["letter", "Amount", "Running Total"],
         svec!["a", "13", "13"],
@@ -1051,15 +1030,12 @@ END {
     ];
     assert_eq!(got, expected);
 
-    let end = wrk.output_stderr(&mut cmd);
     let expected_end = "Min/Max: 7/72 Grand total of 3 rows: 275\n".to_string();
     assert_eq!(end, expected_end);
 
     let table_txt = wrk.read_to_string("count.txt").unwrap();
     let expected_table_txt = "4\n";
     assert_eq!(table_txt, expected_table_txt);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1253,7 +1229,7 @@ END {
         .arg("file:testbeginend.luau")
         .arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, end): (Vec<Vec<String>>, String) = wrk.read_stdout_and_stderr_on_success(&mut cmd);
     let expected = vec![
         svec!["letter", "Amount", "Running Total"],
         svec!["a", "13", "13"],
@@ -1268,11 +1244,8 @@ END {
     ];
     assert_eq!(got, expected);
 
-    let end = wrk.output_stderr(&mut cmd);
     let expected_end = "Min/Max: 7/72 Grand total of 4 rows: 275\n".to_string();
     assert_eq!(end, expected_end);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1338,7 +1311,7 @@ END {
         .arg("file:testrandominsertrecord.luau")
         .arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, end): (Vec<Vec<String>>, String) = wrk.read_stdout_and_stderr_on_success(&mut cmd);
     // let got2: String = wrk.stdout(&mut cmd);
     // println!("got2: {got2:?}");
 
@@ -1356,11 +1329,8 @@ END {
     ];
     assert_eq!(got, expected);
 
-    let end = wrk.output_stderr(&mut cmd);
     let expected_end = "Min/Max: 7/72 Grand total of 4 rows: 305\n".to_string();
     assert_eq!(end, expected_end);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1408,7 +1378,7 @@ END {
         .arg("file:testbeginend.luau")
         .arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, end): (Vec<Vec<String>>, String) = wrk.read_stdout_and_stderr_on_success(&mut cmd);
     let expected = vec![
         svec!["letter", "code digit", "Running Total"],
         svec!["a", "2", "2"],
@@ -1418,11 +1388,8 @@ END {
     ];
     assert_eq!(got, expected);
 
-    let end = wrk.output_stderr(&mut cmd);
     let expected_end = "The lock combination is 2715. Again, 2, 7, 1, 5.\n".to_string();
     assert_eq!(end, expected_end);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1459,7 +1426,7 @@ fn luau_aggregation_with_embedded_begin_end_and_beginend_options() {
         )
         .arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, end): (Vec<Vec<String>>, String) = wrk.read_stdout_and_stderr_on_success(&mut cmd);
     let expected = vec![
         svec!["letter", "Amount", "Total"],
         svec!["a", "13", "14"],
@@ -1469,11 +1436,8 @@ fn luau_aggregation_with_embedded_begin_end_and_beginend_options() {
     ];
     assert_eq!(got, expected);
 
-    let end = wrk.output_stderr(&mut cmd);
     let expected_end = "Minimum/Maximum: 7/72 Grand total of 4 rows: 279\n".to_string();
     assert_eq!(end, expected_end);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1542,7 +1506,7 @@ END {
         .arg("file:testbeginend.luau")
         .arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, end): (Vec<Vec<String>>, String) = wrk.read_stdout_and_stderr_on_success(&mut cmd);
     let expected = vec![
         svec!["letter", "Amount", "Running Total"],
         svec!["d", "7", "7"],
@@ -1552,11 +1516,8 @@ END {
     ];
     assert_eq!(got, expected);
 
-    let end = wrk.output_stderr(&mut cmd);
     let expected_end = "Min/Max: 7/72 Grand total of 4 rows: 305\n".to_string();
     assert_eq!(end, expected_end);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1634,7 +1595,7 @@ END {
         .arg("file:testbeginend.luau")
         .arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, end): (Vec<Vec<String>>, String) = wrk.read_stdout_and_stderr_on_success(&mut cmd);
     let expected = vec![
         svec!["letter", "Amount", "Running Total"],
         svec!["d", "7", "7"],
@@ -1644,11 +1605,8 @@ END {
     ];
     assert_eq!(got, expected);
 
-    let end = wrk.output_stderr(&mut cmd);
     let expected_end = "Min/Max/Range: 7/72/65 Grand total of 4 rows: 305\n".to_string();
     assert_eq!(end, expected_end);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1717,7 +1675,7 @@ END {
         .arg("file:testbeginend.luau")
         .arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, end): (Vec<Vec<String>>, String) = wrk.read_stdout_and_stderr_on_success(&mut cmd);
     let expected = vec![
         svec![
             "letter",
@@ -1732,11 +1690,8 @@ END {
     ];
     assert_eq!(got, expected);
 
-    let end = wrk.output_stderr(&mut cmd);
     let expected_end = "Min/Max: 7/72 Grand total of 4 rows: 305\n".to_string();
     assert_eq!(end, expected_end);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1762,7 +1717,7 @@ fn luau_aggregation_with_begin_end_and_luau_syntax() {
         .arg(r#"return ("Min/Max: " .. math.min(unpack(amt_array)) .. "/" .. math.max(unpack(amt_array)) .. " Grand total of " .. _ROWCOUNT .. " rows: " .. gtotal)"#)
         .arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, end): (Vec<Vec<String>>, String) = wrk.read_stdout_and_stderr_on_success(&mut cmd);
     let expected = vec![
         svec!["letter", "Amount", "Total"],
         svec!["a", "13", "13"],
@@ -1772,11 +1727,8 @@ fn luau_aggregation_with_begin_end_and_luau_syntax() {
     ];
     assert_eq!(got, expected);
 
-    let end = wrk.output_stderr(&mut cmd);
     let expected_end = "Min/Max: -72/13 Grand total of 4 rows: 275\n".to_string();
     assert_eq!(end, expected_end);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]

--- a/tests/test_pivotp.rs
+++ b/tests/test_pivotp.rs
@@ -329,8 +329,7 @@ pivotp_test!(
             "quantile@1.5",
             "sales.csv",
         ]);
-        wrk.assert_err(&mut cmd);
-        let stderr = wrk.output_stderr(&mut cmd);
+        let stderr = wrk.stderr_on_error(&mut cmd);
         assert!(
             stderr.contains("Invalid quantile probability"),
             "expected 'Invalid quantile probability' in stderr, got: {stderr}"
@@ -468,9 +467,7 @@ pivotp_test!(
             "sales.csv",
         ]);
 
-        wrk.assert_err(&mut cmd);
-
-        let msg = wrk.output_stderr(&mut cmd);
+        let msg = wrk.stderr_on_error(&mut cmd);
         let expected_msg = r#"Polars error: ExprContext { error: ComputeError(ErrString("aggregation 'item' expected no or a single value, got 2 values")), expr: ErrString("col(\"sales\").filter([(col(\"product\"))"#;
         assert!(msg.starts_with(expected_msg));
     }
@@ -834,9 +831,7 @@ pivotp_test!(
             "sales.csv",
         ]);
 
-        wrk.assert_success(&mut cmd);
-
-        let msg = wrk.output_stderr(&mut cmd);
+        let msg = wrk.stderr_on_success(&mut cmd);
         let expected_msg = "Info: High variability in values (CV > 1), using Median for more \
                             robust central tendency\nPivot on-column cardinality:\n  product: \
                             2\n(2, 3)\n";
@@ -1393,9 +1388,8 @@ fn pivotp_smart_date_ascending() {
         "--try-parsedates",
         "date_ascending.csv",
     ]);
-    wrk.assert_success(&mut cmd);
 
-    let stderr = wrk.output_stderr(&mut cmd);
+    let stderr = wrk.stderr_on_success(&mut cmd);
     // Should use Last — ascending date values, most recent is most useful
     assert!(
         stderr.contains("Last") || stderr.contains("Ascending"),
@@ -1985,8 +1979,7 @@ pivotp_groupby_test!(
     |wrk: Workdir, mut cmd: process::Command| {
         cmd.args(["--agg", "len", "test.csv"]);
 
-        wrk.assert_err(&mut cmd);
-        let stderr = wrk.output_stderr(&mut cmd);
+        let stderr = wrk.stderr_on_error(&mut cmd);
         assert!(
             stderr.contains("--index <cols> is required in group-by mode"),
             "Expected --index required error, got: {stderr}"
@@ -2000,8 +1993,7 @@ pivotp_groupby_test!(
     |wrk: Workdir, mut cmd: process::Command| {
         cmd.args(["--index", "GROUP", "--agg", "len", "--subtotal", "test.csv"]);
 
-        wrk.assert_err(&mut cmd);
-        let stderr = wrk.output_stderr(&mut cmd);
+        let stderr = wrk.stderr_on_error(&mut cmd);
         assert!(
             stderr.contains("--subtotal is not supported in group-by mode"),
             "Expected --subtotal error, got: {stderr}"
@@ -2015,8 +2007,7 @@ pivotp_groupby_test!(
     |wrk: Workdir, mut cmd: process::Command| {
         cmd.args(["--index", "GROUP", "--agg", "len", "--validate", "test.csv"]);
 
-        wrk.assert_err(&mut cmd);
-        let stderr = wrk.output_stderr(&mut cmd);
+        let stderr = wrk.stderr_on_error(&mut cmd);
         assert!(
             stderr.contains("--validate is not supported in group-by mode"),
             "Expected --validate error, got: {stderr}"
@@ -2037,8 +2028,7 @@ pivotp_groupby_test!(
             "test.csv",
         ]);
 
-        wrk.assert_err(&mut cmd);
-        let stderr = wrk.output_stderr(&mut cmd);
+        let stderr = wrk.stderr_on_error(&mut cmd);
         assert!(
             stderr.contains("--sort-columns is not supported in group-by mode"),
             "Expected --sort-columns error, got: {stderr}"
@@ -2052,8 +2042,7 @@ pivotp_groupby_test!(
     |wrk: Workdir, mut cmd: process::Command| {
         cmd.args(["--index", "GROUP", "--agg", "none", "test.csv"]);
 
-        wrk.assert_err(&mut cmd);
-        let stderr = wrk.output_stderr(&mut cmd);
+        let stderr = wrk.stderr_on_error(&mut cmd);
         assert!(
             stderr.contains("not supported in group-by mode"),
             "Expected --agg none error, got: {stderr}"
@@ -2067,8 +2056,7 @@ pivotp_groupby_test!(
     |wrk: Workdir, mut cmd: process::Command| {
         cmd.args(["--index", "GROUP", "--agg", "item", "test.csv"]);
 
-        wrk.assert_err(&mut cmd);
-        let stderr = wrk.output_stderr(&mut cmd);
+        let stderr = wrk.stderr_on_error(&mut cmd);
         assert!(
             stderr.contains("--agg item is not supported in group-by mode"),
             "Expected --agg item error, got: {stderr}"

--- a/tests/test_pseudo.rs
+++ b/tests/test_pseudo.rs
@@ -186,11 +186,10 @@ fn pseudo_overflow() {
         .args(["--increment", "5"])
         .arg("data.csv");
 
-    wrk.assert_err(&mut cmd);
+    let (got, got_err): (Vec<Vec<String>>, String) = wrk.read_stdout_and_stderr_on_error(&mut cmd);
     // Sue gets the last valid counter (u64::MAX) and is written. Repeats of
     // Mary/John continue to resolve from the cache. Bob would need a new
     // pseudonym after the counter overflowed, so the command errors there.
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
         svec!["name", "colors"],
         svec!["ID-18446744073709551605", "yellow"],
@@ -202,7 +201,6 @@ fn pseudo_overflow() {
     ];
     assert_eq!(got, expected);
 
-    let got_err = wrk.output_stderr(&mut cmd);
     assert_eq!(
         got_err,
         "usage error: Counter overflow: incrementing past u64::MAX (18446744073709551615). Last \
@@ -220,14 +218,12 @@ fn pseudo_increment_zero_rejected() {
     let mut cmd = wrk.command("pseudo");
     cmd.arg("name").args(["--increment", "0"]).arg("data.csv");
 
-    wrk.assert_err(&mut cmd);
-    let got_err = wrk.output_stderr(&mut cmd);
+    let (got_stdout, got_err): (String, String) = wrk.stdout_and_stderr_on_error(&mut cmd);
     assert!(
         got_err.contains("--increment must be greater than 0"),
         "stderr was: {got_err}"
     );
     // usage-level errors must not write any partial output to stdout
-    let got_stdout = wrk.stdout::<String>(&mut cmd);
     assert!(
         got_stdout.is_empty(),
         "expected empty stdout, got: {got_stdout:?}"

--- a/tests/test_py.rs
+++ b/tests/test_py.rs
@@ -517,7 +517,8 @@ fn py_filter_error() {
         .arg("integerthis(number) > 14")
         .arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, stderr_string): (Vec<Vec<String>>, String) =
+        wrk.read_stdout_and_stderr_on_error(&mut cmd);
     let expected = vec![
         svec!["letter", "number"],
         svec!["a", "13"],
@@ -527,8 +528,6 @@ fn py_filter_error() {
     ];
     assert_eq!(got, expected);
 
-    wrk.assert_err(&mut cmd);
-    let stderr_string = wrk.output_stderr(&mut cmd);
     assert!(stderr_string.ends_with("Python errors encountered: 4\n"));
 }
 

--- a/tests/test_replace.rs
+++ b/tests/test_replace.rs
@@ -129,11 +129,11 @@ fn replace_null() {
     let mut cmd = wrk.command("replace");
     cmd.arg("\\.0$").arg("<NULL>").arg("data.csv");
 
-    let got_err = wrk.output_stderr(&mut cmd);
+    let (got, got_err): (Vec<Vec<String>>, String) =
+        wrk.read_stdout_and_stderr_on_success(&mut cmd);
     let expected_err = "5\n";
     assert_eq!(got_err, expected_err);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
         svec!["identifier", "color"],
         svec!["164", "yellow"],
@@ -142,8 +142,6 @@ fn replace_null() {
         svec!["167", "yellow"],
     ];
     assert_eq!(got, expected);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -167,7 +165,8 @@ fn replace_unicode() {
         .arg("--unicode")
         .arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, got_err): (Vec<Vec<String>>, String) =
+        wrk.read_stdout_and_stderr_on_success(&mut cmd);
     let expected = vec![
         svec!["identifier", "color"],
         svec!["164.0", "Ƀellow"],
@@ -179,11 +178,8 @@ fn replace_unicode() {
     ];
     assert_eq!(got, expected);
 
-    let got_err = wrk.output_stderr(&mut cmd);
     let expected_err = "4\n";
     assert_eq!(got_err, expected_err);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -330,7 +326,8 @@ fn replace_exact() {
         .arg("John Bloggs")
         .arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, got_err): (Vec<Vec<String>>, String) =
+        wrk.read_stdout_and_stderr_on_success(&mut cmd);
     // Should only replace exact match "J. Bloggs", not "F. J. Bloggs"
     let expected = vec![
         svec!["id", "name"],
@@ -340,11 +337,8 @@ fn replace_exact() {
     ];
     assert_eq!(got, expected);
 
-    let got_err = wrk.output_stderr(&mut cmd);
     let expected_err = "1\n";
     assert_eq!(got_err, expected_err);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -366,7 +360,8 @@ fn replace_exact_with_special_chars() {
         .arg("yellow")
         .arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, got_err): (Vec<Vec<String>>, String) =
+        wrk.read_stdout_and_stderr_on_success(&mut cmd);
     // Should only replace exact field match, not substring
     let expected = vec![
         svec!["identifier", "color"],
@@ -377,11 +372,8 @@ fn replace_exact_with_special_chars() {
     ];
     assert_eq!(got, expected);
 
-    let got_err = wrk.output_stderr(&mut cmd);
     let expected_err = "1\n";
     assert_eq!(got_err, expected_err);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -402,7 +394,8 @@ fn replace_exact_no_substring_match() {
         .arg("REPLACED")
         .arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, got_err): (Vec<Vec<String>>, String) =
+        wrk.read_stdout_and_stderr_on_success(&mut cmd);
     // Should NOT replace "F. J. Bloggs" even though it contains "J. Bloggs"
     let expected = vec![
         svec!["id", "name"],
@@ -412,11 +405,8 @@ fn replace_exact_no_substring_match() {
     ];
     assert_eq!(got, expected);
 
-    let got_err = wrk.output_stderr(&mut cmd);
     let expected_err = "1\n";
     assert_eq!(got_err, expected_err);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -439,7 +429,8 @@ fn replace_exact_case_insensitive() {
         .arg("John Bloggs")
         .arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, got_err): (Vec<Vec<String>>, String) =
+        wrk.read_stdout_and_stderr_on_success(&mut cmd);
     // Should replace both "J. Bloggs" and "j. bloggs" with case-insensitive exact match
     let expected = vec![
         svec!["id", "name"],
@@ -450,11 +441,8 @@ fn replace_exact_case_insensitive() {
     ];
     assert_eq!(got, expected);
 
-    let got_err = wrk.output_stderr(&mut cmd);
     let expected_err = "2\n";
     assert_eq!(got_err, expected_err);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -477,7 +465,8 @@ fn replace_exact_with_select() {
         .arg("REPLACED")
         .arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, got_err): (Vec<Vec<String>>, String) =
+        wrk.read_stdout_and_stderr_on_success(&mut cmd);
     // Should only replace exact "test" in name column, not "testing"
     let expected = vec![
         svec!["id", "name", "email"],
@@ -487,11 +476,8 @@ fn replace_exact_with_select() {
     ];
     assert_eq!(got, expected);
 
-    let got_err = wrk.output_stderr(&mut cmd);
     let expected_err = "2\n";
     assert_eq!(got_err, expected_err);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]

--- a/tests/test_safenames.rs
+++ b/tests/test_safenames.rs
@@ -25,7 +25,7 @@ fn safenames_conditional() {
     let mut cmd = wrk.command("safenames");
     cmd.arg("--mode").arg("c").arg("in.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, changed_headers): (Vec<Vec<String>>, String) = wrk.read_stdout_and_stderr(&mut cmd);
     let expected = vec![
         svec![
             "col1",
@@ -50,7 +50,6 @@ fn safenames_conditional() {
     ];
     assert_eq!(got, expected);
 
-    let changed_headers = wrk.output_stderr(&mut cmd);
     let expected_count = "7\n";
     assert_eq!(changed_headers, expected_count);
 }
@@ -80,7 +79,7 @@ fn safenames_always() {
     let mut cmd = wrk.command("safenames");
     cmd.arg("--mode").arg("always").arg("in.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, changed_headers): (Vec<Vec<String>>, String) = wrk.read_stdout_and_stderr(&mut cmd);
     let expected = vec![
         svec![
             "col1",
@@ -99,7 +98,6 @@ fn safenames_always() {
     ];
     assert_eq!(got, expected);
 
-    let changed_headers = wrk.output_stderr(&mut cmd);
     let expected_count = "6\n";
     assert_eq!(changed_headers, expected_count);
 }
@@ -324,7 +322,7 @@ fn safenames_reserved_names_default() {
     let mut cmd = wrk.command("safenames");
     cmd.arg("in.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, changed_headers): (Vec<Vec<String>>, String) = wrk.read_stdout_and_stderr(&mut cmd);
     let expected = vec![
         svec![
             "col1",
@@ -340,7 +338,6 @@ fn safenames_reserved_names_default() {
     ];
     assert_eq!(got, expected);
 
-    let changed_headers = wrk.output_stderr(&mut cmd);
     let expected_count = "6\n";
     assert_eq!(changed_headers, expected_count);
 }
@@ -653,7 +650,7 @@ fn safenames_reserved_names_specified() {
     let mut cmd = wrk.command("safenames");
     cmd.arg("--reserved").arg("waldo").arg("in.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, changed_headers): (Vec<Vec<String>>, String) = wrk.read_stdout_and_stderr(&mut cmd);
     let expected = vec![
         svec![
             "col1",
@@ -669,7 +666,6 @@ fn safenames_reserved_names_specified() {
     ];
     assert_eq!(got, expected);
 
-    let changed_headers = wrk.output_stderr(&mut cmd);
     let expected_count = "6\n";
     assert_eq!(changed_headers, expected_count);
 }
@@ -697,7 +693,7 @@ fn safenames_reserved_names_specified_case_insensitive() {
     let mut cmd = wrk.command("safenames");
     cmd.arg("--reserved").arg("waldo").arg("in.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, changed_headers): (Vec<Vec<String>>, String) = wrk.read_stdout_and_stderr(&mut cmd);
     let expected = vec![
         svec![
             "col1",
@@ -713,7 +709,6 @@ fn safenames_reserved_names_specified_case_insensitive() {
     ];
     assert_eq!(got, expected);
 
-    let changed_headers = wrk.output_stderr(&mut cmd);
     let expected_count = "6\n";
     assert_eq!(changed_headers, expected_count);
 }

--- a/tests/test_search.rs
+++ b/tests/test_search.rs
@@ -233,9 +233,9 @@ fn search_match_with_count() {
     let mut cmd = wrk.command("search");
     cmd.arg("^foo").arg("--count").arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
+    let (got, got_err): (Vec<Vec<String>>, String) =
+        wrk.read_stdout_and_stderr_on_success(&mut cmd);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
         svec!["h1", "h2"],
         svec!["foobar", "barfoo"],
@@ -243,7 +243,6 @@ fn search_match_with_count() {
     ];
     assert_eq!(got, expected);
 
-    let got_err = wrk.output_stderr(&mut cmd);
     assert_eq!(got_err, "2\n");
 }
 
@@ -254,10 +253,8 @@ fn search_match_quick() {
     let mut cmd = wrk.command("search");
     cmd.arg("^a").arg("--quick").arg("data.csv");
 
-    let got_err = wrk.output_stderr(&mut cmd);
+    let (got, got_err): (String, String) = wrk.stdout_and_stderr_on_success(&mut cmd);
     assert_eq!(got_err, "2\n");
-    wrk.assert_success(&mut cmd);
-    let got: String = wrk.stdout(&mut cmd);
     assert_eq!(got, "");
 }
 
@@ -271,15 +268,11 @@ fn search_match_quick_json() {
     let mut cmd = wrk.command("search");
     cmd.arg("^a").arg("--quick").arg("--json").arg("data.csv");
 
-    // Workdir::output_stderr returns the literal "No error" sentinel when
-    // stderr is empty and the command succeeded.
-    let got_err = wrk.output_stderr(&mut cmd);
-    assert_eq!(
-        got_err, "No error",
+    let (got, got_err): (String, String) = wrk.stdout_and_stderr_on_success(&mut cmd);
+    assert!(
+        got_err.is_empty(),
         "--quick --json should silence stderr (--json implies --quiet); got: {got_err:?}"
     );
-    wrk.assert_success(&mut cmd);
-    let got: String = wrk.stdout(&mut cmd);
     assert_eq!(got, "");
 }
 
@@ -314,15 +307,13 @@ fn search_indexed_parallel_quick() {
         .arg("--jobs")
         .arg("4")
         .arg("data.csv");
-    let par_err = wrk.output_stderr(&mut par_cmd);
-    wrk.assert_success(&mut par_cmd);
+    let (par_out, par_err): (String, String) = wrk.stdout_and_stderr_on_success(&mut par_cmd);
 
     // Same earliest-match row regardless of parallelism
     assert_eq!(seq_err, par_err);
     assert!(!seq_err.trim().is_empty());
 
     // --quick produces no stdout
-    let par_out: String = wrk.stdout(&mut par_cmd);
     assert_eq!(par_out, "");
 }
 
@@ -420,7 +411,8 @@ fn search_ignore_case_count() {
     cmd.arg("^FoO").arg("--count").arg("data.csv");
     cmd.arg("--ignore-case");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, got_err): (Vec<Vec<String>>, String) =
+        wrk.read_stdout_and_stderr_on_success(&mut cmd);
     let expected = vec![
         svec!["h1", "h2"],
         svec!["foobar", "barfoo"],
@@ -428,10 +420,7 @@ fn search_ignore_case_count() {
     ];
     assert_eq!(got, expected);
 
-    let got_err = wrk.output_stderr(&mut cmd);
     assert_eq!(got_err, "2\n");
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -457,14 +446,12 @@ fn search_unicode_count() {
     cmd.arg("^Ḟoo").arg("--count").arg("data.csv");
     cmd.arg("--unicode");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, got_err): (Vec<Vec<String>>, String) =
+        wrk.read_stdout_and_stderr_on_success(&mut cmd);
     let expected = vec![svec!["h1", "h2"], svec!["Ḟooƀar", "ḃarḟoo"]];
     assert_eq!(got, expected);
 
-    let got_err = wrk.output_stderr(&mut cmd);
     assert_eq!(got_err, "1\n");
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -490,14 +477,12 @@ fn search_unicode_envvar_count() {
     cmd.env("QSV_REGEX_UNICODE", "1");
     cmd.arg("^Ḟoo").arg("--count").arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, got_err): (Vec<Vec<String>>, String) =
+        wrk.read_stdout_and_stderr_on_success(&mut cmd);
     let expected = vec![svec!["h1", "h2"], svec!["Ḟooƀar", "ḃarḟoo"]];
     assert_eq!(got, expected);
 
-    let got_err = wrk.output_stderr(&mut cmd);
     assert_eq!(got_err, "1\n");
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -538,14 +523,12 @@ fn search_no_headers_count() {
     cmd.arg("^foo").arg("--count").arg("data.csv");
     cmd.arg("--no-headers");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, got_err): (Vec<Vec<String>>, String) =
+        wrk.read_stdout_and_stderr_on_success(&mut cmd);
     let expected = vec![svec!["foobar", "barfoo"], svec!["barfoo", "foobar"]];
     assert_eq!(got, expected);
 
-    let got_err = wrk.output_stderr(&mut cmd);
     assert_eq!(got_err, "2\n");
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -571,14 +554,12 @@ fn search_select_count() {
     cmd.arg("^foo").arg("--count").arg("data.csv");
     cmd.arg("--select").arg("h2");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, got_err): (Vec<Vec<String>>, String) =
+        wrk.read_stdout_and_stderr_on_success(&mut cmd);
     let expected = vec![svec!["h1", "h2"], svec!["barfoo", "foobar"]];
     assert_eq!(got, expected);
 
-    let got_err = wrk.output_stderr(&mut cmd);
     assert_eq!(got_err, "1\n");
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -606,14 +587,12 @@ fn search_select_no_headers_count() {
     cmd.arg("--select").arg("2");
     cmd.arg("--no-headers");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, got_err): (Vec<Vec<String>>, String) =
+        wrk.read_stdout_and_stderr_on_success(&mut cmd);
     let expected = vec![svec!["barfoo", "foobar"]];
     assert_eq!(got, expected);
 
-    let got_err = wrk.output_stderr(&mut cmd);
     assert_eq!(got_err, "1\n");
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -643,7 +622,8 @@ fn search_invert_match_count() {
     cmd.arg("^foo").arg("--count").arg("data.csv");
     cmd.arg("--invert-match");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, got_count): (Vec<Vec<String>>, String) =
+        wrk.read_stdout_and_stderr_on_success(&mut cmd);
     let expected = vec![
         svec!["foobar", "barfoo"],
         svec!["a", "b"],
@@ -651,10 +631,8 @@ fn search_invert_match_count() {
     ];
     assert_eq!(got, expected);
 
-    let got = wrk.output_stderr(&mut cmd);
     let expected = "2\n";
-    assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
+    assert_eq!(got_count, expected);
 }
 
 #[test]
@@ -682,14 +660,12 @@ fn search_invert_match_no_headers_count() {
     cmd.arg("--invert-match");
     cmd.arg("--no-headers");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, got_err): (Vec<Vec<String>>, String) =
+        wrk.read_stdout_and_stderr_on_success(&mut cmd);
     let expected = vec![svec!["a", "b"], svec!["Ḟooƀar", "ḃarḟoo"]];
     assert_eq!(got, expected);
 
-    let got_err = wrk.output_stderr(&mut cmd);
     assert_eq!(got_err, "2\n");
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -806,7 +782,8 @@ fn search_flag_invert_match_count() {
         .args(["--flag", "flagged"]);
     cmd.arg("--invert-match");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, got_err): (Vec<Vec<String>>, String) =
+        wrk.read_stdout_and_stderr_on_success(&mut cmd);
     let expected = vec![
         svec!["h1", "h2", "flagged"],
         svec!["foobar", "barfoo", "0"],
@@ -816,10 +793,7 @@ fn search_flag_invert_match_count() {
     ];
     assert_eq!(got, expected);
 
-    let got_err = wrk.output_stderr(&mut cmd);
     assert_eq!(got_err, "2\n");
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -833,14 +807,12 @@ fn search_flag_invert_matchonly_count() {
         .args(["--flag", "M"]);
     cmd.arg("--invert-match");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, got_err): (Vec<Vec<String>>, String) =
+        wrk.read_stdout_and_stderr_on_success(&mut cmd);
     let expected = vec![svec!["M"], svec!["2"], svec!["4"]];
     assert_eq!(got, expected);
 
-    let got_err = wrk.output_stderr(&mut cmd);
     assert_eq!(got_err, "2\n");
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -854,14 +826,14 @@ fn search_preview() {
         .arg(test_file)
         .args(["--preview-match", "2"]);
 
-    let preview = wrk.output_stderr(&mut cmd);
+    let (got, preview): (Vec<Vec<String>>, String) =
+        wrk.read_stdout_and_stderr_on_success(&mut cmd);
     let expected_preview = r#"case_enquiry_id,open_dt,target_dt,closed_dt,ontime,case_status,closure_reason,case_title,subject,reason,type,queue,department,submittedphoto,closedphoto,location,fire_district,pwd_district,city_council_district,police_district,neighborhood,neighborhood_services_district,ward,precinct,location_street_name,location_zipcode,latitude,longitude,source
 101004113298,2022-01-01 00:16:00,2022-04-01 00:16:06,2022-01-10 08:42:23,ONTIME,Closed,Case Closed. Closed date : Mon Jan 10 08:42:23 EST 2022 Resolved No Cause 1/10/22 ,SCHEDULED Unsatisfactory Utilities - Electrical  Plumbing,Inspectional Services,Housing,Unsatisfactory Utilities - Electrical  Plumbing,ISD_Housing (INTERNAL),ISD,,,47 W Cedar St  Boston  MA  02114,3,1B,8,A1,Beacon Hill,14,Ward 5,0504,47 W Cedar St,02114,42.3594,-71.07,Constituent Call
 101004141354,2022-01-20 08:07:49,2022-01-21 08:30:00,2022-01-20 08:45:03,ONTIME,Closed,Case Closed. Closed date : Thu Jan 20 08:45:03 EST 2022 Noted ,CE Collection,Public Works Department,Street Cleaning,CE Collection,PWDx_District 1B: North End,PWDx,,,21-23 Temple St  Boston  MA  02114,3,1B,1,A1,Beacon Hill,3,Ward 3,0306,21-23 Temple St,02114,42.3606,-71.0638,City Worker App
 Previewed 2 matches in 100 initial records in"#;
     assert!(preview.starts_with(expected_preview));
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
         svec!["case_enquiry_id", "open_dt", "target_dt", "closed_dt", "ontime", "case_status", "closure_reason", "case_title", "subject", "reason", "type", "queue", "department", "submittedphoto", "closedphoto", "location", "fire_district", "pwd_district", "city_council_district", "police_district", "neighborhood", "neighborhood_services_district", "ward", "precinct", "location_street_name", "location_zipcode", "latitude", "longitude", "source"], 
         svec!["101004113298", "2022-01-01 00:16:00", "2022-04-01 00:16:06", "2022-01-10 08:42:23", "ONTIME", "Closed", "Case Closed. Closed date : Mon Jan 10 08:42:23 EST 2022 Resolved No Cause 1/10/22 ", "SCHEDULED Unsatisfactory Utilities - Electrical  Plumbing", "Inspectional Services", "Housing", "Unsatisfactory Utilities - Electrical  Plumbing", "ISD_Housing (INTERNAL)", "ISD", "", "", "47 W Cedar St  Boston  MA  02114", "3", "1B", "8", "A1", "Beacon Hill", "14", "Ward 5", "0504", "47 W Cedar St", "02114", "42.3594", "-71.07", "Constituent Call"], 
@@ -873,7 +845,6 @@ Previewed 2 matches in 100 initial records in"#;
         svec!["101004115066", "2022-01-03 15:51:00", "2022-01-04 15:51:30", "", "OVERDUE", "Open", " ", "Sidewalk Repair (Make Safe)", "Public Works Department", "Highway Maintenance", "Sidewalk Repair (Make Safe)", "PWDx_Highway Construction", "PWDx", "https://311.boston.gov/media/boston/report/photos/61d361c905bbcf180c2b1dd3/report.jpg", "", "64 Anderson St  Boston  MA  02114", "3", "1B", "8", "A1", "Beacon Hill", "14", "Ward 5", "0503", "64 Anderson St", "02114", "42.359", "-71.0676", "Citizens Connect App"],
     ];
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -889,16 +860,14 @@ fn search_preview_json() {
         .arg("--quiet")
         .args(["--preview-match", "2"]);
 
-    let preview = wrk.output_stderr(&mut cmd);
+    let (got, preview): (String, String) = wrk.stdout_and_stderr_on_success(&mut cmd);
     let expected_preview = r#"[{"case_enquiry_id":"101004113298","open_dt":"2022-01-01 00:16:00","target_dt":"2022-04-01 00:16:06","closed_dt":"2022-01-10 08:42:23","ontime":"ONTIME","case_status":"Closed","closure_reason":"Case Closed. Closed date : Mon Jan 10 08:42:23 EST 2022 Resolved No Cause 1/10/22 ","case_title":"SCHEDULED Unsatisfactory Utilities - Electrical  Plumbing","subject":"Inspectional Services","reason":"Housing","type":"Unsatisfactory Utilities - Electrical  Plumbing","queue":"ISD_Housing (INTERNAL)","department":"ISD","submittedphoto":null,"closedphoto":null,"location":"47 W Cedar St  Boston  MA  02114","fire_district":"3","pwd_district":"1B","city_council_district":"8","police_district":"A1","neighborhood":"Beacon Hill","neighborhood_services_district":"14","ward":"Ward 5","precinct":"0504","location_street_name":"47 W Cedar St","location_zipcode":"02114","latitude":"42.3594","longitude":"-71.07","source":"Constituent Call"},{"case_enquiry_id":"101004141354","open_dt":"2022-01-20 08:07:49","target_dt":"2022-01-21 08:30:00","closed_dt":"2022-01-20 08:45:03","ontime":"ONTIME","case_status":"Closed","closure_reason":"Case Closed. Closed date : Thu Jan 20 08:45:03 EST 2022 Noted ","case_title":"CE Collection","subject":"Public Works Department","reason":"Street Cleaning","type":"CE Collection","queue":"PWDx_District 1B: North End","department":"PWDx","submittedphoto":null,"closedphoto":null,"location":"21-23 Temple St  Boston  MA  02114","fire_district":"3","pwd_district":"1B","city_council_district":"1","police_district":"A1","neighborhood":"Beacon Hill","neighborhood_services_district":"3","ward":"Ward 3","precinct":"0306","location_street_name":"21-23 Temple St","location_zipcode":"02114","latitude":"42.3606","longitude":"-71.0638","source":"City Worker App"}]"#;
     assert_eq!(
         serde_json::from_str::<Value>(&preview).unwrap(),
         serde_json::from_str::<Value>(expected_preview).unwrap()
     );
-    let got: String = wrk.stdout(&mut cmd);
     let expected = r#"[{"case_enquiry_id":"101004113298","open_dt":"2022-01-01 00:16:00","target_dt":"2022-04-01 00:16:06","closed_dt":"2022-01-10 08:42:23","ontime":"ONTIME","case_status":"Closed","closure_reason":"Case Closed. Closed date : Mon Jan 10 08:42:23 EST 2022 Resolved No Cause 1/10/22 ","case_title":"SCHEDULED Unsatisfactory Utilities - Electrical  Plumbing","subject":"Inspectional Services","reason":"Housing","type":"Unsatisfactory Utilities - Electrical  Plumbing","queue":"ISD_Housing (INTERNAL)","department":"ISD","submittedphoto":null,"closedphoto":null,"location":"47 W Cedar St  Boston  MA  02114","fire_district":"3","pwd_district":"1B","city_council_district":"8","police_district":"A1","neighborhood":"Beacon Hill","neighborhood_services_district":"14","ward":"Ward 5","precinct":"0504","location_street_name":"47 W Cedar St","location_zipcode":"02114","latitude":"42.3594","longitude":"-71.07","source":"Constituent Call"},{"case_enquiry_id":"101004141354","open_dt":"2022-01-20 08:07:49","target_dt":"2022-01-21 08:30:00","closed_dt":"2022-01-20 08:45:03","ontime":"ONTIME","case_status":"Closed","closure_reason":"Case Closed. Closed date : Thu Jan 20 08:45:03 EST 2022 Noted ","case_title":"CE Collection","subject":"Public Works Department","reason":"Street Cleaning","type":"CE Collection","queue":"PWDx_District 1B: North End","department":"PWDx","submittedphoto":null,"closedphoto":null,"location":"21-23 Temple St  Boston  MA  02114","fire_district":"3","pwd_district":"1B","city_council_district":"1","police_district":"A1","neighborhood":"Beacon Hill","neighborhood_services_district":"3","ward":"Ward 3","precinct":"0306","location_street_name":"21-23 Temple St","location_zipcode":"02114","latitude":"42.3606","longitude":"-71.0638","source":"City Worker App"},{"case_enquiry_id":"101004141367","open_dt":"2022-01-20 08:15:45","target_dt":"2022-01-21 08:30:00","closed_dt":"2022-01-20 08:45:12","ontime":"ONTIME","case_status":"Closed","closure_reason":"Case Closed. Closed date : Thu Jan 20 08:45:12 EST 2022 Noted ","case_title":"CE Collection","subject":"Public Works Department","reason":"Street Cleaning","type":"CE Collection","queue":"PWDx_District 1B: North End","department":"PWDx","submittedphoto":null,"closedphoto":null,"location":"12 Derne St  Boston  MA  02114","fire_district":"3","pwd_district":"1B","city_council_district":"1","police_district":"A1","neighborhood":"Beacon Hill","neighborhood_services_district":"3","ward":"Ward 3","precinct":"0306","location_street_name":"12 Derne St","location_zipcode":"02114","latitude":"42.3596","longitude":"-71.0634","source":"City Worker App"},{"case_enquiry_id":"101004113348","open_dt":"2022-01-01 06:46:29","target_dt":"2022-01-05 08:30:00","closed_dt":"2022-01-01 15:10:16","ontime":"ONTIME","case_status":"Closed","closure_reason":"Case Closed. Closed date : Sat Jan 01 15:10:16 EST 2022 Noted Trash bags sent in for collection. No evidence or code violations found at this time  ","case_title":"Improper Storage of Trash (Barrels)","subject":"Public Works Department","reason":"Code Enforcement","type":"Improper Storage of Trash (Barrels)","queue":"PWDx_Code Enforcement","department":"PWDx","submittedphoto":"https://311.boston.gov/media/boston/report/photos/61d03f0d05bbcf180c2965fd/report.jpg","closedphoto":null,"location":"14 S Russell St  Boston  MA  02114","fire_district":"3","pwd_district":"1B","city_council_district":"1","police_district":"A1","neighborhood":"Beacon Hill","neighborhood_services_district":"3","ward":"Ward 3","precinct":"0306","location_street_name":"14 S Russell St","location_zipcode":"02114","latitude":"42.3607","longitude":"-71.0659","source":"Citizens Connect App"},{"case_enquiry_id":"101004113431","open_dt":"2022-01-01 10:35:45","target_dt":"2022-01-05 08:30:00","closed_dt":"2022-01-01 14:59:41","ontime":"ONTIME","case_status":"Closed","closure_reason":"Case Closed. Closed date : Sat Jan 01 14:59:41 EST 2022 Noted Bags sent in for collection. Ticket issued  ","case_title":"Improper Storage of Trash (Barrels)","subject":"Public Works Department","reason":"Code Enforcement","type":"Improper Storage of Trash (Barrels)","queue":"PWDx_Code Enforcement","department":"PWDx","submittedphoto":"https://311.boston.gov/media/boston/report/photos/61d074c005bbcf180c298048/report.jpg","closedphoto":null,"location":"40 Anderson St  Boston  MA  02114","fire_district":"3","pwd_district":"1B","city_council_district":"8","police_district":"A1","neighborhood":"Beacon Hill","neighborhood_services_district":"14","ward":"Ward 5","precinct":"0504","location_street_name":"40 Anderson St","location_zipcode":"02114","latitude":"42.3598","longitude":"-71.0676","source":"Citizens Connect App"},{"case_enquiry_id":"101004113717","open_dt":"2022-01-01 21:11:00","target_dt":"2022-01-04 08:30:00","closed_dt":"2022-01-04 09:30:03","ontime":"OVERDUE","case_status":"Closed","closure_reason":"Case Closed. Closed date : 2022-01-04 09:30:03.91 Case Noted Dear Constituent     NGRID is aware of the broken gate and will send a crew to repair.    We are waiting on there schedule to do so.    Regards   Rich DiMarzo  781-853-9016 ","case_title":"Request for Pothole Repair","subject":"Public Works Department","reason":"Highway Maintenance","type":"Request for Pothole Repair","queue":"PWDx_Contractor Complaints","department":"PWDx","submittedphoto":"https://311.boston.gov/media/boston/report/photos/61d109cf05bbcf180c29c167/Pothole_1.jpg","closedphoto":null,"location":"INTERSECTION of Charles River Plz & Cambridge St  Boston  MA  ","fire_district":"3","pwd_district":"1B","city_council_district":"7","police_district":"A1","neighborhood":"Beacon Hill","neighborhood_services_district":"3","ward":"3","precinct":"0305","location_street_name":"INTERSECTION Charles River Plz & Cambridge St","location_zipcode":null,"latitude":"42.3594","longitude":"-71.0587","source":"Citizens Connect App"},{"case_enquiry_id":"101004115066","open_dt":"2022-01-03 15:51:00","target_dt":"2022-01-04 15:51:30","closed_dt":null,"ontime":"OVERDUE","case_status":"Open","closure_reason":" ","case_title":"Sidewalk Repair (Make Safe)","subject":"Public Works Department","reason":"Highway Maintenance","type":"Sidewalk Repair (Make Safe)","queue":"PWDx_Highway Construction","department":"PWDx","submittedphoto":"https://311.boston.gov/media/boston/report/photos/61d361c905bbcf180c2b1dd3/report.jpg","closedphoto":null,"location":"64 Anderson St  Boston  MA  02114","fire_district":"3","pwd_district":"1B","city_council_district":"8","police_district":"A1","neighborhood":"Beacon Hill","neighborhood_services_district":"14","ward":"Ward 5","precinct":"0503","location_street_name":"64 Anderson St","location_zipcode":"02114","latitude":"42.359","longitude":"-71.0676","source":"Citizens Connect App"}]"#;
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]

--- a/tests/test_searchset.rs
+++ b/tests/test_searchset.rs
@@ -160,15 +160,13 @@ fn searchset_indexed_parallel_quick() {
         .arg("--jobs")
         .arg("4")
         .arg("data.csv");
-    let par_err = wrk.output_stderr(&mut par_cmd);
-    wrk.assert_success(&mut par_cmd);
+    let (par_out, par_err): (String, String) = wrk.stdout_and_stderr_on_success(&mut par_cmd);
 
     // Same earliest-match row regardless of parallelism
     assert_eq!(seq_err, par_err);
     assert!(!seq_err.trim().is_empty());
 
     // --quick produces no stdout
-    let par_out: String = wrk.stdout(&mut par_cmd);
     assert_eq!(par_out, "");
 }
 
@@ -293,10 +291,8 @@ fn searchset_quick() {
     let mut cmd = wrk.command("searchset");
     cmd.arg("regexset.txt").arg("--quick").arg("data.csv");
 
-    let got_err = wrk.output_stderr(&mut cmd);
+    let (got, got_err): (String, String) = wrk.stdout_and_stderr_on_success(&mut cmd);
     assert_eq!(got_err, "1\n");
-    wrk.assert_success(&mut cmd);
-    let got: String = wrk.stdout(&mut cmd);
     assert_eq!(got, "");
 }
 
@@ -418,7 +414,8 @@ fn searchset_ignore_case_count() {
     cmd.arg("regexset.txt").arg("--count").arg("data.csv");
     cmd.arg("--ignore-case");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let (got, got_count): (Vec<Vec<String>>, String) =
+        wrk.read_stdout_and_stderr_on_success(&mut cmd);
     let expected = vec![
         svec!["h1", "h2"],
         svec!["foobar", "barfoo"],
@@ -428,11 +425,8 @@ fn searchset_ignore_case_count() {
     ];
     assert_eq!(got, expected);
 
-    let got = wrk.output_stderr(&mut cmd);
     let expected = "4\n";
-    assert_eq!(got, expected);
-
-    wrk.assert_success(&mut cmd);
+    assert_eq!(got_count, expected);
 }
 
 #[test]
@@ -587,15 +581,13 @@ fn searchset_flag_complex() {
         .arg("--flag-matches-only")
         .arg("--json");
 
-    let got: String = wrk.stdout(&mut cmd);
-    let got_stderr: String = wrk.output_stderr(&mut cmd);
+    let (got, got_stderr): (String, String) = wrk.stdout_and_stderr_on_success(&mut cmd);
 
     let expected = wrk.load_test_resource("boston311-100-pii-searchset.csv");
     assert_eq!(dos2unix(&got), dos2unix(&expected).trim_end());
 
     let expected_stderr = r#"{"rows_with_matches":5,"total_matches":6,"record_count":100}"#;
     assert_eq!(got_stderr.trim_end(), expected_stderr);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -614,8 +606,7 @@ fn searchset_flag_complex_unmatched_output() {
         .arg("unmatched.csv")
         .arg("--json");
 
-    let got: String = wrk.stdout(&mut cmd);
-    let got_stderr: String = wrk.output_stderr(&mut cmd);
+    let (got, got_stderr): (String, String) = wrk.stdout_and_stderr_on_success(&mut cmd);
 
     let expected = wrk.load_test_resource("boston311-100-pii-searchset.csv");
     assert_eq!(dos2unix(&got), dos2unix(&expected).trim_end());
@@ -625,8 +616,6 @@ fn searchset_flag_complex_unmatched_output() {
 
     let unmatched_got: String = wrk.from_str(&wrk.path("unmatched.csv"));
     assert_eq!(unmatched_got, nopii_file);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]

--- a/tests/test_searchset.rs
+++ b/tests/test_searchset.rs
@@ -274,13 +274,9 @@ fn searchset_match_count() {
     let mut cmd = wrk.command("searchset");
     cmd.arg("regexset.txt").arg("--count").arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_success(&mut cmd);
     let expected = "3\n";
     assert_eq!(got, expected);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]

--- a/tests/test_split.rs
+++ b/tests/test_split.rs
@@ -767,10 +767,7 @@ fn split_nooutdir() {
 
     let mut cmd = wrk.command("split");
     cmd.args(["--size", "2"]).arg("in.csv");
-    wrk.run(&mut cmd);
-
-    wrk.assert_err(&mut cmd);
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_error(&mut cmd);
     let expected = "usage error: <outdir> is not specified or is a file.\n";
     assert_eq!(got, expected);
 }

--- a/tests/test_sqlp.rs
+++ b/tests/test_sqlp.rs
@@ -3573,8 +3573,7 @@ fn sqlp_decimal_comma_validation() {
         .arg("--decimal-comma")
         .arg("select * from _t_1");
 
-    wrk.assert_err(&mut cmd);
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_error(&mut cmd);
     assert!(got.contains("Using --decimal-comma with a comma separator is invalid"));
 
     // Test 2: --decimal-comma with semicolon delimiter should succeed
@@ -3698,8 +3697,7 @@ fn sqlp_decimal_comma_validation_with_output_file() {
         .args(["--output", "output.csv"])
         .arg("select * from _t_1");
 
-    wrk.assert_err(&mut cmd);
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_error(&mut cmd);
     assert!(got.contains("Using --decimal-comma with a comma separator is invalid"));
 }
 

--- a/tests/test_template.rs
+++ b/tests/test_template.rs
@@ -1182,14 +1182,13 @@ fn template_render_error_summary() {
         .arg("template.txt")
         .arg("data.csv");
 
-    let stderr = wrk.output_stderr(&mut cmd);
+    let (got, stderr): (String, String) = wrk.stdout_and_stderr(&mut cmd);
     assert!(
         stderr.contains("3 row(s) failed to render"),
         "expected render-failure summary on stderr, got: {stderr:?}"
     );
 
     // The per-row error message should still be in stdout (existing behavior).
-    let got: String = wrk.stdout(&mut cmd);
     assert!(
         got.contains("RENDERING ERROR (1)"),
         "expected per-row error in stdout, got: {got:?}"

--- a/tests/test_validate.rs
+++ b/tests/test_validate.rs
@@ -1938,12 +1938,9 @@ fn validate_with_fancy_regex() {
         .arg("data.csv")
         .arg("schema.json")
         .arg("--fancy-regex");
-    wrk.output(&mut cmd_fancy);
-
     // we still get an error here as the test data is invalid,
     // not because of the regex engine
-    wrk.assert_err(&mut cmd_fancy);
-    let got = wrk.output_stderr(&mut cmd_fancy);
+    let got = wrk.stderr_on_error(&mut cmd_fancy);
     assert_eq!(got, "4 out of 5 records invalid.\n");
 
     // Check validation-errors.tsv - should show 4 invalid passwords
@@ -2612,14 +2609,10 @@ fn validate_multiple_files_json_output() {
     let mut cmd = wrk.command("validate");
     cmd.arg("--json").arg("file1.csv").arg("file2.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.output_stderr(&mut cmd);
+    let (stdout_str, got): (String, String) = wrk.stdout_and_stderr_on_success(&mut cmd);
     assert!(got.contains("✅ All 2 files are valid."));
 
     // Check that JSON output is produced for each file
-    let output = wrk.output(&mut cmd);
-    let stdout_str = String::from_utf8_lossy(&output.stdout);
     assert!(stdout_str.contains("\"delimiter_char\":\",\""));
     assert!(stdout_str.contains("\"num_records\":2"));
 }
@@ -2647,14 +2640,10 @@ fn validate_multiple_files_pretty_json_output() {
     let mut cmd = wrk.command("validate");
     cmd.arg("--pretty-json").arg("file1.csv").arg("file2.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.output_stderr(&mut cmd);
+    let (stdout_str, got): (String, String) = wrk.stdout_and_stderr_on_success(&mut cmd);
     assert!(got.contains("✅ All 2 files are valid."));
 
     // Check that pretty JSON output is produced for each file
-    let output = wrk.output(&mut cmd);
-    let stdout_str = String::from_utf8_lossy(&output.stdout);
     assert!(stdout_str.contains("{\n  \"delimiter_char\": \",\""));
     assert!(stdout_str.contains("\"num_records\": 2"));
 }
@@ -2768,15 +2757,13 @@ fn validate_single_file_backward_compatibility() {
     let mut cmd = wrk.command("validate");
     cmd.arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got_stderr: String = wrk.output_stderr(&mut cmd);
-    let output = wrk.output(&mut cmd);
-    let got_stdout = String::from_utf8_lossy(&output.stdout);
+    let (got_stdout, got_stderr): (String, String) = wrk.stdout_and_stderr_on_success(&mut cmd);
 
     let expected = "Valid: 3 Columns: (\"id\", \"name\", \"age\"); Records: 2; Delimiter: ,";
-    // The output might be on stdout instead of stderr
-    if got_stderr.contains("No error") {
+    // The output might be on stdout instead of stderr. `output_stderr` used to
+    // return the literal "No error" sentinel for the empty-stderr case this
+    // branch is testing for.
+    if got_stderr.is_empty() {
         assert_eq!(got_stdout.trim(), expected);
     } else {
         assert_eq!(got_stderr, expected);

--- a/tests/test_validate.rs
+++ b/tests/test_validate.rs
@@ -618,11 +618,10 @@ fn validate_adur_public_toilets_dataset_with_json_schema_valid_output() {
         .arg("schema.json")
         .args(["--valid-output", "-"]);
 
-    let out = wrk.output_stderr(&mut cmd);
+    let (got, out): (Vec<Vec<String>>, String) = wrk.read_stdout_and_stderr_on_error(&mut cmd);
     let expected = "13\n";
     assert_eq!(out, expected);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
         svec!["ExtractDate", "OrganisationURI", "OrganisationLabel", "ServiceTypeURI", "ServiceTypeLabel", "LocationText", "CoordinateReferenceSystem", "GeoX", "GeoY", "GeoPointLicensingURL", "Category", "AccessibleCategory", "RADARKeyNeeded", "BabyChange", "FamilyToilet", "ChangingPlace", "AutomaticPublicConvenience", "FullTimeStaffing", "PartOfCommunityScheme", "CommunitySchemeName", "ChargeAmount", "InfoURL", "OpeningHours", "ManagedBy", "ReportEmail", "ReportTel", "Notes", "UPRN", "Postcode", "StreetAddress", "GeoAreaURI", "GeoAreaLabel"], 
         svec!["07/07/2014 00:00", "http://opendatacommunities.org/id/district-council/adur", "Adur", "http://id.esd.org.uk/service/579", "Public toilets", "PUBLIC CONVENIENCES MONKS RECREATION GROUND CRABTREE LANE LANCING", "OSGB36", "518225", "104730", "http://www.ordnancesurvey.co.uk/business-and-government/help-and-support/public-sector/guidance/derived-data-exemptions.html", "Female and male", "None", "Yes", "No", "No", "No", "No", "No", "No", "", "", "http://www.adur-worthing.gov.uk/streets-and-travel/public-toilets/", "S = 09:00 - 15:00 W = 09:00 - 15:00", "ADC", "surveyor_2@adur-worthing.gov.uk", "01903 221471", "", "60002210", "", "PUBLIC CONVENIENCES MONKS RECREATION GROUND CRABTREE LANE LANCING", "", ""], 
@@ -640,8 +639,6 @@ fn validate_adur_public_toilets_dataset_with_json_schema_valid_output() {
         svec!["07/07/2014 00:00", "http://opendatacommunities.org/id/district-council/adur", "Adur", "http://id.esd.org.uk/service/579", "Public toilets", "BEACH TOILETS BASIN ROAD SOUTH SOUTHWICK", "OSGB36", "522083", "105168", "http://www.ordnancesurvey.co.uk/business-and-government/help-and-support/public-sector/guidance/derived-data-exemptions.html", "Female and male", "Unisex", "Yes", "No", "No", "No", "No", "No", "No", "", "", "http://www.adur-worthing.gov.uk/streets-and-travel/public-toilets/", "09.00 - 17.00", "ADC", "surveyor_15@adur-worthing.gov.uk", "01903 221471", "", "60034215", "", "PUBLIC CONVENIENCES CIVIC CENTRE HAM ROAD SHOREHAM-BY-SEA", "", ""]    
     ];
     assert_eq!(got, expected);
-
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]

--- a/tests/test_validate.rs
+++ b/tests/test_validate.rs
@@ -1780,16 +1780,14 @@ fn validate_no_format_validation() {
         .arg("data.csv")
         .arg("schema.json");
 
-    wrk.assert_success(&mut cmd);
+    let got: String = wrk.stderr_on_success(&mut cmd);
+    let expected = "All 3 records valid.\n";
+    assert_eq!(got, expected);
 
     // Should not create any error files since all records are valid
     // when format validation is disabled
     assert!(!wrk.path("data.csv.invalid").exists());
     assert!(!wrk.path("data.csv.validation-errors.tsv").exists());
-
-    let got: String = wrk.output_stderr(&mut cmd);
-    let expected = "All 3 records valid.\n";
-    assert_eq!(got, expected);
 }
 
 #[test]
@@ -1848,9 +1846,7 @@ fn validate_invalid_json_schema_file() {
     let mut cmd = wrk.command("validate");
     cmd.arg("schema").arg("schema.json");
 
-    wrk.assert_err(&mut cmd);
-
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_error(&mut cmd);
     // reqwest >=0.13.4 appends " for url (<url>)" to body-decoding errors; match the
     // stable prefix only so we don't re-couple to reqwest's exact wording.
     let expected_prefix =
@@ -1885,9 +1881,7 @@ fn validate_invalid_json_schema_file() {
     let mut cmd = wrk.command("validate");
     cmd.arg("schema").arg("schema2.json");
 
-    wrk.assert_err(&mut cmd);
-
-    let got = wrk.output_stderr(&mut cmd);
+    let got = wrk.stderr_on_error(&mut cmd);
     assert_eq!(
         got,
         "JSON Schema Meta-Reference Error: \"stringy\" is not valid under any of the schemas \
@@ -2691,12 +2685,14 @@ fn validate_multiple_files_quiet_mode() {
     let mut cmd = wrk.command("validate");
     cmd.arg("--quiet").arg("file1.csv").arg("file2.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    // In quiet mode, there should be no output to stderr
-    let got: String = wrk.output_stderr(&mut cmd);
-    // The output might be "No error" if there's no stderr output
-    assert!(got.is_empty() || got == "No error");
+    // In quiet mode, there should be no output to stderr. `output_stderr` used to
+    // substitute the literal "No error" for empty stderr on a successful run, so the
+    // assertion had to accept it; `stderr_on_success` returns stderr verbatim.
+    let got: String = wrk.stderr_on_success(&mut cmd);
+    assert!(
+        got.is_empty(),
+        "expected no stderr in quiet mode, got: {got:?}"
+    );
 }
 
 #[test]

--- a/tests/workdir.rs
+++ b/tests/workdir.rs
@@ -166,18 +166,6 @@ impl Workdir {
         o
     }
 
-    /// Run `cmd` once and return its full `Output` with success asserted, for
-    /// tests that need both streams in a shape the tuple helpers don't cover.
-    pub fn output_on_success(&self, cmd: &mut process::Command) -> process::Output {
-        self.run_once(cmd, Some(true))
-    }
-
-    /// Run `cmd` once and return its full `Output` with a non-zero exit
-    /// asserted. The failure-path twin of `output_on_success`.
-    pub fn output_on_error(&self, cmd: &mut process::Command) -> process::Output {
-        self.run_once(cmd, Some(false))
-    }
-
     /// Run `cmd` ONCE and return `(stdout parsed as CSV, stderr)`. Use this
     /// when a test asserts on both streams: `read_stdout` followed by
     /// `output_stderr` runs the command twice, so the rows and the stderr text

--- a/tests/workdir.rs
+++ b/tests/workdir.rs
@@ -106,9 +106,9 @@ impl Workdir {
         Ok(contents)
     }
 
-    /// read stdout of a command
-    pub fn read_stdout<T: Csv>(&self, cmd: &mut process::Command) -> T {
-        let stdout: String = self.stdout(cmd);
+    /// Parse captured stdout bytes as CSV. The single definition of how
+    /// `read_stdout` and friends interpret stdout, so every variant agrees.
+    fn csv_from_stdout<T: Csv>(stdout: &[u8]) -> T {
         let mut rdr = csv::ReaderBuilder::new()
             .has_headers(false)
             .flexible(true)
@@ -124,35 +124,149 @@ impl Workdir {
         Csv::from_vecs(records)
     }
 
+    /// Parse captured stdout bytes as `T`. Note the trailing CR/LF trim —
+    /// assertions comparing against literals depend on it, so every variant
+    /// must go through here rather than parsing the bytes directly.
+    fn parse_stdout<T: FromStr>(stdout: &[u8]) -> T {
+        let stdout = String::from_utf8_lossy(stdout);
+        stdout
+            .trim_matches(&['\r', '\n'][..])
+            .parse()
+            .ok()
+            .unwrap_or_else(|| panic!("Could not convert from string: '{stdout}'"))
+    }
+
+    /// Run `cmd` exactly once, optionally asserting the exit status.
+    /// `expect_success` of `None` makes no assertion at all.
+    fn run_once(
+        &self,
+        cmd: &mut process::Command,
+        expect_success: Option<bool>,
+    ) -> process::Output {
+        {
+            // ensures stderr has been flushed before we run our cmd
+            let mut _stderr = io::stderr();
+            _stderr.flush().unwrap();
+        }
+        let o = cmd.output().unwrap();
+        if let Some(want) = expect_success {
+            assert!(
+                o.status.success() == want,
+                "\n\n===== {:?} =====\ncommand {} but expected {}!\n\ncwd: {}\n\nstatus: \
+                 {}\n\nstdout: {}\n\nstderr: {}\n\n=====\n",
+                cmd,
+                if want { "failed" } else { "succeeded" },
+                if want { "success" } else { "an error" },
+                self.dir.display(),
+                o.status,
+                String::from_utf8_lossy(&o.stdout),
+                String::from_utf8_lossy(&o.stderr)
+            );
+        }
+        o
+    }
+
+    /// Run `cmd` once and return its full `Output` with success asserted, for
+    /// tests that need both streams in a shape the tuple helpers don't cover.
+    pub fn output_on_success(&self, cmd: &mut process::Command) -> process::Output {
+        self.run_once(cmd, Some(true))
+    }
+
+    /// Run `cmd` once and return its full `Output` with a non-zero exit
+    /// asserted. The failure-path twin of `output_on_success`.
+    pub fn output_on_error(&self, cmd: &mut process::Command) -> process::Output {
+        self.run_once(cmd, Some(false))
+    }
+
+    /// Run `cmd` ONCE and return `(stdout parsed as CSV, stderr)`. Use this
+    /// when a test asserts on both streams: `read_stdout` followed by
+    /// `output_stderr` runs the command twice, so the rows and the stderr text
+    /// come from different executions. Makes no assertion about exit status —
+    /// see `read_stdout_and_stderr_on_success` when success matters.
+    pub fn read_stdout_and_stderr<T: Csv>(&self, cmd: &mut process::Command) -> (T, String) {
+        let o = self.run_once(cmd, None);
+        (
+            Self::csv_from_stdout(&o.stdout),
+            String::from_utf8_lossy(&o.stderr).to_string(),
+        )
+    }
+
+    /// Run `cmd` ONCE, assert it exited successfully, and return
+    /// `(stdout parsed as CSV, stderr)`.
+    pub fn read_stdout_and_stderr_on_success<T: Csv>(
+        &self,
+        cmd: &mut process::Command,
+    ) -> (T, String) {
+        let o = self.run_once(cmd, Some(true));
+        (
+            Self::csv_from_stdout(&o.stdout),
+            String::from_utf8_lossy(&o.stderr).to_string(),
+        )
+    }
+
+    /// Run `cmd` ONCE, assert it exited with a non-zero status, and return
+    /// `(stdout parsed as CSV, stderr)`.
+    pub fn read_stdout_and_stderr_on_error<T: Csv>(
+        &self,
+        cmd: &mut process::Command,
+    ) -> (T, String) {
+        let o = self.run_once(cmd, Some(false));
+        (
+            Self::csv_from_stdout(&o.stdout),
+            String::from_utf8_lossy(&o.stderr).to_string(),
+        )
+    }
+
+    /// Run `cmd` ONCE and return `(stdout parsed as T, stderr)`. The
+    /// non-CSV counterpart of `read_stdout_and_stderr`; stdout is trimmed of
+    /// trailing CR/LF exactly as `stdout` does.
+    pub fn stdout_and_stderr<T: FromStr>(&self, cmd: &mut process::Command) -> (T, String) {
+        let o = self.run_once(cmd, None);
+        (
+            Self::parse_stdout(&o.stdout),
+            String::from_utf8_lossy(&o.stderr).to_string(),
+        )
+    }
+
+    /// Run `cmd` ONCE, assert it exited successfully, and return
+    /// `(stdout parsed as T, stderr)`.
+    pub fn stdout_and_stderr_on_success<T: FromStr>(
+        &self,
+        cmd: &mut process::Command,
+    ) -> (T, String) {
+        let o = self.run_once(cmd, Some(true));
+        (
+            Self::parse_stdout(&o.stdout),
+            String::from_utf8_lossy(&o.stderr).to_string(),
+        )
+    }
+
+    /// Run `cmd` ONCE, assert it exited with a non-zero status, and return
+    /// `(stdout parsed as T, stderr)`.
+    pub fn stdout_and_stderr_on_error<T: FromStr>(
+        &self,
+        cmd: &mut process::Command,
+    ) -> (T, String) {
+        let o = self.run_once(cmd, Some(false));
+        (
+            Self::parse_stdout(&o.stdout),
+            String::from_utf8_lossy(&o.stderr).to_string(),
+        )
+    }
+
+    /// read stdout of a command
+    pub fn read_stdout<T: Csv>(&self, cmd: &mut process::Command) -> T {
+        let stdout: String = self.stdout(cmd);
+        Self::csv_from_stdout(stdout.as_bytes())
+    }
+
     /// Run `cmd`, assert it exited successfully, and return its stdout parsed
     /// as CSV. Use this instead of `assert_success` followed by `read_stdout`,
     /// which executes `cmd` twice — the second run could fail yet still emit
     /// parseable CSV, silently masking the failure.
     pub fn read_stdout_on_success<T: Csv>(&self, cmd: &mut process::Command) -> T {
-        let o = cmd.output().unwrap();
-        assert!(
-            o.status.success(),
-            "\n\n===== {:?} =====\ncommand failed but expected success!\n\ncwd: {}\n\nstatus: \
-             {}\n\nstdout: {}\n\nstderr: {}\n\n=====\n",
-            cmd,
-            self.dir.display(),
-            o.status,
-            String::from_utf8_lossy(&o.stdout),
-            String::from_utf8_lossy(&o.stderr)
-        );
-        let mut rdr = csv::ReaderBuilder::new()
-            .has_headers(false)
-            .flexible(true)
-            .from_reader(io::Cursor::new(o.stdout));
-
-        let records: Vec<Vec<String>> = rdr
-            .records()
-            .collect::<Result<Vec<csv::StringRecord>, _>>()
-            .unwrap()
-            .into_iter()
-            .map(|r| r.iter().map(std::string::ToString::to_string).collect())
-            .collect();
-        Csv::from_vecs(records)
+        let o = self.run_once(cmd, Some(true));
+        Self::csv_from_stdout(&o.stdout)
     }
 
     pub fn command(&self, command_str: &str) -> process::Command {
@@ -175,12 +289,7 @@ impl Workdir {
 
     pub fn stdout<T: FromStr>(&self, cmd: &mut process::Command) -> T {
         let o = self.output(cmd);
-        let stdout = String::from_utf8_lossy(&o.stdout);
-        stdout
-            .trim_matches(&['\r', '\n'][..])
-            .parse()
-            .ok()
-            .unwrap_or_else(|| panic!("Could not convert from string: '{stdout}'"))
+        Self::parse_stdout(&o.stdout)
     }
 
     pub fn output_stderr(&self, cmd: &mut process::Command) -> String {


### PR DESCRIPTION
Completes #4415, after #4422 (viz) and #4423 (the mechanical tiers). **Zero sites remain in `tests/` where the exit status, stdout, and stderr an assertion reads come from different runs.**

## What was left

83 sites the previous PR deferred: tests that inspect **both** streams, so each ran the command once for stdout and again for stderr — often a third time for `assert_success`:

```rust
let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);   // run #1
let end = wrk.output_stderr(&mut cmd);                   // run #2
wrk.assert_success(&mut cmd);                            // run #3
```

## New helper family

```
{read_stdout,stdout}_and_stderr{,_on_success,_on_error}
```

Six one-run helpers returning both streams. `read_stdout` / `stdout` / `read_stdout_on_success` are refactored onto the same two private decoders, so every variant agrees on how stdout is interpreted — in particular the trailing CR/LF trim `stdout` applies, which several assertions compare against. `stderr_on_error` from #4423 covers the rest.

## Three commits

1. **13 sites hidden by variable shadowing.** #4423's analyzer keyed on the command variable *name*, so a test that rebinds `let mut cmd = wrk.command(..)` for a second command looked like one variable run many times and was skipped. Tracking each binding as its own generation exposes them; all were plain `assert_err`/`assert_success` pairs.
2. **56 sites via the tuple helpers**, 11 files, eliminating 60+ redundant executions.
3. **The last 20**, including 14 in macro-generated tests.

## Correctness properties held throughout

- **The single run is anchored at the EARLIEST original execution point**, never the latest. This is the failure mode roborev caught in #4423 (a deleted `assert_success` was what executed the command, so side-effect assertions between it and the stderr read started passing vacuously). Anchoring early makes that structurally impossible.
- **No test gained a status assertion it didn't have.** The 8 `read_stdout`-only and 2 `stdout`-only sites use the non-asserting variants.
- **No `.arg`/`.args`/`.env`/`.stdin` mutation sits between the runs being merged**, so no two intentionally different commands were collapsed into one.

## Sites that changed meaning (all in the strengthening direction)

`output_stderr` substitutes the literal `"No error"` for empty stderr on a successful run; the new helpers return stderr verbatim. Three tests were built around that sentinel:

| test | was | now |
|---|---|---|
| `search_match_quick_json` | `assert_eq!(got_err, "No error")` | `assert!(got_err.is_empty())` |
| `validate_multiple_files_quiet_mode` | `got.is_empty() \|\| got == "No error"` | `assert!(got.is_empty())` |
| `validate_single_file_backward_compatibility` | `if got_stderr.contains("No error")` | `if got_stderr.is_empty()` |

Each now asserts what its own comment always said it meant.

## Two conversions done by hand for a reason

- **`luau_register_lookup_table_on_url`** and its `_dathere_` twin have a 500 ms `sleep` commented *"ensure the file is closed properly"* between runs 1 and 2 — a Windows file-handle-release guard. The sleep is **kept**, moved ahead of the single run, since what it protects is the registered lookup file's handle before the command opens it.
- **`test_search` / `test_searchset`** bound both streams to `got` by shadowing; the stderr binding is now `got_count`.

## Verification

| config | unit | integration | failed |
|---|---|---|---|
| `all_features` | 973 | 3687 (65 ignored) | 0 |
| `lite` | 113 | 2204 (11 ignored) | 0 |
| `datapusher_plus` | 503 | 2462 (39 ignored) | 0 |
| `qsvmcp` | 958 | 3390 (42 ignored) | 0 |

Plus `test_py` under `-F all_features,python` (19 passed). `cargo clippy --tests -F all_features` clean; `cargo +nightly fmt` applied.

The 77 remaining `output_stderr` calls are all single-execution uses, where the helper's `"No error"` sentinel is still meaningful. `output_stderr` itself is unchanged.