### PR TITLE
test: no test asserts a command's status on a different run than its output (0 double-run sites)

### DIFF
--- a/scripts/double-run-check.py
+++ b/scripts/double-run-check.py
@@ -102,6 +102,12 @@ def blank_literals(src):
     corrupts block identity for the rest of the function and silently hides
     real double-run sites (tests/test_search.rs::search_indexed_parallel_json
     and five in tests/test_excel.rs are the cases that proved it).
+
+    Char and byte-char literals matter for the same reason and for a worse one:
+    `b'{'` (tests/test_viz.rs) unbalances the brace stack, and `split_once('"')`
+    (also test_viz) would otherwise open a bogus string literal that blanks
+    everything up to the next quote. A `'` that is not a char literal is a
+    lifetime and is left alone.
     """
     out = []
     i, n = 0, len(src)
@@ -131,6 +137,24 @@ def blank_literals(src):
                     j += 1
                     break
                 j += 1
+            out.append(re.sub(r"[^\n]", " ", src[i:j]))
+            i = j
+            continue
+        # char / byte-char literal: 'x', '\n', b'{'. A `'` that is NOT one of
+        # these is a lifetime (`&'a str`, `'static`) and must be left alone.
+        if c == "'":
+            j = i + 1
+            if j < n and src[j] == "\\":
+                j += 2
+                while j < n and src[j] != "'":
+                    j += 1
+                j += 1
+            elif j + 1 < n and src[j + 1] == "'":
+                j += 2
+            else:
+                out.append(c)  # lifetime
+                i += 1
+                continue
             out.append(re.sub(r"[^\n]", " ", src[i:j]))
             i = j
             continue

--- a/scripts/double-run-check.py
+++ b/scripts/double-run-check.py
@@ -94,9 +94,69 @@ STATUS = {"assert_success", "assert_err"}
 OPT_OUT_RE = re.compile(r"//\s*double-run-check:\s*intentional")
 
 
+def blank_literals(src):
+    """Replace the CONTENTS of string/char literals and comments with spaces.
+
+    Line structure is preserved, so line numbers still line up. Without this the
+    braces inside a `r#"[{"a": 1}]"#` fixture are counted as blocks, which
+    corrupts block identity for the rest of the function and silently hides
+    real double-run sites (tests/test_search.rs::search_indexed_parallel_json
+    and five in tests/test_excel.rs are the cases that proved it).
+    """
+    out = []
+    i, n = 0, len(src)
+    while i < n:
+        c = src[i]
+        # raw string: r, r#, r##, ...
+        if c == "r" and i + 1 < n and src[i + 1] in '"#':
+            j = i + 1
+            hashes = 0
+            while j < n and src[j] == "#":
+                hashes += 1
+                j += 1
+            if j < n and src[j] == '"':
+                close = '"' + "#" * hashes
+                end = src.find(close, j + 1)
+                end = n if end == -1 else end + len(close)
+                out.append(" " * (end - i) if "\n" not in src[i:end] else re.sub(r"[^\n]", " ", src[i:end]))
+                i = end
+                continue
+        if c == '"':
+            j = i + 1
+            while j < n:
+                if src[j] == "\\":
+                    j += 2
+                    continue
+                if src[j] == '"':
+                    j += 1
+                    break
+                j += 1
+            out.append(re.sub(r"[^\n]", " ", src[i:j]))
+            i = j
+            continue
+        if c == "/" and i + 1 < n and src[i + 1] == "/":
+            j = src.find("\n", i)
+            j = n if j == -1 else j
+            out.append(" " * (j - i))
+            i = j
+            continue
+        if c == "/" and i + 1 < n and src[i + 1] == "*":
+            j = src.find("*/", i + 2)
+            j = n if j == -1 else j + 2
+            out.append(re.sub(r"[^\n]", " ", src[i:j]))
+            i = j
+            continue
+        out.append(c)
+        i += 1
+    return "".join(out)
+
+
 def scan(path):
     """Yield one dict per command variable that is run more than once in a test fn."""
-    lines = open(path, encoding="utf-8").read().split("\n")
+    raw = open(path, encoding="utf-8").read()
+    lines = raw.split("\n")
+    # braces are counted on a literal-free copy; everything else reads the real source
+    code_lines = blank_literals(raw).split("\n")
     fns = [(i, m.group(1)) for i, l in enumerate(lines) if (m := FN_RE.match(l))]
     fns.append((len(lines), None))
 
@@ -108,8 +168,8 @@ def scan(path):
         blocks = []
         stack = []
         next_id = 0
-        for line in body:
-            trimmed = re.sub(r"//.*$", "", line).strip()
+        for line in code_lines[start:end]:
+            trimmed = line.strip()
             # a leading `}` closes the block this line's statement is NOT in,
             # so pop before recording (`} else {` belongs to neither arm)
             closes_first = trimmed.startswith("}")

--- a/scripts/double-run-check.py
+++ b/scripts/double-run-check.py
@@ -34,9 +34,15 @@ Two classes of finding must NOT be blindly converted, and are reported separatel
     assertions that used to observe the command's side effects start running
     before it and pass vacuously.
 
-Calls in different `if`/`else` branches are NOT double runs; brace depth is
-tracked so those are excluded (`tests/test_slice.rs::test_slice` is the case
-that proves it).
+Calls in different `if`/`else` branches are NOT double runs; each line's
+enclosing block is identified so those are excluded (`tests/test_slice.rs::test_slice`
+is the case that proves it — `assert_success` in the `--json` arm, `read_stdout`
+in the `else`).
+
+A test that runs one command twice ON PURPOSE (caching, idempotence, indexed vs
+unindexed) opts out with a comment anywhere in the function:
+
+    // double-run-check: intentional -- second request must hit the disk cache
 """
 
 import argparse
@@ -71,7 +77,9 @@ RUNNERS = [
 RUN_RE = re.compile(r"wrk\.(" + "|".join(RUNNERS) + r")(?:::<[^>]*>)?\(&mut (\w+)\)")
 # a fresh `let mut cmd = wrk.command(..)` starts a new logical command, even when
 # it reuses the name of an earlier one
-BIND_RE = re.compile(r"^\s*let mut (\w+)\s*(?::[^=]*)?=\s*(wrk\.command|process::Command|Command::new)")
+BIND_RE = re.compile(
+    r"^\s*let mut (\w+)\s*(?::[^=]*)?=\s*(?:[\w:]*::)?(?:wrk\.command|Command::new)"
+)
 FN_RE = re.compile(r"fn (\w+)\(")
 MUT_RE = re.compile(r"\.\s*(args?|envs?|env_remove|env_clear|current_dir|stdin)\s*\(")
 # statements whose meaning depends on whether the command has run yet
@@ -82,6 +90,8 @@ HAZARD_RE = re.compile(
 )
 # helpers that only assert the exit status vs. those that read what the command produced
 STATUS = {"assert_success", "assert_err"}
+# a test that runs one command twice deliberately says so with this marker
+OPT_OUT_RE = re.compile(r"//\s*double-run-check:\s*intentional")
 
 
 def scan(path):
@@ -92,12 +102,31 @@ def scan(path):
 
     for (start, name), (end, _) in zip(fns, fns[1:]):
         body = lines[start:end]
-        depth = 0
-        depths = []
+        # Identify the enclosing block of every line by a stack of unique block ids,
+        # not by brace DEPTH: the two arms of an if/else sit at the same depth but are
+        # different blocks, and only one of them runs.
+        blocks = []
+        stack = []
+        next_id = 0
         for line in body:
-            depths.append(depth)
-            code = re.sub(r"//.*$", "", line)
-            depth += code.count("{") - code.count("}")
+            trimmed = re.sub(r"//.*$", "", line).strip()
+            # a leading `}` closes the block this line's statement is NOT in,
+            # so pop before recording (`} else {` belongs to neither arm)
+            closes_first = trimmed.startswith("}")
+            if closes_first and stack:
+                stack.pop()
+            blocks.append(tuple(stack))
+            for ch in trimmed[1:] if closes_first else trimmed:
+                if ch == "{":
+                    stack.append(next_id)
+                    next_id += 1
+                elif ch == "}" and stack:
+                    stack.pop()
+
+        # a test that runs one command twice ON PURPOSE (caching, idempotence,
+        # index-vs-no-index) opts out by saying so
+        if OPT_OUT_RE.search("\n".join(body)):
+            continue
 
         generation = collections.Counter()
         events = collections.defaultdict(list)
@@ -113,11 +142,9 @@ def scan(path):
             if len(evs) < 2:
                 continue
             first, last = evs[0][0], evs[-1][0]
-            # different if/else branches are not sequential runs
-            block = depths[first]
-            if any(depths[k] != block for k, _ in evs):
-                continue
-            if any(depths[k] < block for k in range(first + 1, last)):
+            # calls in different blocks (if/else arms, separate loop bodies) are
+            # alternatives, not sequential runs of the same command
+            if any(blocks[k] != blocks[first] for k, _ in evs):
                 continue
             between = body[first + 1 : last]
             names = [n for _, n in evs]

--- a/scripts/double-run-check.py
+++ b/scripts/double-run-check.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""
+double-run-check.py — Find integration tests that run one command more than once.
+
+`tests/workdir.rs` helpers each spawn the qsv binary. A test that calls two of
+them on the same `Command` runs that command twice, so the properties it
+asserts describe DIFFERENT executions:
+
+    wrk.assert_success(&mut cmd);                           // run #1: exit status
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);  // run #2: the data
+
+Either direction can be masked — a run that succeeds while emitting the wrong
+data, or a second run that fails yet still emits parseable output. The `*_on_success`
+/ `*_on_error` helpers exist to capture one `Output` and assert against that.
+This script finds the sites that still don't.
+
+Usage:
+    scripts/double-run-check.py [--json] [--hazards] [PATH ...]
+
+    (no flags)  summary counts by shape and by file
+    --json      one JSON object per site on stdout, for scripted conversion
+    --hazards   only sites where converting could change WHEN the command runs
+
+Exit status is 0 regardless of findings; this is a reporting tool, not a gate.
+
+Two classes of finding must NOT be blindly converted, and are reported separately:
+
+  * `mutated`  — a `.arg()` / `.env()` call sits between the two runs, so they
+    are deliberately two different commands.
+  * `hazard`   — a statement between the two runs observes or alters state
+    (`.exists()`, `read_to_string`, `wrk.create*`, `std::fs::`). Collapsing to a
+    single run moves WHEN the command executes relative to that statement. The
+    single run must be anchored at the EARLIEST original execution point, or
+    assertions that used to observe the command's side effects start running
+    before it and pass vacuously.
+
+Calls in different `if`/`else` branches are NOT double runs; brace depth is
+tracked so those are excluded (`tests/test_slice.rs::test_slice` is the case
+that proves it).
+"""
+
+import argparse
+import collections
+import glob
+import json
+import os
+import re
+import sys
+
+# Workdir helpers that spawn the binary. `output_stderr` is included: it runs the
+# command like the rest, it just also carries a legacy "No error" sentinel.
+RUNNERS = [
+    "output",
+    "run",
+    "stdout",
+    "read_stdout",
+    "read_stdout_on_success",
+    "read_stdout_and_stderr",
+    "read_stdout_and_stderr_on_success",
+    "read_stdout_and_stderr_on_error",
+    "stdout_and_stderr",
+    "stdout_and_stderr_on_success",
+    "stdout_and_stderr_on_error",
+    "stdout_on_success",
+    "stderr_on_success",
+    "stderr_on_error",
+    "output_stderr",
+    "assert_success",
+    "assert_err",
+]
+RUN_RE = re.compile(r"wrk\.(" + "|".join(RUNNERS) + r")(?:::<[^>]*>)?\(&mut (\w+)\)")
+# a fresh `let mut cmd = wrk.command(..)` starts a new logical command, even when
+# it reuses the name of an earlier one
+BIND_RE = re.compile(r"^\s*let mut (\w+)\s*(?::[^=]*)?=\s*(wrk\.command|process::Command|Command::new)")
+FN_RE = re.compile(r"fn (\w+)\(")
+MUT_RE = re.compile(r"\.\s*(args?|envs?|env_remove|env_clear|current_dir|stdin)\s*\(")
+# statements whose meaning depends on whether the command has run yet
+HAZARD_RE = re.compile(
+    r"\.exists\(\)|read_to_string|read_csv|wrk\.path\(|wrk\.from_str|load_test"
+    r"|std::fs::|fs::(read|write|metadata|remove)|File::create"
+    r"|wrk\.create(_from_string|_indexed|_with_delim)?\("
+)
+# helpers that only assert the exit status vs. those that read what the command produced
+STATUS = {"assert_success", "assert_err"}
+
+
+def scan(path):
+    """Yield one dict per command variable that is run more than once in a test fn."""
+    lines = open(path, encoding="utf-8").read().split("\n")
+    fns = [(i, m.group(1)) for i, l in enumerate(lines) if (m := FN_RE.match(l))]
+    fns.append((len(lines), None))
+
+    for (start, name), (end, _) in zip(fns, fns[1:]):
+        body = lines[start:end]
+        depth = 0
+        depths = []
+        for line in body:
+            depths.append(depth)
+            code = re.sub(r"//.*$", "", line)
+            depth += code.count("{") - code.count("}")
+
+        generation = collections.Counter()
+        events = collections.defaultdict(list)
+        for k, line in enumerate(body):
+            if line.strip().startswith("//"):
+                continue
+            if m := BIND_RE.match(line):
+                generation[m.group(1)] += 1
+            for m in RUN_RE.finditer(line):
+                events[(m.group(2), generation[m.group(2)])].append((k, m.group(1)))
+
+        for (var, _gen), evs in events.items():
+            if len(evs) < 2:
+                continue
+            first, last = evs[0][0], evs[-1][0]
+            # different if/else branches are not sequential runs
+            block = depths[first]
+            if any(depths[k] != block for k, _ in evs):
+                continue
+            if any(depths[k] < block for k in range(first + 1, last)):
+                continue
+            between = body[first + 1 : last]
+            names = [n for _, n in evs]
+            yield {
+                "file": path,
+                "fn": name,
+                "var": var,
+                "line": start + 1 + first,
+                "end_line": start + 1 + last,
+                "runners": names,
+                "runs": len(evs),
+                "reads_data": bool({n for n in names} - STATUS),
+                "mutated": bool(MUT_RE.search("\n".join(between))),
+                "hazard": [b.strip()[:100] for b in between if HAZARD_RE.search(b)],
+            }
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[1])
+    ap.add_argument("paths", nargs="*", default=None)
+    ap.add_argument("--json", action="store_true", help="emit one JSON object per site")
+    ap.add_argument("--hazards", action="store_true", help="only ordering-hazard sites")
+    args = ap.parse_args()
+
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    paths = args.paths or sorted(glob.glob(os.path.join(root, "tests", "test_*.rs")))
+
+    sites = [s for p in paths for s in scan(p)]
+    if args.hazards:
+        sites = [s for s in sites if s["hazard"] and not s["mutated"]]
+
+    if args.json:
+        for s in sites:
+            print(json.dumps(s))
+        return
+
+    convertible = [s for s in sites if not s["mutated"] and not s["hazard"]]
+    print(f"double-run sites:            {len(sites)}")
+    print(f"  deliberately two commands: {sum(1 for s in sites if s['mutated'])}")
+    print(f"  ordering hazard:           {sum(1 for s in sites if s['hazard'] and not s['mutated'])}")
+    print(f"  mechanically convertible:  {len(convertible)}")
+    if not sites:
+        return
+    print("\nby shape:")
+    for shape, n in collections.Counter(
+        tuple(sorted(set(s["runners"]))) for s in sites
+    ).most_common():
+        print(f"  {n:4d}  {' + '.join(shape)}")
+    print("\nby file:")
+    for f, n in collections.Counter(s["file"] for s in sites).most_common():
+        print(f"  {n:4d}  {os.path.relpath(f, root)}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_count.rs
+++ b/tests/test_count.rs
@@ -33,8 +33,7 @@ fn count_from_csvzip() {
     let mut cmd = wrk.command("count");
     cmd.arg(test_file);
 
-    wrk.assert_success(&mut cmd);
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     assert_eq!(got, "100".to_string());
 }
 
@@ -49,8 +48,7 @@ fn count_from_zip_multientry() {
     let mut cmd = wrk.command("count");
     cmd.arg(test_file);
 
-    wrk.assert_success(&mut cmd);
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     assert_eq!(got, "6".to_string());
 }
 

--- a/tests/test_describegpt.rs
+++ b/tests/test_describegpt.rs
@@ -227,14 +227,13 @@ fn describegpt_valid_json() {
     cmd.arg("in.csv").arg("--all").args(["--format", "json"]);
 
     // Check that the output is valid JSON
-    let got = wrk.stdout::<String>(&mut cmd);
+    let got = wrk.stdout_on_success::<String>(&mut cmd);
     match serde_json::from_str::<serde_json::Value>(&got) {
         Ok(_) => (),
         Err(e) => panic!("Error parsing JSON: {e}"),
     }
 
     // Check that the command ran successfully
-    wrk.assert_success(&mut cmd);
 }
 // Test individual flags: --description
 #[test]
@@ -1176,14 +1175,13 @@ fn describegpt_larger_dataset() {
         .arg("--no-cache");
 
     // Check that the output is valid JSON
-    let got = wrk.stdout::<String>(&mut cmd);
+    let got = wrk.stdout_on_success::<String>(&mut cmd);
     match serde_json::from_str::<serde_json::Value>(&got) {
         Ok(_) => (),
         Err(e) => panic!("Error parsing JSON: {e}"),
     }
 
     // Check that the command ran successfully
-    wrk.assert_success(&mut cmd);
 }
 
 // Test with dataset containing special characters
@@ -1391,10 +1389,9 @@ fn describegpt_prompt_no_dictionary_output() {
         .arg("--no-cache");
 
     // Check that the command ran successfully
-    wrk.assert_success(&mut cmd);
 
     // Get the output and verify that it does not contain dictionary output
-    let output = wrk.stdout::<String>(&mut cmd);
+    let output = wrk.stdout_on_success::<String>(&mut cmd);
 
     // The output should not contain typical dictionary markers
     // Dictionary output typically contains structured JSON with field definitions

--- a/tests/test_diff.rs
+++ b/tests/test_diff.rs
@@ -92,9 +92,7 @@ fn diff_diff_left_and_original_right_sort_diff_result_by_lines_by_default() {
     let mut cmd = wrk.command("diff");
     cmd.arg(test_file).arg(test_file2);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
 
     let diff_result_file_name = "diff_result_diff_left_original_right.csv";
 
@@ -148,9 +146,7 @@ fn diff_sort_diff_result_by_lines_by_default_modified_rows_interleaved() {
     let mut cmd = wrk.command("diff");
     cmd.args(["left.csv", "right.csv"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected: Vec<Vec<String>> = vec![
         svec!["diffresult", "h1", "h2", "h3"],
         svec!["-", "4", "foo", "bar"],
@@ -269,9 +265,7 @@ fn diff_different_delimiters_sort_diff_result_by_first_column() {
         ";",
     ]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
 
     let diff_result_file_name = "diff_result_original_left_diff_right_sort_columns.csv";
 
@@ -370,9 +364,7 @@ fn diff_key_sort_by_column_name() {
         "h1,h3,h2",
     ]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected: Vec<Vec<String>> = vec![
         svec!["diffresult", "h1", "h2", "h3"],
         svec!["-", "2", "fooz", "bart"],
@@ -451,9 +443,7 @@ fn diff_only_left_has_headers_headers_in_result() {
     let mut cmd = wrk.command("diff");
     cmd.args(["left.csv", "right.csv", "--no-headers-right"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["diffresult", "h1", "h2", "h3"],
         svec!["-", "1", "foo", "bar",],
@@ -476,9 +466,7 @@ fn diff_only_right_has_headers_headers_in_result() {
     let mut cmd = wrk.command("diff");
     cmd.args(["left.csv", "right.csv", "--no-headers-left"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["diffresult", "h1", "h2", "h3"],
         svec!["-", "1", "foo", "bar",],
@@ -562,9 +550,7 @@ fn diff_no_diff_with_generic_headers_in_result() {
         "--no-headers-right",
     ]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["diffresult", "_col_1", "_col_2", "_col_3",]];
 
     assert_eq!(got, expected);
@@ -677,9 +663,7 @@ fn diff_drop_equal_fields_flag_on_modified_rows_one_row_modified() {
     let mut cmd = wrk.command("diff");
     cmd.args(["left.csv", "right.csv", "--drop-equal-fields"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = "\
 diffresult,h1,h2,h3
 -,1,deleted,row
@@ -786,9 +770,7 @@ fn diff_drop_equal_fields_flag_on_modified_rows_multiple_key_fields_far_apart() 
     // here, first and last columns are our key fields
     cmd.args(["left.csv", "right.csv", "--drop-equal-fields", "-k", "0,3"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = "\
 diffresult,h1,h2,h3,h4
 -,1,deleted,row,id1
@@ -821,9 +803,7 @@ fn diff_drop_equal_columns_drops_unchanged_columns() {
     let mut cmd = wrk.command("diff");
     cmd.args(["left.csv", "right.csv", "--drop-equal-columns"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     // h2 is unchanged everywhere, so it is dropped. h1 (key) and h3 (modified) remain.
     let expected = "\
 diffresult,h1,h3
@@ -858,9 +838,7 @@ fn diff_drop_equal_columns_combined_with_drop_equal_fields() {
         "--drop-equal-fields",
     ]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     // h4 is unchanged everywhere -> dropped. h2 differs in row 2, h3 differs in row 1,
     // so both columns are kept; within them, equal fields are blanked per modified row.
     let expected = "\
@@ -893,9 +871,7 @@ fn diff_drop_equal_columns_keeps_columns_with_added_or_deleted_data() {
     let mut cmd = wrk.command("diff");
     cmd.args(["left.csv", "right.csv", "--drop-equal-columns"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     // h2 is equal in the modified row but has data in the added/deleted rows, so it is
     // kept. h4 is empty everywhere, so it is dropped.
     let expected = "\
@@ -926,9 +902,7 @@ fn diff_drop_equal_columns_with_no_headers_projects_generic_headers() {
         "--drop-equal-columns",
     ]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     // generic headers are generated, then projected to the kept columns.
     let expected = "\
 diffresult,_col_1,_col_3
@@ -1023,9 +997,7 @@ fn diff_with_mixed_delimiters() {
         "right.csv",
     ]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = "\
 diffresult|h1|h2|h3
 -|1|foo|bar

--- a/tests/test_excel.rs
+++ b/tests/test_excel.rs
@@ -530,7 +530,7 @@ fn excel_metadata() {
     let mut cmd = wrk.command("excel");
     cmd.arg("--metadata").arg("csv").arg(xls_file);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec![
             "index",
@@ -660,7 +660,6 @@ fn excel_metadata() {
         ],
     ];
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -672,7 +671,7 @@ fn excel_short_metadata() {
     let mut cmd = wrk.command("excel");
     cmd.arg("--metadata").arg("short").arg(xls_file);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["index", "sheet_name", "type", "visible"],
         svec!["0", "First", "WorkSheet", "Visible"],
@@ -685,7 +684,6 @@ fn excel_short_metadata() {
         svec!["7", "Last", "WorkSheet", "Visible"],
     ];
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -943,7 +941,7 @@ fn ods_metadata() {
     let mut cmd = wrk.command("excel");
     cmd.arg("--metadata").arg("c").arg(xls_file);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec![
             "index",
@@ -976,7 +974,6 @@ fn ods_metadata() {
     ];
 
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -988,14 +985,13 @@ fn ods_short_metadata() {
     let mut cmd = wrk.command("excel");
     cmd.arg("--metadata").arg("s").arg(xls_file);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["index", "sheet_name", "type", "visible"],
         svec!["0", "Sheet1", "WorkSheet", "Visible"],
     ];
 
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1034,7 +1030,7 @@ fn excel_metadata_sheet_types() {
     let mut cmd = wrk.command("excel");
     cmd.arg("--metadata").arg("csv").arg(xls_file);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec![
             "index",
@@ -1108,7 +1104,6 @@ fn excel_metadata_sheet_types() {
         ],
     ];
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1120,7 +1115,7 @@ fn excel_metadata_sheet_types_xlsx() {
     let mut cmd = wrk.command("excel");
     cmd.arg("--metadata").arg("csv").arg(xlsx_file);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec![
             "index",
@@ -1195,7 +1190,6 @@ fn excel_metadata_sheet_types_xlsx() {
         ],
     ];
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1241,7 +1235,7 @@ fn excel_metadata_sheet_types_xlsb() {
     let mut cmd = wrk.command("excel");
     cmd.arg("--metadata").arg("csv").arg(xlsb_file);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec![
             "index",
@@ -1316,7 +1310,6 @@ fn excel_metadata_sheet_types_xlsb() {
         ],
     ];
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1328,7 +1321,7 @@ fn excel_metadata_sheet_types_ods() {
     let mut cmd = wrk.command("excel");
     cmd.arg("--metadata").arg("csv").arg(ods_file);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec![
             "index",
@@ -1402,7 +1395,6 @@ fn excel_metadata_sheet_types_ods() {
         ],
     ];
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1453,7 +1445,7 @@ fn excel_integer_headers() {
     let mut cmd = wrk.command("excel");
     cmd.arg(xls_file);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["location ", "2020", "2021", "2022"],
         svec!["Here", "1", "2", "3"],
@@ -1461,7 +1453,6 @@ fn excel_integer_headers() {
     ];
 
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1473,11 +1464,10 @@ fn excel_range_cols() {
     let mut cmd = wrk.command("excel");
     cmd.arg("--range").arg("a:b").arg(xls_file);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["A", "B"], svec!["2", "3"], svec!["3", "4"]];
 
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1489,11 +1479,10 @@ fn excel_range_rowcols() {
     let mut cmd = wrk.command("excel");
     cmd.arg("--range").arg("d2:e2").arg(xls_file);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["5", "6"]];
 
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1505,11 +1494,10 @@ fn excel_range_double_letter_cols() {
     let mut cmd = wrk.command("excel");
     cmd.arg("--range").arg("z1:ab2").arg(xls_file);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["Z", "AA", "AB"], svec!["27", "28", "29"]];
 
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1521,11 +1509,10 @@ fn excel_neg_float() {
     let mut cmd = wrk.command("excel");
     cmd.arg("--range").arg("b2:b").arg(xls_file);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["-100.01"], svec!["-200.02"]];
 
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1537,11 +1524,10 @@ fn excel_small_neg_float() {
     let mut cmd = wrk.command("excel");
     cmd.arg("--range").arg("c2:c").arg(xls_file);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["-0.01"], svec!["-0.02"]];
 
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1553,11 +1539,10 @@ fn excel_neg_int() {
     let mut cmd = wrk.command("excel");
     cmd.arg("--range").arg("d2:d").arg(xls_file);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["-1"], svec!["-2"]];
 
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1569,11 +1554,10 @@ fn excel_zero() {
     let mut cmd = wrk.command("excel");
     cmd.arg("--range").arg("e2:e").arg(xls_file);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["0"], svec!["0"]];
 
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1585,11 +1569,10 @@ fn excel_small_pos_float() {
     let mut cmd = wrk.command("excel");
     cmd.arg("--range").arg("f2:f").arg(xls_file);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["0.01"], svec!["0.02"]];
 
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1601,11 +1584,10 @@ fn excel_pos_float() {
     let mut cmd = wrk.command("excel");
     cmd.arg("--range").arg("g2:g").arg(xls_file);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["100.01"], svec!["200.02"]];
 
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1617,11 +1599,10 @@ fn excel_pos_int() {
     let mut cmd = wrk.command("excel");
     cmd.arg("--range").arg("h2:h").arg(xls_file);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["1"], svec!["2"]];
 
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1633,11 +1614,10 @@ fn excel_large_floats() {
     let mut cmd = wrk.command("excel");
     cmd.arg(xls_file);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["A"], svec!["9.22337203685478e+19"]];
 
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1680,7 +1660,7 @@ fn excel_table_range() {
     let mut cmd = wrk.command("excel");
     cmd.arg("--table").arg("Table1").arg(xlsx_file);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["tabc1", "tabc2", "tabc3"],
         svec!["a2", "false", "2.2"],
@@ -1691,7 +1671,6 @@ fn excel_table_range() {
     ];
 
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1703,7 +1682,7 @@ fn excel_named_range() {
     let mut cmd = wrk.command("excel");
     cmd.arg("--range").arg("TestNamedRange").arg(xlsx_file);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["alpha", "1", "5"],
         svec!["beta", "2.2", "6"],
@@ -1713,7 +1692,6 @@ fn excel_named_range() {
     ];
 
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1725,7 +1703,7 @@ fn excel_absolute_range() {
     let mut cmd = wrk.command("excel");
     cmd.arg("--range").arg("Sheet2!A1:C3").arg(xlsx_file);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["col1", "col2", "col3"],
         svec!["1", "e", "1.1"],
@@ -1733,7 +1711,6 @@ fn excel_absolute_range() {
     ];
 
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1745,7 +1722,7 @@ fn excel_absolute_range2() {
     let mut cmd = wrk.command("excel");
     cmd.arg("--range").arg("Sheet2!$A$1:$C$3").arg(xlsx_file);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["col1", "col2", "col3"],
         svec!["1", "e", "1.1"],
@@ -1753,7 +1730,6 @@ fn excel_absolute_range2() {
     ];
 
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1765,11 +1741,10 @@ fn excel_cell_simple() {
     let mut cmd = wrk.command("excel");
     cmd.arg("--cell").arg("d2").arg(xls_file);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["5"]];
 
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1781,11 +1756,10 @@ fn excel_cell_sheet_qualified() {
     let mut cmd = wrk.command("excel");
     cmd.arg("--cell").arg("Sheet2!C2").arg(xlsx_file);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["1.1"]];
 
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1797,11 +1771,10 @@ fn excel_cell_absolute() {
     let mut cmd = wrk.command("excel");
     cmd.arg("--cell").arg("Sheet2!$C$2").arg(xlsx_file);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["1.1"]];
 
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1813,11 +1786,10 @@ fn excel_cell_double_letter_col() {
     let mut cmd = wrk.command("excel");
     cmd.arg("--cell").arg("aa2").arg(xls_file);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["28"]];
 
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1834,9 +1806,8 @@ fn excel_cell_precedence() {
         .arg(xls_file);
 
     // --cell should take precedence, so we should get d2's value, not e2's
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["5"]];
 
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }

--- a/tests/test_excel.rs
+++ b/tests/test_excel.rs
@@ -695,7 +695,7 @@ fn excel_metadata_pretty_json() {
     let mut cmd = wrk.command("excel");
     cmd.arg("--metadata").arg("J").arg(xls_file);
 
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
 
     let expected = r#"excel-xls.xls","format": "Excel: xls","sheet_count": 8,"has_1904_epoch": false,"sheet": [
     {
@@ -785,7 +785,6 @@ fn excel_metadata_pretty_json() {
   ],"name_count": 1,"tables": [],"table_count": 0
 }"#;
     assert!(got.ends_with(expected));
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -797,7 +796,7 @@ fn excel_metadata_xlsx_ranges_tables_pretty_json() {
     let mut cmd = wrk.command("excel");
     cmd.arg("--metadata").arg("J").arg(xls_file);
 
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
 
     let expected = r#"excel-xlsx.xlsx","format": "Excel: xlsx","sheet_count": 7,"has_1904_epoch": false,"sheet": [
     {
@@ -929,7 +928,6 @@ fn excel_metadata_xlsx_ranges_tables_pretty_json() {
   ],"table_count": 1
 }"#;
     assert!(got.ends_with(expected));
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1003,7 +1001,7 @@ fn ods_metadata_pretty_json() {
     let mut cmd = wrk.command("excel");
     cmd.arg("--metadata").arg("J").arg(xls_file);
 
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = r#"excel-ods.ods","format": "ODS","sheet_count": 1,"sheet": [
     {
       "index": 0,"name": "Sheet1","typ": "WorkSheet","visible": "Visible","headers": [
@@ -1018,7 +1016,6 @@ fn ods_metadata_pretty_json() {
 }"#;
 
     assert!(got.ends_with(expected));
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1201,10 +1198,9 @@ fn excel_metadata_sheet_types_xlsx_short_json() {
     let mut cmd = wrk.command("excel");
     cmd.arg("--metadata").arg("S").arg(xlsx_file);
 
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = r#"any_sheets.xlsx","format":"xlsx","sheet_count":4,"has_1904_epoch":false,"sheet":[{"index":0,"name":"Visible","typ":"WorkSheet","visible":"Visible"},{"index":1,"name":"Hidden","typ":"WorkSheet","visible":"Hidden"},{"index":2,"name":"VeryHidden","typ":"WorkSheet","visible":"VeryHidden"},{"index":3,"name":"Chart","typ":"ChartSheet","visible":"Visible"}]}"#;
     assert!(got.ends_with(expected));
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1220,10 +1216,9 @@ fn excel_metadata_1904_epoch_xlsx_short_json() {
     let mut cmd = wrk.command("excel");
     cmd.arg("--metadata").arg("S").arg(xlsx_file);
 
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = r#"excel-1904-epoch.xlsx","format":"xlsx","sheet_count":1,"has_1904_epoch":true,"sheet":[{"index":0,"name":"Dates1904","typ":"WorkSheet","visible":"Visible"}]}"#;
     assert!(got.ends_with(expected));
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]

--- a/tests/test_extdedup.rs
+++ b/tests/test_extdedup.rs
@@ -68,7 +68,7 @@ fn extdedupe_csvmode() {
     cmd.arg(test_file)
         .arg("boston311-100-extdeduped.csv")
         .args(["--select", "case_enquiry_id,open_dt,target_dt"]);
-    wrk.output(&mut cmd);
+    let output = wrk.output(&mut cmd);
 
     // load deduped output
     let deduped_output: String = wrk.from_str(&wrk.path("boston311-100-extdeduped.csv"));
@@ -78,9 +78,7 @@ fn extdedupe_csvmode() {
 
     assert_eq!(dos2unix(&deduped_output), dos2unix(&expected_csv));
 
-    // Check that the correct number of rows were deduplicated
-    let output = wrk.output(&mut cmd);
-
+    // Check that the correct number of rows were deduplicated:
     // 20 duplicates should be removed
     assert!(String::from_utf8_lossy(&output.stderr).contains("20\n"));
 }
@@ -101,7 +99,7 @@ fn extdedupe_csvmode_dupesoutput() {
             "--dupes-output",
             "boston311-100-extdededuped-dupeoutput.csv",
         ]);
-    wrk.output(&mut cmd);
+    let output = wrk.output(&mut cmd);
 
     // load deduped output
     let deduped_output: String = wrk.from_str(&wrk.path("boston311-100-extdeduped.csv"));
@@ -120,7 +118,6 @@ fn extdedupe_csvmode_dupesoutput() {
     assert_eq!(dos2unix(&dupes_output), dos2unix(&expected_output));
 
     // Check that the correct number of rows were deduplicated
-    let output = wrk.output(&mut cmd);
     // 20 duplicates should be removed
     assert!(String::from_utf8_lossy(&output.stderr).contains("20\n"));
 }
@@ -136,7 +133,7 @@ fn extdedupe_csvmode_neighborhood() {
     cmd.arg(test_file)
         .arg("boston311-100-extdeduped.csv")
         .args(["--select", "neighborhood"]);
-    wrk.output(&mut cmd);
+    let output = wrk.output(&mut cmd);
 
     // load deduped output
     let deduped_output: String = wrk.from_str(&wrk.path("boston311-100-extdeduped.csv"));
@@ -146,9 +143,7 @@ fn extdedupe_csvmode_neighborhood() {
 
     assert_eq!(dos2unix(&deduped_output), dos2unix(&expected_csv));
 
-    // Check that the correct number of rows were deduplicated
-    let output = wrk.output(&mut cmd);
-
+    // Check that the correct number of rows were deduplicated:
     // 81 duplicates should be removed
     assert!(String::from_utf8_lossy(&output.stderr).contains("81\n"));
 }

--- a/tests/test_extsort.rs
+++ b/tests/test_extsort.rs
@@ -91,8 +91,7 @@ fn extsort_issue_2391() {
     cmd.arg("issue2391-test_ids.csv")
         .args(["--select", "tc_id,pnm,pc_id"]);
 
-    wrk.assert_success(&mut cmd);
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["pnm", "tc_id", "pc_id"],
         svec!["405", "139280", "9730000630075"],

--- a/tests/test_fetch.rs
+++ b/tests/test_fetch.rs
@@ -638,13 +638,10 @@ fn fetch_custom_user_agent() {
         .arg("Mozilla/5.0 (platform; rv:geckoversion) Gecko/geckotrail Firefox/firefoxversion")
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got = wrk.stdout::<String>(&mut cmd);
+    let got = wrk.stdout_on_success::<String>(&mut cmd);
     assert!(got.contains(
         "Mozilla/5.0 (platform; rv:geckoversion) Gecko/geckotrail Firefox/firefoxversion"
     ));
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -767,13 +764,10 @@ fn fetchpost_custom_user_agent() {
         .arg("Mozilla/5.0 (platform; rv:geckoversion) Gecko/geckotrail Firefox/firefoxversion")
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got = wrk.stdout::<String>(&mut cmd);
+    let got = wrk.stdout_on_success::<String>(&mut cmd);
     assert!(got.contains(
         "Mozilla/5.0 (platform; rv:geckoversion) Gecko/geckotrail Firefox/firefoxversion"
     ));
-    wrk.assert_success(&mut cmd);
 }
 
 use std::{net::SocketAddr, sync::mpsc, thread};
@@ -1771,6 +1765,8 @@ fn fetchpost_disk_cache() {
         .arg(r#"."form""#)
         .arg("data.csv");
 
+    // double-run-check: intentional -- the point of the test is that the SECOND
+    // run hits the disk cache, so it must stay two executions.
     // First request should not be cached
     let got1 = wrk.stdout::<String>(&mut cmd);
 

--- a/tests/test_fetch.rs
+++ b/tests/test_fetch.rs
@@ -326,7 +326,7 @@ fn fetch_simple_diskcache() {
         .args(["--disk-cache-dir", dc_dir])
         .args(["--rate-limit", "2"]);
 
-    let got = wrk.stdout::<String>(&mut cmd);
+    let got = wrk.stdout_on_success::<String>(&mut cmd);
 
     let expected = r#"{"errors":[{"title":"HTTP ERROR","detail":"HTTP ERROR 404 - Not Found"}]}
 {"country":"United States","country abbreviation":"US","post code":"90210","places":[{"place name":"Beverly Hills","longitude":"-118.4065","latitude":"34.0901","state":"California","state abbreviation":"CA"}]}
@@ -335,8 +335,6 @@ fn fetch_simple_diskcache() {
 {"errors":[{"title":"Invalid URL","detail":"relative URL without a base"}]}"#;
 
     assert_eq!(got, expected);
-
-    wrk.assert_success(&mut cmd);
 
     // cached v3 uses redb (a single file), not sled (a directory): the on-disk
     // cache is `{name}_v{DISK_FILE_VERSION}.redb`, not `{name}_v1/conf`.
@@ -587,9 +585,7 @@ fn fetch_custom_header() {
         .arg(r#"[ ."headers"."X-Api-Key", ."headers"."X-Api-Secret" ]"#)
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got = wrk.stdout::<String>(&mut cmd);
+    let got = wrk.stdout_on_success::<String>(&mut cmd);
     let expected = "[\"DEMO_KEY\",\"ABC123XYZ\"]";
     assert_eq!(got, expected);
 }
@@ -662,11 +658,10 @@ fn fetch_user_agent() {
     let mut cmd = wrk.command("fetch");
     cmd.arg("URL").arg("data.csv");
 
-    let got = wrk.stdout::<String>(&mut cmd);
+    let got = wrk.stdout_on_success::<String>(&mut cmd);
     // the default user agent should contain the name of the qsv command used,
     // in this case "fetch"
     assert!(got.contains("; fetch; "));
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -1073,9 +1068,7 @@ fn fetchpost_simple_test() {
         .arg("response")
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
 
     let mut got_parsed: Vec<Vec<String>> = Vec::new();
     let mut record_parsed: Vec<String> = Vec::new();
@@ -1400,9 +1393,7 @@ fn fetchpost_literalurl_test() {
         .arg("response")
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
 
     let mut got_parsed: Vec<Vec<String>> = Vec::new();
     let mut record_parsed: Vec<String> = Vec::new();
@@ -1545,9 +1536,7 @@ fn fetchpost_payload_template() {
         .arg(r#"."data""#)
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
 
     let expected = vec![
         svec!["first_name", "last_name", "age", "city", "response"],
@@ -1624,9 +1613,7 @@ fn fetchpost_payload_template_with_globals() {
         .arg(r#"."data""#)
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
 
     let expected = vec![
         svec!["first_name", "last_name", "age", "city", "response"],
@@ -1693,9 +1680,7 @@ fn fetchpost_payload_template_with_report() {
         .arg("short")
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
 
     let expected = vec![
         svec!["first_name", "last_name", "age", "city", "response"],
@@ -1751,9 +1736,7 @@ fn fetchpost_with_headers() {
         .arg(r#"."headers""#)
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got = wrk.stdout::<String>(&mut cmd);
+    let got = wrk.stdout_on_success::<String>(&mut cmd);
     assert!(got.contains("X-Test-Header"));
     assert!(got.contains("test123"));
     assert!(got.contains("X-Another-Header"));
@@ -1824,9 +1807,7 @@ fn fetchpost_content_type() {
         .arg("text/plain")
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got = wrk.stdout::<String>(&mut cmd);
+    let got = wrk.stdout_on_success::<String>(&mut cmd);
     assert!(got.starts_with(
         r#"{"args":{},"data":"\"Greeting: Hello World\"","files":{},"form":{},"headers":{"#
     ));

--- a/tests/test_frequency.rs
+++ b/tests/test_frequency.rs
@@ -154,9 +154,7 @@ fn frequency_trim() {
         .args(["--limit", "0"])
         .args(["--select", "h2"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let mut got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let mut got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     got.sort_unstable();
     let expected = vec![
         svec!["field", "value", "count", "percentage", "rank"],
@@ -2237,9 +2235,7 @@ fn frequency_weight_basic() {
         .args(["--select", "value"])
         .args(["--weight", "weight"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let mut got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let mut got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     // Sort by value for consistent comparison
     got.sort_by(|a, b| {
         if a.len() < 2 || b.len() < 2 {
@@ -3073,9 +3069,7 @@ fn frequency_weight_unq_limit_with_limit_zero() {
         .args(["--limit", "0"])
         .args(["--unq-limit", "5"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let mut got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let mut got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     got.sort_by(|a, b| {
         if a.len() < 2 || b.len() < 2 {
             std::cmp::Ordering::Equal
@@ -3233,9 +3227,7 @@ fn frequency_weight_extremely_large_values() {
         .args(["--select", "value"])
         .args(["--weight", "weight"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let mut got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let mut got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     got.sort_by(|a, b| {
         if a.len() < 2 || b.len() < 2 {
             std::cmp::Ordering::Equal
@@ -3414,9 +3406,7 @@ fn frequency_weight_no_other_zero() {
         .args(["--select", "value"])
         .args(["--weight", "weight"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let mut got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let mut got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     got.sort_by(|a, b| {
         if a.len() < 2 || b.len() < 2 {
             std::cmp::Ordering::Equal

--- a/tests/test_frequency.rs
+++ b/tests/test_frequency.rs
@@ -677,9 +677,7 @@ fn frequency_all_unique() {
     let mut cmd = wrk.command("frequency");
     cmd.args(["--select", "1"]).arg(testdata);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["field", "value", "count", "percentage", "rank"],
         svec!["case_enquiry_id", "<ALL_UNIQUE>", "100", "100", "0"],
@@ -906,9 +904,7 @@ fn frequency_all_unique_stats_cache_default() {
     let mut cmd = wrk.command("frequency");
     cmd.args(["--select", "1"]).arg(testdata);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["field", "value", "count", "percentage", "rank"],
         svec!["case_enquiry_id", "<ALL_UNIQUE>", "100", "100", "0"],
@@ -1201,9 +1197,7 @@ fn frequency_vis_whitespace() {
         .arg("--vis-whitespace")
         .arg("--pct-nulls");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     // NULL is now at the end by default (--null-sorted flag changes this behavior)
     let expected = vec![
         svec!["field", "value", "count", "percentage", "rank"],
@@ -1499,8 +1493,7 @@ fn frequency_json_all_unique() {
     cmd.args(["--select", "1"])
         .arg(testdata.clone())
         .arg("--json");
-    wrk.assert_success(&mut cmd);
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let v: Value = serde_json::from_str(&got).unwrap();
     // Accept either full path or just filename for input
     let input = v["input"].as_str().unwrap();
@@ -1539,8 +1532,7 @@ fn frequency_json_vis_whitespace() {
         .arg("--vis-whitespace")
         .arg("--json")
         .arg("--pct-nulls");
-    wrk.assert_success(&mut cmd);
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let v: Value = serde_json::from_str(&got).unwrap();
     assert!(v["input"].as_str().unwrap().ends_with("in.csv"));
     assert_eq!(v["rowcount"], 6);
@@ -1748,8 +1740,7 @@ fn frequency_toon_all_unique() {
     cmd.args(["--select", "1"])
         .arg(testdata.clone())
         .arg("--toon");
-    wrk.assert_success(&mut cmd);
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = r#"rowcount: 100
 fieldcount: 1
 fields[1]:
@@ -1796,8 +1787,7 @@ fn frequency_toon_vis_whitespace() {
         .arg("--vis-whitespace")
         .arg("--toon")
         .arg("--pct-nulls");
-    wrk.assert_success(&mut cmd);
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let v: Value = toon_format::decode(
         &got,
         &toon_format::DecodeOptions {
@@ -2191,9 +2181,7 @@ fn frequency_rank_ties_json() {
     let (wrk, mut cmd) = setup_rank_test_sorted("frequency_rank_ties_json");
     cmd.args(["--rank-strategy", "average"]).arg("--json");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let v: Value = serde_json::from_str(&got).unwrap();
     assert!(v["input"].as_str().unwrap().ends_with("in.csv"));
     assert_eq!(v["rowcount"], 16);
@@ -2900,9 +2888,7 @@ fn frequency_weight_with_unq_limit_all_unique() {
         .args(["--limit", "0"])
         .args(["--unq-limit", "10"]); // This should be ignored for all-unique columns
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
 
     // With --weight and all-unique columns, should show a single <ALL_UNIQUE> entry
     let freq_rows: Vec<_> = got.iter().filter(|r| r.len() > 1 && r[0] == "id").collect();
@@ -2945,9 +2931,7 @@ fn frequency_weight_with_unq_limit_and_limit() {
         .args(["--limit", "5"])
         .args(["--unq-limit", "10"]); // Both should be ignored for all-unique columns
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
 
     // With --weight and all-unique columns, should show a single <ALL_UNIQUE> entry
     let freq_rows: Vec<_> = got.iter().filter(|r| r.len() > 1 && r[0] == "id").collect();
@@ -3215,9 +3199,7 @@ fn frequency_weight_infinity_values() {
         .args(["--select", "value"])
         .args(["--weight", "weight"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
 
     let expected_values = vec![
         svec!["field", "value", "count", "percentage", "rank"],

--- a/tests/test_geocode.rs
+++ b/tests/test_geocode.rs
@@ -24,9 +24,7 @@ fn geocode_suggest() {
     let mut cmd = wrk.command("geocode");
     cmd.arg("suggest").arg("Location").arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["Location"],
         svec!["(41.90059, -87.85673)"],
@@ -68,9 +66,7 @@ fn geocode_suggest_select() {
     // use select syntax to select the last column
     cmd.arg("suggest").arg("_").arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["c1", "c2", "Location"],
         svec!["1", "2", "(41.90059, -87.85673)"],
@@ -96,9 +92,7 @@ fn geocode_suggestnow_default() {
     let mut cmd = wrk.command("geocode");
     cmd.arg("suggestnow").arg("Brooklyn");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["Location"],
         svec!["Brooklyn, New York US: 40.6501, -73.94958"],
@@ -117,9 +111,7 @@ fn geocode_suggestnow_formatstr_dyncols() {
          {state_fips:us_state_fips_code}, {county_fips:us_county_fips_code}, {timezone:timezone}",
     ]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec![
             "Location",
@@ -167,8 +159,7 @@ fn geocode_suggest_intl() {
         .args(["-f", "%city-admin1-country"])
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["Location"],
         svec!["Paris, Île-de-France Region FR"],
@@ -209,9 +200,7 @@ fn geocode_suggest_intl_country_filter() {
         .args(["-f", "%city-admin1-country"])
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["Location"],
         svec!["Paris, Texas US"],
@@ -260,9 +249,7 @@ fn geocode_suggestnow() {
         .args(["--country", "US"])
         .args(["-f", "%city-admin1-country"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["Location"], svec!["Paris, Texas US"]];
     assert_eq!(got, expected);
 }
@@ -277,9 +264,7 @@ fn geocode_reversenow() {
         "{name}, {admin2} County, {admin1} - {population} {timezone}",
     ]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["Location"],
         svec!["Brooklyn, Kings County, New York - 2736074 America/New_York"],
@@ -355,9 +340,7 @@ fn geocode_suggest_intl_multi_country_filter() {
         .args(["-f", "%city-admin1-country"])
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["Location"],
         svec!["Paris, Île-de-France Region FR"],
@@ -399,9 +382,7 @@ fn geocode_suggest_filter_country_admin1() {
         .args(["--admin1", "US.NY,New J,Metro Manila"])
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["Location"],
         svec!["Melrose Park, Illinois, Cook US"],
@@ -448,9 +429,7 @@ fn geocode_suggest_invalid() {
         .args(["--invalid-result", "<ERROR>"])
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["Location"],
         svec!["(41.90059, -87.85673)"],
@@ -492,9 +471,7 @@ fn geocode_suggest_dynfmt() {
         )
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["Location"],
         svec!["41.90059:-87.85673 - Melrose Park, Illinois:17-031 US NA USD CA,MX,CU"],
@@ -531,8 +508,7 @@ fn geocode_suggest_pretty_json() {
         .arg("%pretty-json")
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["Location"],
         svec![
@@ -673,9 +649,7 @@ fn geocode_suggest_invalid_dynfmt() {
         .arg("{latitude}:{longitude} - {name}, {admin1} {invalid_field}")
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["Location"],
         svec!["Invalid dynfmt template."],
@@ -710,9 +684,7 @@ fn geocode_suggest_fmt() {
         .arg("%city-state-country")
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["Location"],
         svec!["Elmhurst, Illinois US"],
@@ -749,9 +721,7 @@ fn geocode_suggest_fmt_json() {
         .arg("%json")
         .arg("data.csv");
 
-    let got: String = wrk.stdout(&mut cmd);
-
-    wrk.assert_success(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
 
     let expected = r######"Location
 "{""cityrecord"":{""id"":4891010,""name"":""Elmhurst"",""latitude"":41.899471282958984,""longitude"":-87.94033813476562,""country"":{""id"":6252001,""code"":""US"",""name"":""United States""},""admin_division"":{""id"":4896861,""code"":""US.IL"",""name"":""Illinois""},""admin2_division"":{""id"":4890213,""code"":""US.IL.043"",""name"":""DuPage County""},""timezone"":""America/Chicago"",""names"":{""en"":""Elmhurst""},""country_names"":{""en"":""United States""},""admin1_names"":{""en"":""Illinois""},""admin2_names"":{""en"":""DuPage County""},""population"":45957}, ""countryrecord"":{""info"":{""iso"":""US"",""iso3"":""USA"",""iso_numeric"":""840"",""fips"":""US"",""name"":""United States"",""capital"":""Washington"",""area"":""9629091"",""population"":327167434,""continent"":""NA"",""tld"":"".us"",""currency_code"":""USD"",""currency_name"":""Dollar"",""phone"":""1"",""postal_code_format"":""#####-####"",""postal_code_regex"":""^\\d{5}(-\\d{4})?$"",""languages"":""en-US,es-US,haw,fr"",""geonameid"":6252001,""neighbours"":""CA,MX,CU"",""equivalent_fips_code"":""""},""names"":{""en"":""United States""},""capital_names"":{""en"":""Washington D.C.""}}, ""us_fips_codes"":{""us_state_code"":""IL"",""us_state_name"":""Illinois"",""us_state_fips_code"":""17"",""us_county"":""DuPage County"",""us_county_fips_code"":""043""}}"
@@ -787,9 +757,7 @@ fn geocode_suggest_fmt_cityrecord() {
         .arg("%cityrecord")
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["Location"],
         svec![
@@ -875,9 +843,7 @@ fn geocode_reverse() {
     let mut cmd = wrk.command("geocode");
     cmd.arg("reverse").arg("Location").arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["Location"],
         svec!["The Bronx, New York US"],
@@ -918,9 +884,7 @@ fn geocode_reverse_fmtstring() {
         .arg("%city-state-country")
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["Location"],
         svec!["The Bronx, New York US"],
@@ -955,9 +919,7 @@ fn geocode_reverse_fmtstring_intl() {
         .arg("%city-admin1-country")
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["Location"],
         svec!["Barcelona, Catalonia ES"],
@@ -992,9 +954,7 @@ fn geocode_reverse_fmtstring_intl_dynfmt() {
         .arg("pop: {population} tz: {timezone}")
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["Location"],
         svec!["pop: 1686208 tz: Europe/Madrid"],
@@ -1029,9 +989,7 @@ fn geocode_reverse_fmtstring_intl_invalid_dynfmt() {
         .arg("pop: {population} tz: {timezone} {doesnotexistfield}")
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["Location"],
         svec!["Invalid dynfmt template."],
@@ -1072,9 +1030,7 @@ fn geocode_suggest_dyncols_fmt() {
         ])
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec![
             "Location",
@@ -1197,9 +1153,7 @@ fn geocode_reverse_dyncols_fmt() {
         ])
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["Location", "city_col", "tz_col", "capital_col", "pop_col"],
         svec![
@@ -1287,9 +1241,7 @@ fn geocode_countryinfo() {
     let mut cmd = wrk.command("geocode");
     cmd.arg("countryinfo").arg("Country").arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["Country"],
         svec!["United States"],
@@ -1334,9 +1286,7 @@ fn geocode_countryinfo_formatstr() {
         ])
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["Country"],
         svec!["United States Pop: 327167434 in NA using Dollar all in 9629091 square kms."],
@@ -1377,9 +1327,7 @@ fn geocode_countryinfo_formatstr_pretty_json() {
         .args(["--formatstr", "%pretty-json"])
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
 
     let expected = vec![
         svec!["Country"],
@@ -1465,8 +1413,7 @@ fn geocode_countryinfonow() {
     let mut cmd = wrk.command("geocode");
     cmd.arg("countryinfonow").arg("US");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
-    wrk.assert_success(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["Location"], svec!["United States"]];
     assert_eq!(got, expected);
 }
@@ -1483,9 +1430,7 @@ fn geocode_countryinfonow_formatstr() {
          {area} square kms.",
     ]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["Location"],
         svec!["Canada Pop: 37058856 in NA using Dollar all in 9984670 square kms."],
@@ -1502,9 +1447,7 @@ fn geocode_countryinfonow_formatstr_pretty_json() {
         .arg("mx")
         .args(["--formatstr", "%pretty-json"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = "{\n  \"info\": {\n    \"iso\": \"MX\",\"iso3\": \"MEX\",\"iso_numeric\": \
                     \"484\",\"fips\": \"MX\",\"name\": \"Mexico\",\"capital\": \"Mexico \
                     City\",\"area\": \"1972550\",\"population\": 126190788,\"continent\": \
@@ -1538,9 +1481,7 @@ fn geocode_iplookup() {
     let mut cmd = wrk.command("geocode");
     cmd.arg("iplookup").arg("IP").arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["IP"],
         svec!["8.8.8.8"],
@@ -1574,9 +1515,7 @@ fn geocode_iplookup_formatstr() {
         .args(["--formatstr", "%city-state-country"])
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["IP"],
         svec!["Ashburn, Virginia US"],
@@ -1609,9 +1548,7 @@ fn geocode_iplookup_formatstr_dynfmt() {
         ])
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["IP"],
         svec!["City: Ashburn, State: Virginia, Country: US - America/New_York"],
@@ -1641,9 +1578,7 @@ fn geocode_iplookup_formatstr_json() {
         .args(["--formatstr", "%json"])
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     // The JSON output will contain the full city record, so we just check that it contains expected
     // fields
     assert!(got[1][0].contains("\"cityrecord\""));
@@ -1673,9 +1608,7 @@ fn geocode_iplookup_formatstr_pretty_json() {
         .args(["--formatstr", "%pretty-json"])
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     // The pretty JSON output will contain the full city record with proper formatting
     assert!(got[1][0].contains("\n  \"cityrecord\""));
     assert!(got[1][0].contains("\n  \"countryrecord\""));
@@ -1703,9 +1636,7 @@ fn geocode_iplookup_formatstr_cityrecord() {
         .args(["--formatstr", "%cityrecord"])
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     // The cityrecord output will contain the full ArchivedCitiesRecord debug format
     assert!(got[1][0].contains("ArchivedCitiesRecord"));
     assert!(got[1][0].contains("name: \"Ashburn\""));
@@ -1739,9 +1670,7 @@ fn geocode_iplookup_dyncols_fmt() {
         ])
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["IP", "city_col", "state_col", "country_col", "tz_col"],
         svec!["3.3.3.3", "Ashburn", "Virginia", "US", "America/New_York"],
@@ -1778,9 +1707,7 @@ fn geocode_iplookup_invalid_result() {
         .args(["--invalid-result", "<NO_LOCATION>"])
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["IP"],
         svec!["Ashburn, Virginia US"],
@@ -1799,9 +1726,7 @@ fn geocode_iplookupnow() {
     let mut cmd = wrk.command("geocode");
     cmd.arg("iplookupnow").arg("3.3.3.3");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["Location"],
         svec!["Ashburn, Virginia US: 39.04372, -77.48749"],
@@ -1817,9 +1742,7 @@ fn geocode_iplookupnow_url() {
     let mut cmd = wrk.command("geocode");
     cmd.arg("iplookupnow").arg("https://nytimes.com");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["Location"],
         svec!["San Francisco, California US: 37.77493, -122.41942"],
@@ -1837,9 +1760,7 @@ fn geocode_iplookupnow_formatstr() {
         .arg("3.3.3.3")
         .args(["--formatstr", "%city-state-country"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["Location"], svec!["Ashburn, Virginia US"]];
     assert_eq!(got, expected);
 }
@@ -1855,9 +1776,7 @@ fn geocode_iplookupnow_formatstr_dynfmt() {
         "City: {name}, State: {admin1}, Country: {country} - {timezone}",
     ]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["Location"],
         svec!["City: Ashburn, State: Virginia, Country: US - America/New_York"],
@@ -1875,9 +1794,7 @@ fn geocode_iplookupnow_formatstr_json() {
         .arg("3.3.3.3")
         .args(["--formatstr", "%json"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     // The JSON output will contain the full city record
     assert!(got.contains("\"cityrecord\""));
     assert!(got.contains("\"countryrecord\""));
@@ -1894,9 +1811,7 @@ fn geocode_iplookupnow_formatstr_pretty_json() {
         .arg("3.3.3.3")
         .args(["--formatstr", "%pretty-json"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     // The pretty JSON output will contain the full city record with proper formatting
     assert!(got.contains("\n  \"cityrecord\""));
     assert!(got.contains("\n  \"countryrecord\""));
@@ -1912,9 +1827,7 @@ fn geocode_iplookupnow_formatstr_cityrecord() {
         .arg("3.3.3.3")
         .args(["--formatstr", "%cityrecord"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     // The cityrecord output will contain the full ArchivedCitiesRecord debug format
     assert!(got.contains("ArchivedCitiesRecord"));
     assert!(got.contains("Ashburn"));
@@ -1930,9 +1843,7 @@ fn geocode_iplookupnow_private_ip() {
     let mut cmd = wrk.command("geocode");
     cmd.arg("iplookupnow").arg("192.168.1.1");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     // Private IP should return the IP address as-is
     assert!(got.contains("192.168.1.1"));
 }
@@ -1945,9 +1856,7 @@ fn geocode_iplookupnow_localhost() {
     let mut cmd = wrk.command("geocode");
     cmd.arg("iplookupnow").arg("127.0.0.1");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     // Localhost should return the IP address as-is
     assert!(got.contains("127.0.0.1"));
 }
@@ -1960,9 +1869,7 @@ fn geocode_iplookupnow_invalid_ip() {
     let mut cmd = wrk.command("geocode");
     cmd.arg("iplookupnow").arg("invalid-ip-address");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     // Invalid IP should return the input as-is
     assert!(got.contains("invalid-ip-address"));
 }
@@ -1975,9 +1882,7 @@ fn geocode_iplookupnow_invalid_url() {
     let mut cmd = wrk.command("geocode");
     cmd.arg("iplookupnow").arg("not-a-valid-url");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     // Invalid URL should return the input as-is
     assert!(got.contains("not-a-valid-url"));
 }
@@ -2040,9 +1945,7 @@ fn geocode_opencage() {
     let mut cmd = wrk.command("geocode");
     cmd.arg("opencage").arg("Location").arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     assert_eq!(got.len(), 4);
     assert_eq!(got[0], svec!["Location"]);
     // forward & reverse rows are geocoded (changed from the input)
@@ -2064,9 +1967,7 @@ fn geocode_opencagenow_forward() {
         .arg("Brooklyn, NY")
         .args(["-f", "%location"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     // %location format is "(lat, long)"
     assert!(got.contains('(') && got.contains(','));
 }
@@ -2079,9 +1980,7 @@ fn geocode_opencagenow_reverse() {
     let mut cmd = wrk.command("geocode");
     cmd.arg("opencagenow").arg("40.71427, -74.00597");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     // a reverse geocode of a NYC coordinate should mention New York
     assert!(got.to_lowercase().contains("new york") || got.to_lowercase().contains("york"));
 }
@@ -2096,9 +1995,7 @@ fn geocode_opencagenow_json() {
         .arg("Brooklyn, NY")
         .args(["-f", "%json"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     // %json on a now subcommand emits valid JSON (no "Location" header)
     let parsed: serde_json::Value = serde_json::from_str(got.trim()).unwrap();
     assert!(parsed.get("formatted").is_some());
@@ -2115,9 +2012,7 @@ fn geocode_opencagenow_dynfmt() {
         .arg("Brooklyn, NY")
         .args(["-f", "{components.country}"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     assert!(got.to_lowercase().contains("united states"));
 }
 

--- a/tests/test_geoconvert.rs
+++ b/tests/test_geoconvert.rs
@@ -19,9 +19,7 @@ fn geoconvert_geojson_to_csv_basic() {
     let mut cmd = wrk.command("geoconvert");
     cmd.arg("data.geojson").arg("geojson").arg("csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["geometry", "name"],
         svec!["POINT(125.6 10.1)", "Dinagat Islands"],
@@ -90,9 +88,7 @@ fn geoconvert_csv_to_geojson_latlon_order() {
         .args(["--latitude", "lat"])
         .args(["--longitude", "lon"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     // Coordinates must be [longitude, latitude]: longitude (125.6) first.
     assert!(
         got.contains("\"coordinates\":[125.6,10.1]"),
@@ -125,9 +121,7 @@ fn geoconvert_geojson_to_csv_max_length_inline() {
         .arg("csv")
         .args(["--max-length", "5"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     // Header row plus the truncated data row.
     assert_eq!(got[0], svec!["geometry", "name"]);
     // geometry "POINT(125.6 10.1)" is longer than 5, so it must be truncated to <=5 bytes + "...".
@@ -184,9 +178,7 @@ fn geoconvert_geojson_to_csv_max_length() {
     let mut cmd = wrk.command("slice");
     cmd.arg(txcities_csv).args(["--len", "5"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
 
     let expected = r#"geometry,OBJECTID,name,Shape_Length,Shape_Area
 POLYGON((-...,1,Abbott,0,0

--- a/tests/test_input.rs
+++ b/tests/test_input.rs
@@ -338,9 +338,7 @@ fn test_input_both_skip_flexible() {
         .args(["--skip-lines", "5"])
         .arg(test_file);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["column1", "column2"],
         svec!["a", "1"],

--- a/tests/test_joinp.rs
+++ b/tests/test_joinp.rs
@@ -1505,9 +1505,7 @@ fn joinp_filter_pattern_matching() {
             "select * from join_result where STARTS_WITH(id, code)",
         ]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["code", "description", "id", "value"],
         svec!["ABC", "Alpha Beta Charlie", "ABC123", "First"],
@@ -1526,9 +1524,7 @@ fn joinp_filter_pattern_matching() {
             "select * from join_result where STRPOS(id, code) > 0",
         ]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["code", "description", "id", "value"],
         svec!["ABC", "Alpha Beta Charlie", "ABC123", "First"],
@@ -1550,9 +1546,7 @@ fn joinp_filter_pattern_matching() {
             "select * from join_result where ENDS_WITH(id, code)",
         ]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["code", "description", "id", "value"],
         svec!["123", "One Two Three", "ABC123", "First"],
@@ -1591,9 +1585,7 @@ fn joinp_filter_pattern_matching() {
             "select * from join_result where STARTS_WITH(code, pattern)",
         ]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["code", "description", "pattern", "meaning"],
         svec!["ABC123", "Full Code 1", "ABC", "Alpha Beta Charlie"],
@@ -1611,9 +1603,7 @@ fn joinp_filter_pattern_matching() {
             "select * from join_result where STRPOS(code, pattern) > 0",
         ]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["code", "description", "pattern", "meaning"],
         svec!["ABC123", "Full Code 1", "ABC", "Alpha Beta Charlie"],
@@ -1632,9 +1622,7 @@ fn joinp_filter_pattern_matching() {
             "select * from join_result where ENDS_WITH(code, pattern)",
         ]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["code", "description", "pattern", "meaning"],
         svec!["ABC123", "Full Code 1", "123", "One Two Three"],
@@ -1672,9 +1660,8 @@ fn test_joinp_cache_schema() {
     // Test 1: No schema caching (default)
     let mut cmd = wrk.command("joinp");
     cmd.args(["has_text", "left.csv", "has_text", "right.csv"]);
-    wrk.assert_success(&mut cmd);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["id", "has_text", "col3", "col4", "col5", "id_right"],
         svec!["1", "1", "a", "b", "c", "1"],
@@ -1706,9 +1693,8 @@ fn test_joinp_cache_schema() {
     cmd.args(["has_text", "left.csv", "has_text", "right.csv"])
         .arg("--cache-schema")
         .arg("-1");
-    wrk.assert_success(&mut cmd);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     assert_eq!(got, expected);
 
     // Test 4: Use and cache string schema
@@ -1716,9 +1702,8 @@ fn test_joinp_cache_schema() {
     cmd.args(["has_text", "left.csv", "has_text", "right.csv"])
         .arg("--cache-schema")
         .arg("-2");
-    wrk.assert_success(&mut cmd);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     assert_eq!(got, expected);
 
     // Test 5: Invalid cache-schema value
@@ -1831,9 +1816,7 @@ fn joinp_ignore_leading_zero() {
     let mut cmd = wrk.command("joinp");
     cmd.args(["id", "left.csv", "id", "right.csv"]).arg("-z");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     // note that id and id_right have been stripped of leading zeros
     // this is because Polars inferred the schema as all integers
     // and automatically converted the values to integers
@@ -1875,9 +1858,7 @@ fn joinp_ignore_leading_zero_string_schema() {
         .arg("-z")
         .args(["--cache-schema", "-2"]); // force schema to all String types
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     // note that id and id_right have been stripped of leading zeros
     // this is because Polars inferred the schema as all integers
     // and automatically converted the values to integers
@@ -1918,9 +1899,7 @@ fn joinp_ignore_leading_zero_with_non_numeric() {
     cmd.args(["code", "left.csv", "code", "right.csv"])
         .arg("--ignore-leading-zeros");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["code", "value", "code_right", "desc"],
         svec!["001A", "a", "1A", "one"],
@@ -1959,9 +1938,7 @@ fn joinp_ignore_leading_zero_multiple_columns() {
         .arg("--ignore-leading-zeros")
         .args(["--cache-schema", "-2"]); // force schema to all String types
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["id", "code", "value", "id_right", "code_right", "desc"],
         svec!["001", "001A", "a", "1", "1A", "one"],
@@ -2001,9 +1978,7 @@ fn joinp_ignore_case_and_leading_zeros() {
         .arg("--ignore-case")
         .args(["--cache-schema", "-2"]); // force schema to all String types
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["id", "code", "value", "id_right", "code_right", "desc"],
         svec!["001", "001abc", "a", "1", "00001ABC", "one"],
@@ -2043,9 +2018,7 @@ fn joinp_ignore_case_and_leading_zeros_coalesce() {
         .arg("--coalesce")
         .args(["--cache-schema", "-2"]); // force schema to all String types
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["id", "code", "value", "desc"],
         svec!["001", "001abc", "a", "one"],
@@ -2082,9 +2055,7 @@ fn joinp_non_equi_greater_than() {
         .args(["prices.csv", "budgets.csv"])
         .args(["--float-precision", "2"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["item_left", "price_left", "customer_right", "budget_right"],
         svec!["apple", "1.00", "Bob", "1.50"],
@@ -2122,9 +2093,7 @@ fn joinp_non_equi_less_than() {
         .arg("date_left < deadline_right")
         .args(["events.csv", "deadlines.csv"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["event_left", "date_left", "task_right", "deadline_right"],
         svec!["meeting", "2024-01-01", "report", "2024-03-01"],
@@ -2162,9 +2131,7 @@ fn joinp_non_equi_less_than_date_arithmetic() {
         .args(["events.csv", "deadlines.csv"])
         .arg("--try-parsedates");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["event_left", "date_left", "task_right", "deadline_right"],
         // svec!["meeting", "2024-01-01", "report", "2024-03-01"], this is less than 4 months
@@ -2201,9 +2168,7 @@ fn joinp_non_equi_not_equal() {
         .arg("team_left != team_right")
         .args(["teams.csv", "matches.csv"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["player_left", "team_left", "opponent1_right", "team_right"],
         svec!["Alice", "Red", "David", "Green"],
@@ -2275,9 +2240,7 @@ fn joinp_non_equi_compound() {
              position_right",
         ]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec![
             "name_left",
@@ -2339,9 +2302,7 @@ fn joinp_ignore_leading_zeros_issue_2424() {
         "file2.csv",
     ]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["id", "company_id", "art_no"],
         svec!["1", "COM1", "0724"],
@@ -2381,9 +2342,7 @@ fn joinp_unicode_normalization() {
     cmd.args(["name", "left.csv", "name", "right.csv"])
         .args(["--norm-unicode", "nfc"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["name", "value", "name_right", "desc"],
         svec!["cafe\u{301}", "a", "café", "one"],
@@ -2423,9 +2382,7 @@ fn joinp_unicode_normalization_with_other_options() {
         .arg("--ignore-case")
         .args(["--cache-schema", "-2"]); // force schema to all String types
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["id", "name", "value", "id_right", "name_right", "desc"],
         svec!["001", "CAFÉ", "a", "1", "café", "one"],
@@ -2467,9 +2424,7 @@ fn joinp_unicode_normalization_ligatures() {
         .args(["--norm-unicode", "nfkc"])
         .args(["--maintain-order", "left"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["name", "value", "name_right", "desc"],
         svec!["ﬁle", "b", "file", "plain"],
@@ -2485,9 +2440,7 @@ fn joinp_unicode_normalization_ligatures() {
     cmd.args(["name", "left.csv", "name", "right.csv"])
         .args(["--norm-unicode", "nfkd"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     assert_eq!(got, expected);
 
     // Test NFC normalization (should NOT decompose ligatures)
@@ -2496,9 +2449,7 @@ fn joinp_unicode_normalization_ligatures() {
         .args(["--norm-unicode", "nfc"])
         .args(["--maintain-order", "left"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["name", "value", "name_right", "desc"],
         svec!["file", "c", "file", "plain"],
@@ -2714,8 +2665,7 @@ fn joinp_decimal_comma_validation() {
         .arg("--decimal-comma")
         .args(["--delimiter", ";"]);
 
-    wrk.assert_success(&mut cmd);
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = r#"id;value;name
 1;100,5;Alice
 2;200,75;Bob"#;
@@ -2731,8 +2681,7 @@ fn joinp_decimal_comma_validation() {
         .arg("--decimal-comma")
         .args(["--delimiter", "\t"]);
 
-    wrk.assert_success(&mut cmd);
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = "id\tvalue\tname\n1\t100,5\tAlice\n2\t200,75\tBob";
     assert_eq!(got, expected);
 
@@ -2745,8 +2694,7 @@ fn joinp_decimal_comma_validation() {
         .arg("--decimal-comma")
         .args(["--delimiter", "|"]);
 
-    wrk.assert_success(&mut cmd);
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = "id|value|name\n1|100,5|Alice\n2|200,75|Bob";
     assert_eq!(got, expected);
 }
@@ -2807,8 +2755,7 @@ fn joinp_decimal_comma_validation_with_ssv_files() {
         .arg("--decimal-comma")
         .args(["--delimiter", ";"]);
 
-    wrk.assert_success(&mut cmd);
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = "id;value;name\n1;100,5;Alice\n2;200,75;Bob";
     assert_eq!(got, expected);
 }
@@ -2943,8 +2890,7 @@ fn joinp_decimal_comma_validation_with_cross_join() {
         .arg("--decimal-comma")
         .args(["--delimiter", ";"]);
 
-    wrk.assert_success(&mut cmd);
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = "id;value;name\n1;100,5;Alice\n1;100,5;Bob\n2;200,75;Alice\n2;200,75;Bob";
     assert_eq!(got, expected);
 }
@@ -2986,8 +2932,7 @@ fn joinp_decimal_comma_validation_with_non_equi_join() {
         .arg("--decimal-comma")
         .args(["--delimiter", ";"]);
 
-    wrk.assert_success(&mut cmd);
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = r#"id_left;value_left;id_right;min_val_right;max_val_right
 1;100,5;1;50,5;150,5
 2;200,75;2;150,0;250,0"#;
@@ -3032,8 +2977,7 @@ fn joinp_decimal_comma_validation_with_asof_join() {
         .arg("--decimal-comma")
         .args(["--delimiter", "|"]);
 
-    wrk.assert_success(&mut cmd);
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected =
         "id|value|date|id_right|price\n1|100,5|2023-01-01||\n2|200,75|2023-01-02|1|50,25";
     assert_eq!(got, expected);
@@ -3072,8 +3016,7 @@ fn joinp_decimal_comma_validation_with_sql_filter() {
         .arg("--sql-filter")
         .arg("select id, value from join_result where value > 150");
 
-    wrk.assert_success(&mut cmd);
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = "id;value\n2;200,75";
     assert_eq!(got, expected);
 }
@@ -3153,9 +3096,8 @@ fn test_joinp_cache_schema_datetime() {
     cmd.args(["id", "left.csv", "id", "right.csv"])
         .arg("--cache-schema")
         .arg("1");
-    wrk.assert_success(&mut cmd);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     assert_eq!(got.len(), 3); // header + 2 matching rows
     assert_eq!(got[0][0], "id");
     assert_eq!(got[0][1], "event_time");

--- a/tests/test_json.rs
+++ b/tests/test_json.rs
@@ -15,9 +15,7 @@ fn json_array_simple() {
     let mut cmd = wrk.command("json");
     cmd.arg("data.json");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["id", "father", "mother", "oldest_child", "boy"],
         svec!["1", "Mark", "Charlotte", "Tom", "true"],
@@ -81,9 +79,7 @@ fn json_object_simple() {
     let mut cmd = wrk.command("json");
     cmd.arg("data.json");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["id", "father", "mother", "oldest_child", "boy"],
         svec!["1", "Mark", "Charlotte", "Tom", "true"],
@@ -103,9 +99,7 @@ fn json_object_select_column_output() {
     cmd.args(["--select", "id,mother,oldest_child,father"])
         .arg("data.json");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["id", "mother", "oldest_child", "father"],
         svec!["1", "Charlotte", "Tom", "Mark"],
@@ -130,9 +124,7 @@ fn json_object_select_column_output_reverse() {
     cmd.args(["--select", "boy,oldest_child,mother,father,id"])
         .arg("data.json");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["boy", "oldest_child", "mother", "father", "id"],
         svec!["true", "Tom", "Charlotte", "Mark", "1"],
@@ -165,9 +157,7 @@ fn json_fruits_stats() {
     let mut cmd = wrk.command("json");
     cmd.arg("data.json");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = r#"field,type,is_ascii,sum,min,max,range,min_length,max_length,mean,stddev,variance,nullcount,max_precision,sparsity
 fruit,String,true,,apple,strawberry,,5,10,,,,0,,0
 price,Float,,7,1.5,3.0,1.5,4,4,2.3333,0.6236,0.3889,0,1,0"#.to_string();
@@ -186,9 +176,7 @@ fn json_fruits_stats_slice_json() {
     let mut stats_cmd = wrk.command("stats");
     stats_cmd.arg(test_file).arg("--force");
 
-    wrk.assert_success(&mut stats_cmd);
-
-    let stats_output: String = wrk.stdout(&mut stats_cmd);
+    let stats_output: String = wrk.stdout_on_success(&mut stats_cmd);
     wrk.create_from_string("stats.csv", stats_output.as_str());
 
     // qsv slice --json
@@ -196,18 +184,14 @@ fn json_fruits_stats_slice_json() {
     slice_cmd.arg("stats.csv");
     slice_cmd.arg("--json");
 
-    wrk.assert_success(&mut slice_cmd);
-
-    let slice_output: String = wrk.stdout(&mut slice_cmd);
+    let slice_output: String = wrk.stdout_on_success(&mut slice_cmd);
     wrk.create_from_string("slice.json", slice_output.as_str());
 
     // qsv json
     let mut json_cmd = wrk.command("json");
     json_cmd.arg("slice.json");
 
-    wrk.assert_success(&mut json_cmd);
-
-    let json_output: String = wrk.stdout(&mut json_cmd);
+    let json_output: String = wrk.stdout_on_success(&mut json_cmd);
 
     assert_eq!(stats_output, json_output);
 }
@@ -236,9 +220,7 @@ fn json_house_stats_slice_json() {
     // qsv json
     let mut json_cmd = wrk.command("json");
     json_cmd.arg("slice.json");
-    let json_output: String = wrk.stdout(&mut json_cmd);
-
-    wrk.assert_success(&mut json_cmd);
+    let json_output: String = wrk.stdout_on_success(&mut json_cmd);
 
     assert_eq!(stats_output, json_output);
 }
@@ -268,8 +250,7 @@ fn json_house_diff() {
     // qsv json
     let mut json_cmd = wrk.command("json");
     json_cmd.arg("slice.json");
-    wrk.assert_success(&mut json_cmd);
-    let json_output: String = wrk.stdout(&mut json_cmd);
+    let json_output: String = wrk.stdout_on_success(&mut json_cmd);
     wrk.create_from_string("House2.csv", json_output.as_str());
 
     // qsv enum House2.csv -o House2_enum.csv
@@ -309,9 +290,7 @@ fn json_nested() {
     cmd.arg("data.json");
     cmd.args(vec!["--jaq", filter]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["fruit", "price"],
         svec!["apple", "0.5"],
@@ -333,9 +312,7 @@ fn json_nested_object() {
     let mut cmd = wrk.command("json");
     cmd.arg("data.json");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["name", "details.color", "details.qty"],
         svec!["apple", "red", "5"],
@@ -356,9 +333,7 @@ fn json_nested_array() {
     let mut cmd = wrk.command("json");
     cmd.arg("data.json");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["name", "tags.0", "tags.1"],
         svec!["apple", "fruit", "red"],
@@ -380,9 +355,7 @@ fn json_heterogeneous_missing_keys() {
     let mut cmd = wrk.command("json");
     cmd.arg("data.json");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["fruit", "cost", "price", "rating"],
         svec!["apple", "1.75", "2.5", ""],
@@ -401,9 +374,7 @@ fn json_null_value_empty_field() {
     let mut cmd = wrk.command("json");
     cmd.arg("data.json");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["a", "b"], svec!["1", ""], svec!["2", "3"]];
     assert_eq!(got, expected);
 }
@@ -435,9 +406,7 @@ fn json_literal_separator_char_preserved() {
     let mut cmd = wrk.command("json");
     cmd.arg("data.json");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["a\u{241D}b", "c"], svec!["1", "2"]];
     assert_eq!(got, expected);
 }
@@ -498,9 +467,7 @@ fn json_2843_default_select() {
     let mut cmd = wrk.command("json");
     cmd.arg(test_file);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = wrk.load_test_resource("2843-test.csv");
 
     assert_eq!(got.trim(), expected.trim());
@@ -519,9 +486,7 @@ fn json_jaq_bigint_precision() {
     cmd.arg("data.json");
     cmd.args(vec!["--jaq", "."]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["id", "name"], svec!["9007199254740993", "alice"]];
     assert_eq!(got, expected);
 }
@@ -542,9 +507,7 @@ fn json_jaq_bigint_u64_precision() {
     cmd.arg("data.json");
     cmd.args(vec!["--jaq", "."]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["id", "name"], svec!["12345678901234567890", "alice"]];
     assert_eq!(got, expected);
 }

--- a/tests/test_jsonl.rs
+++ b/tests/test_jsonl.rs
@@ -85,7 +85,7 @@ fn jsonl_simple_ignore_error() {
     let mut cmd = wrk.command("jsonl");
     cmd.arg("--ignore-errors").arg("data.jsonl");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     // 4 is ignored as its invalid jsonl
     let expected = vec![
         svec!["id", "father", "mother", "oldest_child", "boy"],
@@ -95,8 +95,6 @@ fn jsonl_simple_ignore_error() {
         svec!["5", "Donald", "Melania", "Ivanka", "false"],
     ];
     assert_eq!(got, expected);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -111,7 +109,7 @@ fn jsonl_ignore_error_first_line_malformed() {
     let mut cmd = wrk.command("jsonl");
     cmd.arg("--ignore-errors").arg("data.jsonl");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     // line 1 is malformed; --ignore-errors must skip it and infer headers
     // from line 2 (the first parseable line).
     let expected = vec![
@@ -120,8 +118,6 @@ fn jsonl_ignore_error_first_line_malformed() {
         svec!["3", "Bob", "Jerry"],
     ];
     assert_eq!(got, expected);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -131,7 +127,7 @@ fn jsonl_bare_scalars() {
     let mut cmd = wrk.command("jsonl");
     cmd.arg("data.jsonl");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     // top-level non-Object roots: header is the synthesized "value" column,
     // each row is the stringified root (null -> empty cell, array -> joined).
     let expected = vec![
@@ -143,8 +139,6 @@ fn jsonl_bare_scalars() {
         svec!["1,2,3"],
     ];
     assert_eq!(got, expected);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]

--- a/tests/test_jsonl.rs
+++ b/tests/test_jsonl.rs
@@ -58,7 +58,7 @@ fn jsonl_simple_error() {
     let mut cmd = wrk.command("jsonl");
     cmd.arg("data.jsonl");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_error(&mut cmd);
     // 4 and 5 are not displayed as jsonl encounters an error and just stops
     let expected = vec![
         svec!["id", "father", "mother", "oldest_child", "boy"],
@@ -67,8 +67,6 @@ fn jsonl_simple_error() {
         svec!["3", "Bob", "Monika", "Jerry", "true"],
     ];
     assert_eq!(got, expected);
-
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]

--- a/tests/test_luau.rs
+++ b/tests/test_luau.rs
@@ -1743,7 +1743,7 @@ fn luau_map_remap_with_qsv_coalesce() {
         .arg("{id,qsv_coalesce(name_right,name)}")
         .arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["id", "name"],
         svec!["1", "Artur A. Mosiyan"],
@@ -1752,8 +1752,6 @@ fn luau_map_remap_with_qsv_coalesce() {
         svec!["4", "Eleonora V. Avanesyan"],
     ];
     assert_eq!(got, expected);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -3424,10 +3422,9 @@ fn luau_map_remap_does_not_overwrite_input_globals() {
         .arg("{a, tonumber(b) * 2}")
         .arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["a", "doubled"], svec!["1", "4"]];
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -3452,9 +3449,8 @@ return headers[1] .. "/" .. headers[2] .. "/" .. headers[3];
     let mut cmd = wrk.command("luau");
     cmd.arg("map").arg("h").arg("test.LUAU").arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     assert_eq!(got, vec![svec!["k", "h"], svec!["x", "k/v1/v2"]]);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -3479,8 +3475,7 @@ fn luau_random_access_lastrow_no_headers() {
             r#"BEGIN { _INDEX = _LASTROW }! _INDEX = -1; return tostring(_LASTROW) .. "/" .. tostring(_ROWCOUNT)"#,
         )
         .arg("data.csv");
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     // only the row at _LASTROW (index 2, value "3") is processed before _INDEX = -1
     assert_eq!(got, vec![svec!["3", "2/3"]]);
-    wrk.assert_success(&mut cmd);
 }

--- a/tests/test_luau.rs
+++ b/tests/test_luau.rs
@@ -1145,7 +1145,7 @@ END {
         .arg("file:testqsvcmd.luau")
         .arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["letter", "Amount", "Running Total"],
         svec!["a", "13", "13"],
@@ -1161,8 +1161,6 @@ END {
         dos2unix(&echo_text).trim_end(),
         dos2unix(expected_echo_text).trim_end()
     );
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]

--- a/tests/test_replace.rs
+++ b/tests/test_replace.rs
@@ -16,7 +16,7 @@ fn replace() {
     let mut cmd = wrk.command("replace");
     cmd.arg("\\.0$").arg("").arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["identifier", "color"],
         svec!["164", "yellow"],
@@ -25,7 +25,6 @@ fn replace() {
         svec!["167", "yellow"],
     ];
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -44,7 +43,7 @@ fn replace_regex_literal() {
     let mut cmd = wrk.command("replace");
     cmd.arg("$low^").arg("low").arg("--literal").arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["identifier", "color"],
         svec!["164.0", "yellow"],
@@ -53,7 +52,6 @@ fn replace_regex_literal() {
         svec!["167.0", "yellow.0"],
     ];
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -501,7 +499,7 @@ fn replace_all_emails_with_placeholder() {
         .arg("<EMAIL>")
         .arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["email"],
         svec!["<EMAIL>"],
@@ -513,8 +511,6 @@ fn replace_all_emails_with_placeholder() {
         svec!["hello world"],
     ];
     assert_eq!(got, expected);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -527,7 +523,7 @@ fn replace_indexed_parallel() {
     let mut cmd = wrk.command("replace");
     cmd.arg("Police").arg("Pulisya").arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec![
             "Unique Key",
@@ -794,7 +790,6 @@ fn replace_indexed_parallel() {
         ],
     ];
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 
     // now index the file
     wrk.create_from_string("data.csv", &data);
@@ -848,8 +843,7 @@ fn replace_indexed_empty() {
         .arg("--jobs")
         .arg("2")
         .arg("--not-one");
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["identifier", "color"]];
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }

--- a/tests/test_replace.rs
+++ b/tests/test_replace.rs
@@ -806,11 +806,9 @@ fn replace_indexed_parallel() {
         .arg("data.csv")
         .arg("--jobs")
         .arg("2");
-    wrk.assert_success(&mut cmd);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]

--- a/tests/test_reverse.rs
+++ b/tests/test_reverse.rs
@@ -137,8 +137,7 @@ fn reverse_indexed_asserts_success() {
     wrk.create_indexed("in.csv", vec![svec!["h1", "h2"], svec!["a", "b"]]);
     let mut cmd = wrk.command("reverse");
     cmd.arg("in.csv");
-    wrk.assert_success(&mut cmd);
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["h1", "h2"], svec!["a", "b"]];
     assert_eq!(got, expected);
 
@@ -155,8 +154,7 @@ fn reverse_indexed_asserts_success() {
     );
     let mut cmd = wrk.command("reverse");
     cmd.arg("in.csv");
-    wrk.assert_success(&mut cmd);
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["h1", "h2"],
         svec!["c", "3"],
@@ -173,8 +171,7 @@ fn reverse_indexed_asserts_success() {
     );
     let mut cmd = wrk.command("reverse");
     cmd.arg("--no-headers").arg("in.csv");
-    wrk.assert_success(&mut cmd);
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["c", "3"], svec!["b", "2"], svec!["a", "1"]];
     assert_eq!(got, expected);
 }

--- a/tests/test_safenames.rs
+++ b/tests/test_safenames.rs
@@ -206,7 +206,7 @@ fn safenames_verify_verbose_pretty_json() {
     let mut cmd = wrk.command("safenames");
     cmd.arg("--mode").arg("J").arg("in.csv");
 
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
 
     let expected = r#"{
   "header_count": 13,"duplicate_count": 2,"duplicate_headers": [
@@ -230,8 +230,6 @@ fn safenames_verify_verbose_pretty_json() {
   ]
 }"#;
     assert_eq!(got, expected);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -264,13 +262,11 @@ fn safenames_verify_verbose_json() {
     let mut cmd = wrk.command("safenames");
     cmd.arg("--mode").arg("j").arg("in.csv");
 
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
 
     let expected = r#"{"header_count":13,"duplicate_count":2,"duplicate_headers":[":4","col1:5"],"unsafe_headers":["This is a column with invalid chars!# and leading & trailing spaces","","this is already a Postgres Safe Column","1starts with 1","col1","col1","col1","","","","col1","_1"],"safe_headers":["col1"]}"#;
 
     assert_eq!(got, expected);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]

--- a/tests/test_sample.rs
+++ b/tests/test_sample.rs
@@ -515,9 +515,7 @@ fn sample_bernoulli_seed() {
         .arg("0.5")
         .arg("in.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["R", "S"],
         svec!["4", "c"],
@@ -639,9 +637,7 @@ fn sample_systematic() {
     let mut cmd = wrk.command("sample");
     cmd.args(["--systematic", "first"]).arg("3").arg("in.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["R", "S"],
         svec!["1", "b"],
@@ -680,9 +676,7 @@ fn sample_stratified() {
         .arg("2")
         .arg("in.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["Group", "Value"],
         svec!["A", "3"],
@@ -724,9 +718,7 @@ fn sample_stratified_large_sample_size() {
         .arg("100")
         .arg("in.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["Group", "Value"],
         svec!["A", "1"],
@@ -882,9 +874,7 @@ fn sample_stratified_empty_stratum() {
         .arg("2")
         .arg("in.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["Group", "Value"],
         svec!["", "2"],
@@ -942,9 +932,7 @@ fn sample_cluster_single_record() {
         .arg("2")
         .arg("in.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["Cluster", "Value"],
         svec!["A", "1"],
@@ -1129,9 +1117,7 @@ fn sample_weighted_invalid_weights() {
         .arg("2")
         .arg("in.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     // Records with invalid weights are treated as having zero weight
     // we requested two samples but returning only one as we ran out of records
     let expected = vec![svec!["ID", "Weight"], svec!["4", "40"]];
@@ -1189,9 +1175,7 @@ fn sample_stratified_with_delimiter() {
         .arg("1")
         .arg("in.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["Group|Value"], svec!["A|2"], svec!["B|3"]];
     assert_eq!(got, expected);
 }
@@ -1293,9 +1277,7 @@ fn sample_remote_bernoulli_streaming_standard_rng() {
         .arg("0.3") // 30% probability
         .arg(test_url);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
 
     // Verify we got the header
     assert_eq!(
@@ -1371,9 +1353,7 @@ fn sample_remote_bernoulli_streaming_cryptosecure() {
         .arg("0.3") // 30% probability
         .arg(test_url);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
 
     // Verify we got the header
     assert_eq!(

--- a/tests/test_schema.rs
+++ b/tests/test_schema.rs
@@ -102,7 +102,7 @@ fn generate_schema_with_optional_flags_notrim_and_validate_with_errors_s390x() {
     let mut cmd3 = wrk.command("validate");
     cmd3.arg("adur-public-toilets.csv");
     cmd3.arg("adur-public-toilets.csv.schema.json");
-    wrk.output(&mut cmd3);
+    wrk.assert_err(&mut cmd3);
 
     // validation report
     let validation_errors_expected = r#"row_number	field	error
@@ -141,7 +141,6 @@ fn generate_schema_with_optional_flags_notrim_and_validate_with_errors_s390x() {
         validation_errors_expected.to_string(),
         validation_error_output
     );
-    wrk.assert_err(&mut cmd3);
 }
 
 #[test]
@@ -188,7 +187,7 @@ fn generate_schema_with_optional_flags_trim_and_validate_with_errors_s390x() {
     cmd3.arg("adur-public-toilets.csv");
     cmd3.arg("--trim");
     cmd3.arg("adur-public-toilets.csv.schema.json");
-    wrk.output(&mut cmd3);
+    wrk.assert_err(&mut cmd3);
 
     // validation report
     let validation_errors_expected = r#"row_number	field	error
@@ -226,7 +225,6 @@ fn generate_schema_with_optional_flags_trim_and_validate_with_errors_s390x() {
         validation_errors_expected.to_string(),
         validation_error_output
     );
-    wrk.assert_err(&mut cmd3);
 }
 
 #[test]
@@ -243,8 +241,6 @@ fn generate_schema_with_defaults_to_stdout() {
     // run schema command
     let mut cmd = wrk.command("schema");
     cmd.arg("adur-public-toilets.csv");
-    wrk.output(&mut cmd);
-
     wrk.assert_success(&mut cmd);
 
     // load output schema file

--- a/tests/test_schema.rs
+++ b/tests/test_schema.rs
@@ -22,8 +22,6 @@ fn generate_schema_with_defaults_and_validate_trim_with_no_errors() {
     // run schema command with value constraints option
     let mut cmd = wrk.command("schema");
     cmd.arg("adur-public-toilets.csv");
-    wrk.output(&mut cmd);
-
     wrk.assert_success(&mut cmd);
 
     // load output schema file
@@ -48,7 +46,9 @@ fn generate_schema_with_defaults_and_validate_trim_with_no_errors() {
     cmd3.arg("adur-public-toilets.csv");
     cmd3.arg("--trim");
     cmd3.arg("adur-public-toilets.csv.schema.json");
-    wrk.output(&mut cmd3);
+    // NB: assert on cmd3. This used to run `cmd` (the SCHEMA command) a second
+    // time down below, so `validate --trim`'s own exit status went unasserted.
+    wrk.assert_success(&mut cmd3);
 
     // not expecting any invalid rows, so confirm there are NO output files generated
     let validation_error_path = &wrk.path("adur-public-toilets.csv.validation-errors.tsv");
@@ -56,7 +56,6 @@ fn generate_schema_with_defaults_and_validate_trim_with_no_errors() {
     assert!(!Path::new(validation_error_path).exists());
     assert!(!Path::new(&wrk.path("adur-public-toilets.csv.valid")).exists());
     assert!(!Path::new(&wrk.path("adur-public-toilets.csv.invalid")).exists());
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]

--- a/tests/test_search.rs
+++ b/tests/test_search.rs
@@ -47,14 +47,13 @@ fn search() {
     let mut cmd = wrk.command("search");
     cmd.arg("^foo").arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["h1", "h2"],
         svec!["foobar", "barfoo"],
         svec!["barfoo", "foobar"],
     ];
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -68,10 +67,9 @@ fn search_indexed_parallel() {
         .arg("data.csv")
         .arg("--jobs")
         .arg("2");
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = "case_enquiry_id,open_dt,target_dt,closed_dt,ontime,case_status,closure_reason,case_title,subject,reason,type,queue,department,submittedphoto,closedphoto,location,fire_district,pwd_district,city_council_district,police_district,neighborhood,neighborhood_services_district,ward,precinct,location_street_name,location_zipcode,latitude,longitude,source\n101004154423,2022-01-31 08:05:00,,,ONTIME,Open, ,Sidewalk Cover / Manhole,Boston Water & Sewer Commission,Sidewalk Cover / Manhole,Sidewalk Cover / Manhole,INFO01_GenericeFormforOtherServiceRequestTypes,INFO,,,8 Putnam St  Charlestown  MA  02129,3,1A,1,A15,Charlestown,2,Ward 2,0201,8 Putnam St,02129,42.3735,-71.0599,Constituent Call\n101004114776,2022-01-03 12:13:47,2022-01-04 12:13:47,2022-01-03 12:41:17,ONTIME,Closed,Case Closed. Closed date : 2022-01-03 12:41:17.887 Case Resolved Area ticketed  ,Parking Enforcement,Transportation - Traffic Division,Enforcement & Abandoned Vehicles,Parking Enforcement,BTDT_Parking Enforcement,BTDT,https://311.boston.gov/media/boston/report/photos/61d32ebc05bbcf180c2b01ff/report.jpg,,126 Elm St  Charlestown  MA  02129,3,1A,1,A15,Charlestown,2,02,0204,126 Elm St,02129,42.3806,-71.0616,Citizens Connect App";
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 
     // now index the file
     let mut cmd = wrk.command("index");
@@ -84,9 +82,8 @@ fn search_indexed_parallel() {
         .arg("data.csv")
         .arg("--jobs")
         .arg("2");
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -118,9 +115,8 @@ fn search_indexed_parallel_json() {
         .arg("--jobs")
         .arg("2")
         .arg("--json");
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -130,10 +126,9 @@ fn search_json() {
     let mut cmd = wrk.command("search");
     cmd.arg("^foo").arg("data.csv").arg("--json");
 
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = r#"[{"h1":"foobar","h2":"barfoo"},{"h1":"barfoo","h2":"foobar"}]"#;
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -146,10 +141,9 @@ fn search_matchonly_json() {
         .arg("--json")
         .args(["--flag", "M"]);
 
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = r#"[{"M":"1"},{"M":"3"}]"#;
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -167,13 +161,12 @@ fn search_json_escapes_keys() {
     let mut cmd = wrk.command("search");
     cmd.arg("^foo").arg("data.csv").arg("--json");
 
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let parsed: Value = serde_json::from_str(&got)
         .unwrap_or_else(|e| panic!("output is not valid JSON: {e}\ngot: {got}"));
     let obj = &parsed[0];
     assert_eq!(obj[r#"he said "hi""#], Value::String("foobar".to_string()));
     assert_eq!(obj[r"back\slash"], Value::String("barfoo".to_string()));
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -187,11 +180,10 @@ fn search_json_escapes_flag_column_key() {
         .arg("--json")
         .args(["--flag", r#"M"quoted"#]);
 
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let parsed: Value = serde_json::from_str(&got)
         .unwrap_or_else(|e| panic!("output is not valid JSON: {e}\ngot: {got}"));
     assert!(parsed[0].get(r#"M"quoted"#).is_some(), "got: {got}");
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -201,9 +193,7 @@ fn search_match() {
     let mut cmd = wrk.command("search");
     cmd.arg("^foo").arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["h1", "h2"],
         svec!["foobar", "barfoo"],
@@ -219,9 +209,7 @@ fn search_match_json() {
     let mut cmd = wrk.command("search");
     cmd.arg("^foo").arg("data.csv").arg("--json");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = r#"[{"h1":"foobar","h2":"barfoo"},{"h1":"barfoo","h2":"foobar"}]"#;
     assert_eq!(got, expected);
 }
@@ -332,8 +320,7 @@ fn search_indexed_parallel_invert_match() {
         .arg("Charlestown")
         .arg("--invert-match")
         .arg("data.csv");
-    let seq_out: String = wrk.stdout(&mut seq_cmd);
-    wrk.assert_success(&mut seq_cmd);
+    let seq_out: String = wrk.stdout_on_success(&mut seq_cmd);
 
     // index and run in parallel
     let mut idx_cmd = wrk.command("index");
@@ -347,8 +334,7 @@ fn search_indexed_parallel_invert_match() {
         .arg("--jobs")
         .arg("4")
         .arg("data.csv");
-    let par_out: String = wrk.stdout(&mut par_cmd);
-    wrk.assert_success(&mut par_cmd);
+    let par_out: String = wrk.stdout_on_success(&mut par_cmd);
 
     assert_eq!(seq_out, par_out);
 }
@@ -392,15 +378,13 @@ fn search_ignore_case() {
     cmd.arg("^FoO").arg("data.csv");
     cmd.arg("--ignore-case");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["h1", "h2"],
         svec!["foobar", "barfoo"],
         svec!["barfoo", "foobar"],
     ];
     assert_eq!(got, expected);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -431,11 +415,9 @@ fn search_unicode() {
     cmd.arg("^Ḟoo").arg("data.csv");
     cmd.arg("--unicode");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["h1", "h2"], svec!["Ḟooƀar", "ḃarḟoo"]];
     assert_eq!(got, expected);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -462,11 +444,9 @@ fn search_unicode_envvar() {
     cmd.env("QSV_REGEX_UNICODE", "1");
     cmd.arg("^Ḟoo").arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["h1", "h2"], svec!["Ḟooƀar", "ḃarḟoo"]];
     assert_eq!(got, expected);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -493,11 +473,9 @@ fn search_no_headers() {
     cmd.arg("^foo").arg("data.csv");
     cmd.arg("--no-headers");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["foobar", "barfoo"], svec!["barfoo", "foobar"]];
     assert_eq!(got, expected);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -508,11 +486,9 @@ fn search_no_headers_json() {
     cmd.arg("^foo").arg("data.csv").arg("--json");
     cmd.arg("--no-headers");
 
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = r#"[{"0":"foobar","1":"barfoo"},{"0":"barfoo","1":"foobar"}]"#;
     assert_eq!(got, expected);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -539,11 +515,9 @@ fn search_select() {
     cmd.arg("^foo").arg("data.csv");
     cmd.arg("--select").arg("h2");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["h1", "h2"], svec!["barfoo", "foobar"]];
     assert_eq!(got, expected);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -571,11 +545,9 @@ fn search_select_no_headers() {
     cmd.arg("--select").arg("2");
     cmd.arg("--no-headers");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["barfoo", "foobar"]];
     assert_eq!(got, expected);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -603,15 +575,13 @@ fn search_invert_match() {
     cmd.arg("^foo").arg("data.csv");
     cmd.arg("--invert-match");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["foobar", "barfoo"],
         svec!["a", "b"],
         svec!["Ḟooƀar", "ḃarḟoo"],
     ];
     assert_eq!(got, expected);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -644,11 +614,9 @@ fn search_invert_match_no_headers() {
     cmd.arg("--invert-match");
     cmd.arg("--no-headers");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["a", "b"], svec!["Ḟooƀar", "ḃarḟoo"]];
     assert_eq!(got, expected);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -675,7 +643,7 @@ fn search_flag() {
     let mut cmd = wrk.command("search");
     cmd.arg("^foo").arg("data.csv").args(["--flag", "flagged"]);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["h1", "h2", "flagged"],
         svec!["foobar", "barfoo", "1"],
@@ -684,7 +652,6 @@ fn search_flag() {
         svec!["Ḟooƀar", "ḃarḟoo", "0"],
     ];
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -695,7 +662,7 @@ fn search_flag_no_headers() {
     cmd.arg("^foo").arg("data.csv").args(["--flag", "flagged"]);
     cmd.arg("--no-headers");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["foobar", "barfoo", "1"],
         svec!["a", "b", "0"],
@@ -703,7 +670,6 @@ fn search_flag_no_headers() {
         svec!["Ḟooƀar", "ḃarḟoo", "0"],
     ];
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -713,10 +679,9 @@ fn search_flag_match_only() {
     let mut cmd = wrk.command("search");
     cmd.arg("^foo").arg("data.csv").args(["--flag", "M"]);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["M"], svec!["1"], svec!["3"]];
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -729,10 +694,9 @@ fn search_flag_match_only_no_headers() {
         .args(["--flag", "M"])
         .arg("--no-headers");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["1"], svec!["3"]];
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -743,7 +707,7 @@ fn search_flag_invert_match() {
     cmd.arg("^foo").arg("data.csv").args(["--flag", "flagged"]);
     cmd.arg("--invert-match");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["h1", "h2", "flagged"],
         svec!["foobar", "barfoo", "0"],
@@ -752,8 +716,6 @@ fn search_flag_invert_match() {
         svec!["Ḟooƀar", "ḃarḟoo", "4"],
     ];
     assert_eq!(got, expected);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -764,11 +726,9 @@ fn search_flag_invert_match_matchonly() {
     cmd.arg("^foo").arg("data.csv").args(["--flag", "M"]);
     cmd.arg("--invert-match");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["M"], svec!["2"], svec!["4"]];
     assert_eq!(got, expected);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -877,11 +837,9 @@ fn search_literal() {
     let mut cmd = wrk.command("search");
     cmd.arg("^bar").arg("data.csv").arg("--literal");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["foo^bar", "barfoo"], svec!["^barfoo", "foobar"]];
     assert_eq!(got, expected);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -891,11 +849,9 @@ fn search_exact() {
     let mut cmd = wrk.command("search");
     cmd.arg("--exact").arg("J. Bloggs").arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["id", "name"], svec!["3", "J. Bloggs"]];
     assert_eq!(got, expected);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -905,11 +861,9 @@ fn search_exact_with_special_chars() {
     let mut cmd = wrk.command("search");
     cmd.arg("--exact").arg("foo^bar").arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["h1", "h2"], svec!["foo^bar", "barfoo"]];
     assert_eq!(got, expected);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -919,12 +873,10 @@ fn search_exact_no_match_substring() {
     let mut cmd = wrk.command("search");
     cmd.arg("--exact").arg("J. Bloggs").arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     // Should only match "J. Bloggs", not "F. J. Bloggs" (substring)
     let expected = vec![svec!["id", "name"], svec!["3", "J. Bloggs"]];
     assert_eq!(got, expected);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -937,11 +889,9 @@ fn search_exact_case_insensitive() {
         .arg("j. bloggs")
         .arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["id", "name"], svec!["3", "J. Bloggs"]];
     assert_eq!(got, expected);
-
-    wrk.assert_success(&mut cmd);
 }
 
 // Test for https://github.com/dathere/qsv/issues/3437
@@ -954,11 +904,9 @@ fn search_no_headers_envvar() {
     cmd.env("QSV_NO_HEADERS", "1");
     cmd.arg("^foo").arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["foobar", "barfoo"], svec!["barfoo", "foobar"]];
     assert_eq!(got, expected);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -970,11 +918,9 @@ fn search_no_headers_envvar_select() {
     cmd.arg("^foo").arg("data.csv");
     cmd.arg("--select").arg("1");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["foobar", "barfoo"]];
     assert_eq!(got, expected);
-
-    wrk.assert_success(&mut cmd);
 }
 
 // Exact reproduction of https://github.com/dathere/qsv/issues/3437
@@ -996,9 +942,7 @@ fn search_no_headers_envvar_issue_3437() {
     cmd.env("QSV_NO_HEADERS", "1");
     cmd.arg("-s").arg("1").arg("@").arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["@", "bar"], svec!["@", "bar"], svec!["@", "bar"]];
     assert_eq!(got, expected);
-
-    wrk.assert_success(&mut cmd);
 }

--- a/tests/test_search.rs
+++ b/tests/test_search.rs
@@ -98,10 +98,9 @@ fn search_indexed_parallel_json() {
         .arg("--jobs")
         .arg("2")
         .arg("--json");
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = r#"[{"case_enquiry_id":"101004154423","open_dt":"2022-01-31 08:05:00","target_dt":null,"closed_dt":null,"ontime":"ONTIME","case_status":"Open","closure_reason":" ","case_title":"Sidewalk Cover / Manhole","subject":"Boston Water & Sewer Commission","reason":"Sidewalk Cover / Manhole","type":"Sidewalk Cover / Manhole","queue":"INFO01_GenericeFormforOtherServiceRequestTypes","department":"INFO","submittedphoto":null,"closedphoto":null,"location":"8 Putnam St  Charlestown  MA  02129","fire_district":"3","pwd_district":"1A","city_council_district":"1","police_district":"A15","neighborhood":"Charlestown","neighborhood_services_district":"2","ward":"Ward 2","precinct":"0201","location_street_name":"8 Putnam St","location_zipcode":"02129","latitude":"42.3735","longitude":"-71.0599","source":"Constituent Call"},{"case_enquiry_id":"101004114776","open_dt":"2022-01-03 12:13:47","target_dt":"2022-01-04 12:13:47","closed_dt":"2022-01-03 12:41:17","ontime":"ONTIME","case_status":"Closed","closure_reason":"Case Closed. Closed date : 2022-01-03 12:41:17.887 Case Resolved Area ticketed  ","case_title":"Parking Enforcement","subject":"Transportation - Traffic Division","reason":"Enforcement & Abandoned Vehicles","type":"Parking Enforcement","queue":"BTDT_Parking Enforcement","department":"BTDT","submittedphoto":"https://311.boston.gov/media/boston/report/photos/61d32ebc05bbcf180c2b01ff/report.jpg","closedphoto":null,"location":"126 Elm St  Charlestown  MA  02129","fire_district":"3","pwd_district":"1A","city_council_district":"1","police_district":"A15","neighborhood":"Charlestown","neighborhood_services_district":"2","ward":"02","precinct":"0204","location_street_name":"126 Elm St","location_zipcode":"02129","latitude":"42.3806","longitude":"-71.0616","source":"Citizens Connect App"}]"#;
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 
     // now index the file
     let mut cmd = wrk.command("index");

--- a/tests/test_searchset.rs
+++ b/tests/test_searchset.rs
@@ -87,7 +87,7 @@ fn searchset() {
     let mut cmd = wrk.command("searchset");
     cmd.arg("regexset.txt").arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["h1", "h2"],
         svec!["foobar", "barfoo"],
@@ -95,7 +95,6 @@ fn searchset() {
         svec!["is waldo here", "spot"],
     ];
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -232,8 +231,7 @@ fn searchset_indexed_parallel_invert_match() {
         .arg("regexset.txt")
         .arg("--invert-match")
         .arg("data.csv");
-    let seq_out: String = wrk.stdout(&mut seq_cmd);
-    wrk.assert_success(&mut seq_cmd);
+    let seq_out: String = wrk.stdout_on_success(&mut seq_cmd);
 
     // index and run in parallel
     let mut idx_cmd = wrk.command("index");
@@ -247,8 +245,7 @@ fn searchset_indexed_parallel_invert_match() {
         .arg("--jobs")
         .arg("4")
         .arg("data.csv");
-    let par_out: String = wrk.stdout(&mut par_cmd);
-    wrk.assert_success(&mut par_cmd);
+    let par_out: String = wrk.stdout_on_success(&mut par_cmd);
 
     assert_eq!(seq_out, par_out);
 }
@@ -323,7 +320,7 @@ fn searchset_unicode() {
     cmd.arg("regexset_unicode.txt").arg("data.csv");
     cmd.arg("--unicode");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["h1", "h2"],
         svec!["foobar", "barfoo"],
@@ -332,7 +329,6 @@ fn searchset_unicode() {
         svec!["Ḟooƀar", "ḃarḟoo"],
     ];
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -344,7 +340,7 @@ fn searchset_unicode_envvar() {
     cmd.env("QSV_REGEX_UNICODE", "1");
     cmd.arg("regexset_unicode.txt").arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["h1", "h2"],
         svec!["foobar", "barfoo"],
@@ -353,7 +349,6 @@ fn searchset_unicode_envvar() {
         svec!["Ḟooƀar", "ḃarḟoo"],
     ];
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -388,7 +383,7 @@ fn searchset_ignore_case() {
     cmd.arg("regexset.txt").arg("data.csv");
     cmd.arg("--ignore-case");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["h1", "h2"],
         svec!["foobar", "barfoo"],
@@ -397,8 +392,6 @@ fn searchset_ignore_case() {
         svec!["bleh", "no, Waldo is there"],
     ];
     assert_eq!(got, expected);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -434,14 +427,13 @@ fn searchset_no_headers() {
     cmd.arg("regexset.txt").arg("data.csv");
     cmd.arg("--no-headers");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["foobar", "barfoo"],
         svec!["barfoo", "foobar"],
         svec!["is waldo here", "spot"],
     ];
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -453,10 +445,9 @@ fn searchset_select() {
     cmd.arg("regexset.txt").arg("data.csv");
     cmd.arg("--select").arg("h2");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["h1", "h2"], svec!["barfoo", "foobar"]];
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -469,10 +460,9 @@ fn searchset_select_no_headers() {
     cmd.arg("--select").arg("2");
     cmd.arg("--no-headers");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["barfoo", "foobar"]];
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -484,7 +474,7 @@ fn searchset_invert_match() {
     cmd.arg("regexset.txt").arg("data.csv");
     cmd.arg("--invert-match");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["foobar", "barfoo"],
         svec!["a", "b"],
@@ -492,7 +482,6 @@ fn searchset_invert_match() {
         svec!["bleh", "no, Waldo is there"],
     ];
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -505,14 +494,13 @@ fn searchset_invert_match_no_headers() {
     cmd.arg("--invert-match");
     cmd.arg("--no-headers");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["a", "b"],
         svec!["Ḟooƀar", "ḃarḟoo"],
         svec!["bleh", "no, Waldo is there"],
     ];
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -525,7 +513,7 @@ fn searchset_flag() {
         .arg("data.csv")
         .args(["--flag", "flagged"]);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["h1", "h2", "flagged"],
         svec!["foobar", "barfoo", "1;1,2"],
@@ -536,7 +524,6 @@ fn searchset_flag() {
         svec!["bleh", "no, Waldo is there", "0"],
     ];
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -550,7 +537,7 @@ fn searchset_flag_invert_match() {
         .args(["--flag", "flagged"]);
     cmd.arg("--invert-match");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["h1", "h2", "flagged"],
         svec!["foobar", "barfoo", "0"],
@@ -561,7 +548,6 @@ fn searchset_flag_invert_match() {
         svec!["bleh", "no, Waldo is there", "6"],
     ];
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -622,7 +608,7 @@ fn searchset_literal() {
     let mut cmd = wrk.command("searchset");
     cmd.arg("regexset.txt").arg("data.csv").arg("--literal");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["h1", "h2"],
         svec!["foo$bar^", "barfoo"],
@@ -631,7 +617,6 @@ fn searchset_literal() {
         svec!["bleh", "no, Wal[do] is there"],
     ];
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -642,14 +627,13 @@ fn searchset_exact() {
     let mut cmd = wrk.command("searchset");
     cmd.arg("regexset.txt").arg("data.csv").arg("--exact");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["h1", "h2"],
         svec!["foo$bar^", "barfoo"],
         svec!["is wal[do] here", "spot"],
     ];
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -660,11 +644,10 @@ fn searchset_exact_with_dots() {
     let mut cmd = wrk.command("searchset");
     cmd.arg("regexset.txt").arg("data.csv").arg("--exact");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     // Should only match "J. Bloggs" exactly, not "F. J. Bloggs" or "JM Bloggs"
     let expected = vec![svec!["id", "name"], svec!["3", "J. Bloggs"]];
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -678,10 +661,9 @@ fn searchset_exact_case_insensitive() {
         .arg("--exact")
         .arg("--ignore-case");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["id", "name"], svec!["3", "J. Bloggs"]];
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -692,11 +674,10 @@ fn searchset_exact_no_match_substring() {
     let mut cmd = wrk.command("searchset");
     cmd.arg("regexset.txt").arg("data.csv").arg("--exact");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     // Should NOT match "F. J. Bloggs" even though it contains "J. Bloggs" as substring
     let expected = vec![svec!["id", "name"], svec!["3", "J. Bloggs"]];
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -711,7 +692,7 @@ fn searchset_comment_lines() {
     let mut cmd = wrk.command("searchset");
     cmd.arg("regexset.txt").arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     // Should match the same rows as the regular regexset (^foo and bar$),
     // ignoring all comment lines
     let expected = vec![
@@ -720,5 +701,4 @@ fn searchset_comment_lines() {
         svec!["barfoo", "foobar"],
     ];
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }

--- a/tests/test_searchset.rs
+++ b/tests/test_searchset.rs
@@ -105,12 +105,10 @@ fn searchset_indexed_parallel() {
     wrk.create_from_string("regexset.txt", "Brighton\nMission Hill");
     let mut cmd = wrk.command("searchset");
     cmd.arg("regexset.txt").arg("data.csv");
-    wrk.assert_success(&mut cmd);
 
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = "case_enquiry_id,open_dt,target_dt,closed_dt,ontime,case_status,closure_reason,case_title,subject,reason,type,queue,department,submittedphoto,closedphoto,location,fire_district,pwd_district,city_council_district,police_district,neighborhood,neighborhood_services_district,ward,precinct,location_street_name,location_zipcode,latitude,longitude,source\n101004113747,2022-01-01 23:46:09,2022-01-17 08:30:00,2022-01-02 11:03:10,ONTIME,Closed,Case Closed. Closed date : Sun Jan 02 11:03:10 EST 2022 Noted Case noted. Duplicate case. Posts already marked for contractor to repair.  ,Street Light Outages,Public Works Department,Street Lights,Street Light Outages,PWDx_Street Light Outages,PWDx,https://311.boston.gov/media/boston/report/photos/61d12e0705bbcf180c29cfc2/report.jpg,,103 N Beacon St  Brighton  MA  02135,11,04,9,D14,Brighton,15,22,2205,103 N Beacon St,02135,42.3549,-71.143,Citizens Connect App\n101004113751,2022-01-01 23:53:44,2022-03-07 08:30:00,,OVERDUE,Open, ,Graffiti Removal,Property Management,Graffiti,Graffiti Removal,PROP_GRAF_GraffitiRemoval,PROP,https://311.boston.gov/media/boston/report/photos/61d12fc905bbcf180c29d11e/report.jpg,,1270 Commonwealth Ave  Allston  MA  02134,11,04,9,D14,Allston / Brighton,15,Ward 21,2105,1270 Commonwealth Ave,02134,42.3492,-71.1325,Citizens Connect App\n101004114593,2022-01-03 09:58:36,2022-01-04 09:58:36,2022-01-03 11:58:53,ONTIME,Closed,Case Closed. Closed date : Mon Jan 03 11:58:53 EST 2022 Resolved Picked up.  ,Pick up Dead Animal,Public Works Department,Street Cleaning,Pick up Dead Animal,PWDx_District 04: Allston/Brighton,PWDx,,,INTERSECTION of Greymere Rd & Washington St  Brighton  MA  ,11,04,8,D14,Allston / Brighton,15,22,2210,INTERSECTION Greymere Rd & Washington St,,42.3594,-71.0587,Citizens Connect App\n101004114624,2022-01-03 10:12:00,2022-05-03 10:12:36,2022-01-13 14:12:46,ONTIME,Closed,Case Closed. Closed date : Thu Jan 13 14:12:46 EST 2022 Noted Violations found. Notice written. ,SCHEDULED Pest Infestation - Residential,Inspectional Services,Housing,Pest Infestation - Residential,ISD_Housing (INTERNAL),ISD,,,20 Washington St  Brighton  MA  02135,11,04,9,D14,Allston / Brighton,15,Ward 21,2112,20 Washington St,02135,42.3425,-71.1412,Constituent Call\n101004114724,2022-01-03 11:36:21,,2022-01-04 16:31:31,ONTIME,Closed,Case Closed. Closed date : 2022-01-04 16:31:31.297 Bulk Item Automation ,Schedule Bulk Item Pickup,Public Works Department,Sanitation,Schedule a Bulk Item Pickup SS,PWDx_Schedule a Bulk Item Pickup,PWDx,,,352 Riverway  Boston  MA  02115,4,10A,8,B2,Mission Hill,14,Ward 10,1004,352 Riverway,02115,42.3335,-71.1113,Self Service\n101004115369,2022-01-04 06:15:33,2022-01-05 08:30:00,2022-01-04 10:00:57,ONTIME,Closed,Case Closed. Closed date : 2022-01-04 10:00:57.823 Case Noted ,Parking Enforcement,Transportation - Traffic Division,Enforcement & Abandoned Vehicles,Parking Enforcement,BTDT_Parking Enforcement,BTDT,https://311.boston.gov/media/boston/report/photos/61d42c4905bbcf180c2b73f2/report.jpg,,14 Wiltshire Rd  Brighton  MA  02135,11,04,9,D14,Allston / Brighton,15,Ward 22,2209,14 Wiltshire Rd,02135,42.3434,-71.1546,Citizens Connect App";
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 
     // now index the file
     let mut cmd = wrk.command("index");
@@ -120,11 +118,9 @@ fn searchset_indexed_parallel() {
     // should still have the same output
     let mut cmd = wrk.command("searchset");
     cmd.arg("regexset.txt").arg("data.csv");
-    wrk.assert_success(&mut cmd);
 
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     assert_eq!(got, expected);
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -257,8 +253,6 @@ fn searchset_match() {
     wrk.create("regexset.txt", regexset_file());
     let mut cmd = wrk.command("searchset");
     cmd.arg("regexset.txt").arg("data.csv");
-
-    wrk.assert_success(&mut cmd);
 
     wrk.assert_success(&mut cmd);
 }

--- a/tests/test_slice.rs
+++ b/tests/test_slice.rs
@@ -291,7 +291,7 @@ fn slice_json_escapes_keys() {
     let mut cmd = wrk.command("slice");
     cmd.arg("data.csv").args(["--start", "0"]).arg("--json");
 
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let parsed: serde_json::Value = serde_json::from_str(&got)
         .unwrap_or_else(|e| panic!("output is not valid JSON: {e}\ngot: {got}"));
     let obj = &parsed[0];
@@ -303,7 +303,6 @@ fn slice_json_escapes_keys() {
         obj[r"back\slash"],
         serde_json::Value::String("b".to_string())
     );
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -682,9 +681,7 @@ fn slice_from_parquet() {
     let mut cmd = wrk.command("slice");
     cmd.arg(test_file).arg("--index").arg("2").arg("--json");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = r#"[{"Unique Key":"20520945","Created Date":"05/27/2011 12:00:00 AM","Closed Date":null,"Agency":"HPD","Agency Name":"Department of Housing Preservation and Development","Complaint Type":"PAINT - PLASTER","Descriptor":"WALLS","Location Type":"RESIDENTIAL BUILDING","Incident Zip":"11225","Incident Address":"1700 BEDFORD AVENUE","Street Name":"BEDFORD AVENUE","Cross Street 1":"MONTGOMERY STREET","Cross Street 2":"SULLIVAN PLACE","Intersection Street 1":null,"Intersection Street 2":null,"Address Type":"ADDRESS","City":"BROOKLYN","Landmark":null,"Facility Type":"N/A","Status":"Open","Due Date":null,"Resolution Description":"The following complaint conditions are still open.HPD may attempt to contact you to verify the correction of the condition or may conduct an inspection.","Resolution Action Updated Date":"06/15/2011 12:00:00 AM","Community Board":"09 BROOKLYN","BBL":"3013020001","Borough":"BROOKLYN","X Coordinate (State Plane)":"996197","Y Coordinate (State Plane)":"181752","Open Data Channel Type":"UNKNOWN","Park Facility Name":"Unspecified","Park Borough":"BROOKLYN","Vehicle Type":null,"Taxi Company Borough":null,"Taxi Pick Up Location":null,"Bridge Highway Name":null,"Bridge Highway Direction":null,"Road Ramp":null,"Bridge Highway Segment":null,"Latitude":null,"Longitude":null,"Location":null}]"#;
     assert_eq!(got, expected);
 }
@@ -697,9 +694,7 @@ fn slice_from_json() {
     let mut cmd = wrk.command("slice");
     cmd.arg(test_file).arg("--index").arg("2").arg("--json");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = r#""Unique Key":"20520945""#;
     assert!(got.contains(expected));
 }
@@ -752,9 +747,7 @@ fn slice_from_arrow() {
     let mut cmd = wrk.command("slice");
     cmd.arg(test_file).arg("--index").arg("2").arg("--json");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = r#""Unique Key":"20520945""#;
     assert!(got.contains(expected));
 }
@@ -767,9 +760,7 @@ fn slice_from_csvgz() {
     let mut cmd = wrk.command("slice");
     cmd.arg(test_file).arg("--index").arg("2").arg("--json");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = "20520945";
     assert!(got.contains(expected));
 }
@@ -782,9 +773,7 @@ fn slice_from_csvzst() {
     let mut cmd = wrk.command("slice");
     cmd.arg(test_file).arg("--index").arg("2").arg("--json");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = "20520945";
     assert!(got.contains(expected));
 }
@@ -797,9 +786,7 @@ fn slice_from_csvzlib() {
     let mut cmd = wrk.command("slice");
     cmd.arg(test_file).arg("--index").arg("2").arg("--json");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = "20520945";
     assert!(got.contains(expected));
 }
@@ -812,9 +799,7 @@ fn slice_from_tsvgz() {
     let mut cmd = wrk.command("slice");
     cmd.arg(test_file).arg("--index").arg("2").arg("--json");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = "20520945";
     assert!(got.contains(expected));
 }
@@ -827,9 +812,7 @@ fn slice_from_tsvzst() {
     let mut cmd = wrk.command("slice");
     cmd.arg(test_file).arg("--index").arg("2").arg("--json");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = "20520945";
     assert!(got.contains(expected));
 }
@@ -842,9 +825,7 @@ fn slice_from_tsvzlib() {
     let mut cmd = wrk.command("slice");
     cmd.arg(test_file).arg("--index").arg("2").arg("--json");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = "20520945";
     assert!(got.contains(expected));
 }
@@ -858,9 +839,7 @@ fn slice_from_csvzip() {
     let mut cmd = wrk.command("slice");
     cmd.arg(test_file).arg("--index").arg("0").arg("--json");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = "101004143000";
     assert!(got.contains(expected));
 }
@@ -879,9 +858,7 @@ fn slice_from_zip_multientry() {
     let mut cmd = wrk.command("slice");
     cmd.arg(test_file).arg("--index").arg("0").arg("--json");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     assert!(got.contains("position"));
     assert!(got.contains("title"));
 }
@@ -893,9 +870,7 @@ fn slice_from_tsv() {
     let mut cmd = wrk.command("slice");
     cmd.arg(test_file).arg("--index").arg("2").arg("--json");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = "20520945";
     assert!(got.contains(expected));
 }
@@ -968,29 +943,25 @@ fn slice_float_precision() {
     // Test with default precision
     let mut cmd = wrk.command("slice");
     cmd.arg(&gzipped_file).arg("--json");
-    wrk.assert_success(&mut cmd);
-    let got_default: String = wrk.stdout(&mut cmd);
+    let got_default: String = wrk.stdout_on_success(&mut cmd);
 
     // Test with custom precision (2 decimal places)
     let mut cmd = wrk.command("slice");
     cmd.arg(&gzipped_file).arg("--json");
     cmd.env("QSV_POLARS_FLOAT_PRECISION", "2");
-    wrk.assert_success(&mut cmd);
-    let got_precision_2: String = wrk.stdout(&mut cmd);
+    let got_precision_2: String = wrk.stdout_on_success(&mut cmd);
 
     // Test with custom precision (5 decimal places)
     let mut cmd = wrk.command("slice");
     cmd.arg(&gzipped_file).arg("--json");
     cmd.env("QSV_POLARS_FLOAT_PRECISION", "5");
-    wrk.assert_success(&mut cmd);
-    let got_precision_5: String = wrk.stdout(&mut cmd);
+    let got_precision_5: String = wrk.stdout_on_success(&mut cmd);
 
     // Test with custom precision (20 decimal places)
     let mut cmd = wrk.command("slice");
     cmd.arg(&parquet_file).arg("--json");
     cmd.env("QSV_POLARS_FLOAT_PRECISION", "20");
-    wrk.assert_success(&mut cmd);
-    let got_precision_20: String = wrk.stdout(&mut cmd);
+    let got_precision_20: String = wrk.stdout_on_success(&mut cmd);
 
     // Verify that the precision affects the output
     // The default precision should be different from precision 2
@@ -1054,10 +1025,8 @@ fn slice_from_json_with_pschema() {
     let mut cmd = wrk.command("slice");
     cmd.arg("test.json").arg("--index").arg("1").arg("--json");
 
-    wrk.assert_success(&mut cmd);
-
     // Verify the output - age should be a string
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = r#""age":"25""#;
     assert!(got.contains(expected));
 }
@@ -1089,10 +1058,8 @@ fn slice_from_jsonl_with_pschema() {
     let mut cmd = wrk.command("slice");
     cmd.arg("test.jsonl").arg("--index").arg("1").arg("--json");
 
-    wrk.assert_success(&mut cmd);
-
     // Verify the output - age should be a string
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = r#""age":"25""#;
     assert!(got.contains(expected));
 }
@@ -1127,10 +1094,8 @@ fn slice_from_csvgz_with_pschema() {
     let mut cmd = wrk.command("slice");
     cmd.arg("test.csv.gz").arg("--index").arg("1").arg("--json");
 
-    wrk.assert_success(&mut cmd);
-
     // Verify the output - age should be a string
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = r#""age":"25""#;
     assert!(got.contains(expected));
 }
@@ -1169,10 +1134,8 @@ fn slice_from_csvzst_with_pschema() {
         .arg("1")
         .arg("--json");
 
-    wrk.assert_success(&mut cmd);
-
     // Verify the output - age should be a string
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = r#""age":"25""#;
     assert!(got.contains(expected));
 }
@@ -1215,10 +1178,8 @@ fn slice_from_csvzlib_with_pschema() {
         .arg("1")
         .arg("--json");
 
-    wrk.assert_success(&mut cmd);
-
     // Verify the output - age should be a string
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = r#""age":"25""#;
     assert!(got.contains(expected));
 }
@@ -1305,10 +1266,8 @@ fn slice_from_tsvgz_with_decimal_precision() {
         .arg("test.tsv.gz")
         .arg("--json");
 
-    wrk.assert_success(&mut cmd);
-
     // Verify the output - value should maintain all decimal places
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
 
     assert!(got.contains("3.1415926535897931159979635"));
     assert!(got.contains("2.7182818284590450907955983"));

--- a/tests/test_snappy.rs
+++ b/tests/test_snappy.rs
@@ -293,9 +293,7 @@ fn snappy_plain_csv_with_sz_extension_fallback() {
     let mut cmd = wrk.command("count");
     cmd.arg("plain.csv.sz");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     assert_eq!(got, "2"); // Should count 2 data rows (excluding header)
 }
 
@@ -320,9 +318,7 @@ fn snappy_case_insensitive_extension() {
     let mut cmd = wrk.command("count");
     cmd.arg("test.csv.SZ");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     assert_eq!(got, "1");
 }
 
@@ -345,10 +341,8 @@ fn snappy_validation_prevents_corrupt_error() {
     let mut cmd = wrk.command("slice");
     cmd.args(["--len", "1"]).arg("data.csv.sz");
 
-    wrk.assert_success(&mut cmd);
-
     // Verify we got the data (should be first row after header)
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["name", "age"], svec!["Alice", "30"]];
     assert_eq!(got, expected);
 }

--- a/tests/test_snappy.rs
+++ b/tests/test_snappy.rs
@@ -38,10 +38,8 @@ fn snappy_roundtrip() {
     let mut cmd = wrk.command("snappy"); // DevSkim: ignore DS126858
     cmd.arg("decompress").arg(out_file); // DevSkim: ignore DS126858
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd); // DevSkim: ignore DS126858
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd); // DevSkim: ignore DS126858
     assert_eq!(got, thedata);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -53,13 +51,11 @@ fn snappy_decompress() {
     let mut cmd = wrk.command("snappy");
     cmd.arg("decompress").arg(test_file);
 
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
 
     let expected = wrk.load_test_resource("boston311-100.csv");
 
     assert_eq!(dos2unix(&got), dos2unix(&expected).trim_end());
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -70,13 +66,11 @@ fn snappy_decompress_url() {
     cmd.arg("decompress")
         .arg("https://github.com/dathere/qsv/raw/master/resources/test/boston311-100.csv.sz");
 
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
 
     let expected = wrk.load_test_resource("boston311-100.csv");
 
     assert_eq!(dos2unix(&got), dos2unix(&expected).trim_end());
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -233,13 +227,9 @@ fn snappy_automatic_decompression() {
     let mut cmd = wrk.command("count");
     cmd.arg(test_file);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = "100";
     assert_eq!(got, expected);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -260,13 +250,9 @@ fn snappy_automatic_compression() {
     let mut cmd = wrk.command("count");
     cmd.arg(got_path);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = "50";
     assert_eq!(got, expected);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]

--- a/tests/test_sniff.rs
+++ b/tests/test_sniff.rs
@@ -177,9 +177,7 @@ fn sniff_url_snappy() {
     let mut cmd = wrk.command("sniff");
     cmd.arg("https://github.com/dathere/qsv/raw/master/resources/test/boston311-100.csv.sz");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
 
     let expected_end = r#"Sampled Records: 100
 Estimated: false
@@ -686,9 +684,7 @@ fn sniff_github_blob_url() {
     let mut cmd = wrk.command("sniff");
     cmd.arg("https://github.com/dathere/qsv/blob/master/resources/test/boston311-100.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
 
     // Should correctly sniff as CSV after auto-transforming to raw URL
     assert!(got.contains("Num Fields: 29"));
@@ -706,9 +702,7 @@ fn sniff_github_raw_url() {
         "https://raw.githubusercontent.com/dathere/qsv/master/resources/test/boston311-100.csv",
     );
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
 
     // Should correctly sniff as CSV
     assert!(got.contains("Num Fields: 29"));

--- a/tests/test_split.rs
+++ b/tests/test_split.rs
@@ -867,7 +867,6 @@ fn split_filter_basic() {
             .arg(wrk.path("."))
             .arg("in.csv");
     }
-    wrk.run(&mut cmd);
     wrk.assert_success(&mut cmd);
 
     // Check that the original files were created
@@ -934,7 +933,6 @@ fn split_filter_with_padding() {
             .arg(wrk.path("."))
             .arg("in.csv");
     }
-    wrk.run(&mut cmd);
     wrk.assert_success(&mut cmd);
     // Check that the original files were created
     assert!(wrk.path("000.csv").exists());
@@ -998,7 +996,6 @@ fn split_filter_with_custom_filename() {
             .arg(wrk.path("."))
             .arg("in.csv");
     }
-    wrk.run(&mut cmd);
     wrk.assert_success(&mut cmd);
     // Check that the original files were created
     assert!(wrk.path("prefix-0.csv").exists());
@@ -1059,7 +1056,6 @@ fn split_filter_with_chunks() {
             .arg(wrk.path("."))
             .arg("in.csv");
     }
-    wrk.run(&mut cmd);
     wrk.assert_success(&mut cmd);
     // Check that the original files were created
     assert!(wrk.path("0.csv").exists());
@@ -1121,7 +1117,6 @@ fn split_filter_with_kb_size() {
             .arg(wrk.path("."))
             .arg(test_file);
     }
-    wrk.run(&mut cmd);
     wrk.assert_success(&mut cmd);
     // Check that at least some of the original files were created
     assert!(wrk.path("0.csv").exists());
@@ -1156,7 +1151,6 @@ fn split_filter_with_no_headers() {
             .arg(wrk.path("."))
             .arg("in.csv");
     }
-    wrk.run(&mut cmd);
     wrk.assert_success(&mut cmd);
     // Check that the original files were created
     assert!(wrk.path("0.csv").exists());
@@ -1217,7 +1211,6 @@ fn split_filter_with_cleanup() {
             .arg(wrk.path("."))
             .arg("in.csv");
     }
-    wrk.run(&mut cmd);
 
     wrk.assert_success(&mut cmd);
 
@@ -1281,7 +1274,6 @@ fn split_filter_without_cleanup() {
             .arg(wrk.path("."))
             .arg("in.csv");
     }
-    wrk.run(&mut cmd);
     wrk.assert_success(&mut cmd);
 
     // Check that the original files were kept
@@ -1346,7 +1338,6 @@ fn split_filter_with_cleanup_failed_command() {
             .arg(wrk.path("."))
             .arg("in.csv");
     }
-    wrk.run(&mut cmd);
     wrk.assert_err(&mut cmd);
 
     // The first chunk should still exist because it was created before the filter command failed
@@ -1385,7 +1376,6 @@ fn split_filter_with_ignore_errors() {
             .arg("in.csv");
     }
     // The command should run successfully despite the filter command failing
-    wrk.run(&mut cmd);
     wrk.assert_success(&mut cmd);
     // Check that the original files were created
     assert!(wrk.path("0.csv").exists());
@@ -1447,7 +1437,6 @@ fn split_filter_powershell() {
         .arg(&wrk.path("."))
         .arg("in.csv");
 
-    wrk.run(&mut cmd);
     wrk.assert_success(&mut cmd);
 
     // Check that the original CSV files were created
@@ -1475,7 +1464,6 @@ fn split_filter_powershell_cleanup() {
         .arg(&wrk.path("."))
         .arg("in.csv");
 
-    wrk.run(&mut cmd);
     wrk.assert_success(&mut cmd);
 
     // Check that the original CSV files were deleted after compression
@@ -1502,7 +1490,6 @@ fn split_filter_windows_paths() {
         .arg("copy /Y %FILE% {}.bak")
         .arg(&wrk.path("."))
         .arg("in.csv");
-    wrk.run(&mut cmd);
     wrk.assert_success(&mut cmd);
 
     // Check that the original files were created
@@ -1532,7 +1519,6 @@ fn split_filter_windows_long_paths() {
         .arg("copy /Y %FILE% {}.bak")
         .arg(&deep_dir)
         .arg("in.csv");
-    wrk.run(&mut cmd);
     wrk.assert_success(&mut cmd);
 
     // Check that the files were created in the deep directory

--- a/tests/test_sqlp.rs
+++ b/tests/test_sqlp.rs
@@ -1189,9 +1189,7 @@ fn sqlp_boston311_sql_cache_schema_decimal_override() {
         .arg("test.sql")
         .args(["--format", "jsonl", "--cache-schema"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = r#"{"latitude":"42.359","longitude":"-71.058700"}
 {"latitude":"42.363","longitude":"-71.056600"}
 {"latitude":"42.288","longitude":"-71.133000"}
@@ -1270,9 +1268,7 @@ fn sqlp_boston311_cte_gz() {
     select ward,count(*) as cnt from boston311_roxbury group by ward order by cnt desc, ward asc;"#,
     );
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["ward", "cnt"],
         svec!["Ward 11", "2"],
@@ -1912,9 +1908,7 @@ fn sqlp_length_fns() {
 "#,
     );
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec![
             "words", "n_chrs1", "n_chrs2", "n_chrs3", "n_bytes", "n_bits"
@@ -1953,9 +1947,7 @@ fn sqlp_length_fns_rnull_set_to_null() {
         )
         .args(["--rnull-values", "NULL"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec![
             "words", "n_chrs1", "n_chrs2", "n_chrs3", "n_bytes", "n_bits"
@@ -2001,9 +1993,7 @@ fn sqlp_control_flow() {
 "#,
     );
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec![
             "coalsc",
@@ -2051,9 +2041,7 @@ fn sqlp_div_sign() {
 "#,
     );
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["a_div_b", "a_floordiv_b", "b_sign"],
         svec!["-0.09950248756218906", "-1", "-1.0"],
@@ -2093,9 +2081,7 @@ fn sqlp_string_replace() {
         )
         .args(["--rnull-values", "NULL"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["words"],
         svec!["English breakfast tea is the best tea"],
@@ -2142,9 +2128,7 @@ fn sqlp_compound_join_basic() {
         )
         .arg("--truncate-ragged-lines");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["a", "b", "a:test2", "b:test2"],
         svec!["2", "3", "2", "3"],
@@ -2191,9 +2175,7 @@ fn sqlp_compound_join_diff_colnames() {
         )
         .arg("--truncate-ragged-lines");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["a", "b", "a:test2", "b:test2", "c"],
         svec!["2", "2", "2", "2", "8"],
@@ -2255,9 +2237,7 @@ fn sqlp_compound_join_three_tables() {
         )
         .arg("--truncate-ragged-lines");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["a", "b", "a:test2", "b:test2", "a:test3", "b:test3", "c"],
         svec!["2", "3", "2", "3", "2", "3", "3"],
@@ -2295,9 +2275,7 @@ fn sqlp_string_concat() {
 "#,
     );
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["c0", "c1", "c2", "c3", "c4", "c5", "c6"],
         svec!["aad", "ad1", "aad", "aad", "ad2", "a:d:1", "a!d!1"],
@@ -2357,9 +2335,7 @@ fn sqlp_string_right_reverse() {
 "#,
     );
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["l", "r", "rev"],
         svec!["ab", "de", "edcba"],
@@ -2398,9 +2374,7 @@ fn sqlp_modulo() {
 "#,
     );
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["a2", "b3", "c4", "d55"],
         svec!["1.5", "0.0", "3.0", "0.0"],
@@ -2436,9 +2410,7 @@ fn sqlp_try_cast() {
 "#,
     );
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["foo", "bar"],
         svec!["65432", "1999-12-31"],
@@ -2478,9 +2450,7 @@ fn sqlp_stddev_variance() {
 "#,
     );
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec![
             "v1_std", "v2_std", "v3_std", "v4_std", "v1_var", "v2_var", "v3_var", "v4_var"
@@ -2528,9 +2498,7 @@ fn sqlp_string_position() {
 "#,
     );
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["a_lc1", "a_uc1", "a_lc2", "a_uc2"],
         svec!["4", "0", "4", "0"],
@@ -2579,9 +2547,7 @@ fn sqlp_date_part() {
         )
         .arg("--try-parsedates");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec![
             "c1", "c2", "c3", "c4", "c5", "c6", "c61", "c62", "c63", "c7", "c8", "c9", "c10",
@@ -2654,9 +2620,7 @@ fn sqlp_date_part_tz() {
         )
         .arg("--try-parsedates");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec![
             "c1", "c2", "c3", "c4", "c5", "c6", "c61", "c62", "c63", "c7", "c8", "c9", "c10",
@@ -2764,9 +2728,7 @@ fn sqlp_date() {
             DATE('03-15-2021 10:30:20 AM EST', '%m-%d-%Y %I:%M:%S %p %Z') as c3"#,
     );
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     // this is the documented behavior of the date function
     // use STRFTIME and STRPTIME for more control
     let expected = vec![
@@ -2802,9 +2764,7 @@ fn sqlp_date_strftime() {
         )
         .arg("--try-parsedates");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["s_dtm", "s_dt", "s_tm"],
         svec!["03.06.1972/23:50:03", "July 05, 1978", "10.10.10"],
@@ -2829,9 +2789,7 @@ fn sqlp_read_jsonl() {
         .as_str(),
     );
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec![
             "case_enquiry_id",
@@ -2988,9 +2946,7 @@ fn sqlp_string_like_ops() {
         FROM likedata"#,
     );
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec![
             "x",
@@ -3050,9 +3006,7 @@ fn sqlp_natural_join() {
   ORDER BY CharacterID"#,
     );
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["CharacterID", "FirstName", "LastName", "Book", "Ship"],
         svec![
@@ -3091,9 +3045,7 @@ fn sqlp_star_ilike() {
   ORDER BY FirstName"#,
     );
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["FirstName", "LastName", "Address"],
         svec!["Bruce", "Wayne", "The Batcave"],
@@ -3111,9 +3063,7 @@ fn sqlp_star_ilike() {
   ORDER BY 3 DESC"#,
     );
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["ID", "Name", "City"],
         svec!["666", "Diana", "Themyscira"],
@@ -3131,9 +3081,7 @@ fn sqlp_star_ilike() {
   ORDER BY Name"#,
     );
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["Name", "Address"],
         svec!["Bruce", "The Batcave"],
@@ -3152,9 +3100,7 @@ fn sqlp_skip_input() {
     cmd.arg("SKIP_INPUT")
         .arg("SELECT 1 AS one, '2' AS two, 3.0 AS three");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["one", "two", "three"], svec!["1", "2", "3.0"]];
 
     assert_eq!(got, expected);
@@ -3290,9 +3236,7 @@ fn sqlp_string_function_joins() {
          STRPOS(r.val, l.val) > 0 ORDER BY l.val, r.val",
     );
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["left_val", "right_val"],
         svec!["bird", "jailbird"],
@@ -3311,9 +3255,7 @@ fn sqlp_string_function_joins() {
          STARTS_WITH(r.val, l.val) ORDER BY l.val, r.val",
     );
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["left_val", "right_val"],
         svec!["cat", "catalog"],
@@ -3329,9 +3271,7 @@ fn sqlp_string_function_joins() {
          ENDS_WITH(r.val, l.val) ORDER BY l.val, r.val",
     );
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["left_val", "right_val"],
         svec!["bird", "jailbird"],
@@ -3347,9 +3287,7 @@ fn sqlp_string_function_joins() {
          STRPOS(l.val, r.val) > 0 ORDER BY l.val, r.val",
     );
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["left_val", "right_val"]]; // Empty because no left values contain right values in our test data
     assert_eq!(got, expected);
 }
@@ -3375,9 +3313,7 @@ fn sqlp_string_to_array() {
         )
         .args(["--format", "json"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = r#"[{"id":1,"cities":["Dubai","Abu Dhabi","Sharjah"]},{"id":2,"cities":["Mumbai","Delhi","Bangalore"]}]"#;
     assert_eq!(got, expected);
 }
@@ -3406,9 +3342,7 @@ fn sqlp_split_part() {
     "#,
     );
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["s+1", "s+3", "s-2"],
         svec!["xx", "zz", "yy"],
@@ -3438,9 +3372,7 @@ fn sqlp_corr() {
         .arg("SELECT CORR(foo, bar) AS corr FROM data")
         .args(["--float-precision", "6"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["corr"], svec!["0.877809"]];
     assert_eq!(got, expected);
 }
@@ -3465,8 +3397,7 @@ fn sqlp_covar_pop() {
         .arg("SELECT COVAR(foo, bar) AS covar FROM data")
         .args(["--float-precision", "2"]);
 
-    wrk.assert_success(&mut cmd);
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![svec!["covar"], svec!["3.75"]];
     assert_eq!(got, expected);
 }
@@ -3494,9 +3425,7 @@ fn sqlp_corr_covar_covar_pop() {
         )
         .args(["--float-precision", "2"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["corr", "covar", "covar_pop"],
         svec!["0.88", "3.75", "3.00"],
@@ -3583,8 +3512,7 @@ fn sqlp_decimal_comma_validation() {
         .args(["--delimiter", ";"])
         .arg("select * from _t_1");
 
-    wrk.assert_success(&mut cmd);
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = "id,value\n\"1,\"\"100,50\"\"\"\n\"2,\"\"200,75\"\"\"";
     assert_eq!(got, expected);
 
@@ -3595,8 +3523,7 @@ fn sqlp_decimal_comma_validation() {
         .args(["--delimiter", "\t"])
         .arg("select * from _t_1");
 
-    wrk.assert_success(&mut cmd);
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = "id,value\n\"1,\"\"100,50\"\"\"\n\"2,\"\"200,75\"\"\"";
     assert_eq!(got, expected);
 
@@ -3607,8 +3534,7 @@ fn sqlp_decimal_comma_validation() {
         .args(["--delimiter", "|"])
         .arg("select * from _t_1");
 
-    wrk.assert_success(&mut cmd);
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = "id,value\n\"1,\"\"100,50\"\"\"\n\"2,\"\"200,75\"\"\"";
     assert_eq!(got, expected);
 }
@@ -3631,8 +3557,7 @@ fn sqlp_decimal_comma_validation_with_tsv_file() {
         .arg("--decimal-comma")
         .arg("select * from _t_1");
 
-    wrk.assert_success(&mut cmd);
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["id", "value"],
         svec!["1", "100,5"],
@@ -3659,8 +3584,7 @@ fn sqlp_decimal_comma_validation_with_ssv_file() {
         .arg("--decimal-comma")
         .arg("select * from _t_1");
 
-    wrk.assert_success(&mut cmd);
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = "id,value\n1,\"100,5\"\n2,\"200,75\"";
     assert_eq!(got, expected);
 }
@@ -3812,9 +3736,7 @@ fn sqlp_union_positional() {
         ) u ORDER BY Value"#,
     );
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["Value", "Tag"],
         svec!["100", "hello"],
@@ -3836,8 +3758,7 @@ fn sqlp_unnest_issue_3108_first() {
     cmd.arg("data.csv")
         .arg("select first(id) as idf, unnest(string_to_array(data, ',')) as value from data");
 
-    wrk.assert_success(&mut cmd);
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["idf", "value"],
         svec!["1", "a"],
@@ -3876,8 +3797,7 @@ fn sqlp_rank_funcs() {
         ORDER BY value, id DESC"#,
     );
 
-    wrk.assert_success(&mut cmd);
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["value", "row_num", "rank", "dense_rank"],
         svec!["10", "6", "6", "6"],
@@ -3900,8 +3820,7 @@ fn sqlp_rank_funcs() {
         FROM data
         ORDER BY value, id"#,
     );
-    wrk.assert_success(&mut cmd);
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["value", "row_num", "rank", "dense_rank"],
         svec!["10", "1", "1", "1"],
@@ -3925,8 +3844,7 @@ fn sqlp_rank_funcs() {
         FROM data
         ORDER BY category, value"#,
     );
-    wrk.assert_success(&mut cmd);
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["category", "value", "row_num", "rank", "dense"],
         svec!["A", "10", "1", "1", "1"],
@@ -3970,8 +3888,7 @@ fn sqlp_named_window_references() {
       WINDOW w AS (PARTITION BY category ORDER BY value)
       ORDER BY category, value"#,
     );
-    wrk.assert_success(&mut cmd);
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["category", "value", "w:sum", "w:min", "w:avg"],
         svec!["A", "10", "10", "10", "20.0"],
@@ -3999,8 +3916,7 @@ fn sqlp_named_window_references() {
         w3 AS ()
       ORDER BY category, value"#,
     );
-    wrk.assert_success(&mut cmd);
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec![
             "category",
@@ -4046,8 +3962,7 @@ fn sqlp_array_to_string() {
         ORDER BY a2s"#,
     );
 
-    wrk.assert_success(&mut cmd);
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["b", "a2s"],
         svec!["1", "first, first"],
@@ -4074,8 +3989,7 @@ fn sqlp_unnest_issue_3108() {
     cmd.arg("data.csv")
         .arg("select id, unnest(string_to_array(data, ',')) as value from data");
 
-    wrk.assert_success(&mut cmd);
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["id", "value"],
         svec!["1", "a"],
@@ -4115,8 +4029,7 @@ fn sqlp_distinct_basic() {
         .args(["--wnull-value", "NULL"])
         .arg("SELECT DISTINCT category FROM data ORDER BY category NULLS LAST");
 
-    wrk.assert_success(&mut cmd);
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["category"],
         svec!["A"],
@@ -4156,8 +4069,7 @@ fn sqlp_distinct_multiple_columns() {
              subcategory",
         );
 
-    wrk.assert_success(&mut cmd);
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["category", "subcategory"],
         svec!["A", "x"],
@@ -4197,8 +4109,7 @@ fn sqlp_distinct_with_nulls() {
         .args(["--wnull-value", "NULL"])
         .arg("SELECT DISTINCT category FROM data ORDER BY category NULLS FIRST");
 
-    wrk.assert_success(&mut cmd);
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["category"],
         svec!["NULL"],
@@ -4238,8 +4149,7 @@ fn sqlp_distinct_all_columns() {
              status, score",
         );
 
-    wrk.assert_success(&mut cmd);
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["category", "subcategory", "value", "status", "score"],
         svec!["A", "x", "100", "active", "10"],
@@ -4284,8 +4194,7 @@ fn sqlp_distinct_on_basic() {
              NULLS LAST, value DESC",
         );
 
-    wrk.assert_success(&mut cmd);
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["category", "value", "status"],
         svec!["A", "100", "active"],
@@ -4325,8 +4234,7 @@ fn sqlp_distinct_on_multiple_keys() {
              subcategory, score DESC",
         );
 
-    wrk.assert_success(&mut cmd);
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["category", "subcategory", "value", "status", "score"],
         svec!["A", "x", "100", "active", "20"],
@@ -4366,8 +4274,7 @@ fn sqlp_distinct_on_with_nulls() {
         .args(["--wnull-value", "NULL"])
         .arg("SELECT DISTINCT ON (category) * FROM data ORDER BY category NULLS LAST, value DESC");
 
-    wrk.assert_success(&mut cmd);
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["category", "subcategory", "value", "status", "score"],
         svec!["A", "x", "100", "active", "10"],
@@ -4412,8 +4319,7 @@ fn sqlp_distinct_on_expression() {
              LAST, value DESC",
         );
 
-    wrk.assert_success(&mut cmd);
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["category", "value"],
         svec!["A", "100"],
@@ -4453,8 +4359,7 @@ fn sqlp_distinct_with_aggregation() {
              category NULLS LAST",
         );
 
-    wrk.assert_success(&mut cmd);
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["category", "cnt"],
         svec!["A", "3"],
@@ -4494,8 +4399,7 @@ fn sqlp_distinct_on_complex_ordering() {
              NULLS LAST, value DESC, status ASC",
         );
 
-    wrk.assert_success(&mut cmd);
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec!["category", "value", "status"],
         svec!["A", "100", "active"],
@@ -4548,10 +4452,9 @@ fn sqlp_datetime_schema_inference() {
         .arg("--cardinality")
         .arg("--stats-jsonl")
         .args(["--cache-threshold", "1"]);
-    wrk.assert_success(&mut cmd);
 
     // Verify stats detected DateTime columns
-    let stats_output: String = wrk.stdout(&mut cmd);
+    let stats_output: String = wrk.stdout_on_success(&mut cmd);
     assert!(stats_output.contains("created_at,DateTime"));
     assert!(stats_output.contains("updated_at,DateTime"));
 

--- a/tests/test_stats.rs
+++ b/tests/test_stats.rs
@@ -1546,9 +1546,7 @@ fn stats_typesonly_infer_boolean_t_f() {
     let mut cmd = wrk.command("stats");
     cmd.arg("--typesonly").arg("--infer-boolean").arg(test_file);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
 
     let expected = wrk.load_test_resource("boston311-10-typesonly-boolean-tf-stats.csv");
 
@@ -1566,9 +1564,7 @@ fn stats_typesonly_infer_boolean_t_f_infer_dates() {
         .arg("--infer-dates")
         .arg(test_file);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
 
     let expected = wrk.load_test_resource("boston311-10-typesonly-boolean-tf-inferdates-stats.csv");
 
@@ -4190,9 +4186,8 @@ fn stats_issue_2668_semicolon_separator() {
 
     // should not fail, and just treat the data as a single column
     // as the default delimiter is comma, and the separator is semicolon
-    wrk.assert_success(&mut cmd);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let expected = vec![
         svec![
             "field",
@@ -4855,9 +4850,8 @@ fn stats_weighted_stddev() {
     cmd.arg("--weight").arg("weight").arg("data.csv");
 
     // Check command succeeds
-    wrk.assert_success(&mut cmd);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     assert!(!got.is_empty(), "Stats output should not be empty");
     assert!(got.len() > 1, "Should have at least one data row");
 
@@ -4906,9 +4900,8 @@ fn stats_weighted_median() {
         .arg("data.csv");
 
     // Check command succeeds
-    wrk.assert_success(&mut cmd);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     assert!(!got.is_empty(), "Stats output should not be empty");
     assert!(
         got.len() > 1,
@@ -4959,9 +4952,8 @@ fn stats_weighted_quartiles() {
         .arg("data.csv");
 
     // Check command succeeds
-    wrk.assert_success(&mut cmd);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     assert!(!got.is_empty(), "Stats output should not be empty");
     assert!(
         got.len() > 1,
@@ -5031,9 +5023,8 @@ fn stats_weighted_mad() {
         .arg("data.csv");
 
     // Check command succeeds
-    wrk.assert_success(&mut cmd);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     assert!(!got.is_empty(), "Stats output should not be empty");
     assert!(
         got.len() > 1,
@@ -5090,9 +5081,8 @@ fn stats_weighted_percentiles() {
         .arg("data.csv");
 
     // Check command succeeds
-    wrk.assert_success(&mut cmd);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     assert!(!got.is_empty(), "Stats output should not be empty");
     assert!(
         got.len() > 1,
@@ -5189,9 +5179,8 @@ fn stats_weighted_geometric_mean() {
     cmd.arg("--weight").arg("weight").arg("data.csv");
 
     // Check command succeeds
-    wrk.assert_success(&mut cmd);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     assert!(!got.is_empty(), "Stats output should not be empty");
     assert!(got.len() > 1, "Should have at least one data row");
 
@@ -5237,9 +5226,8 @@ fn stats_weighted_geometric_mean_unequal_weights() {
     cmd.arg("--weight").arg("weight").arg("data.csv");
 
     // Check command succeeds
-    wrk.assert_success(&mut cmd);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     assert!(!got.is_empty(), "Stats output should not be empty");
     assert!(got.len() > 1, "Should have at least one data row");
 
@@ -5291,9 +5279,8 @@ fn stats_weighted_harmonic_mean() {
     cmd.arg("--weight").arg("weight").arg("data.csv");
 
     // Check command succeeds
-    wrk.assert_success(&mut cmd);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     assert!(!got.is_empty(), "Stats output should not be empty");
     assert!(got.len() > 1, "Should have at least one data row");
 
@@ -5340,9 +5327,8 @@ fn stats_weighted_harmonic_mean_unequal_weights() {
     cmd.arg("--weight").arg("weight").arg("data.csv");
 
     // Check command succeeds
-    wrk.assert_success(&mut cmd);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     assert!(!got.is_empty(), "Stats output should not be empty");
     assert!(got.len() > 1, "Should have at least one data row");
 
@@ -5392,9 +5378,8 @@ fn stats_weighted_geometric_mean_zero_or_negative() {
     cmd.arg("--weight").arg("weight").arg("data.csv");
 
     // Check command succeeds
-    wrk.assert_success(&mut cmd);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     assert!(!got.is_empty(), "Stats output should not be empty");
     assert!(got.len() > 1, "Should have at least one data row");
 
@@ -5440,9 +5425,8 @@ fn stats_weighted_harmonic_mean_zero() {
     cmd.arg("--weight").arg("weight").arg("data.csv");
 
     // Check command succeeds
-    wrk.assert_success(&mut cmd);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     assert!(!got.is_empty(), "Stats output should not be empty");
     assert!(got.len() > 1, "Should have at least one data row");
 
@@ -5499,9 +5483,8 @@ fn stats_weighted_modes() {
         .arg("data.csv");
 
     // Check command succeeds
-    wrk.assert_success(&mut cmd);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     assert!(!got.is_empty(), "Stats output should not be empty");
     assert!(
         got.len() > 1,
@@ -5608,9 +5591,8 @@ fn stats_weighted_modes_multiple() {
         .arg("data.csv");
 
     // Check command succeeds
-    wrk.assert_success(&mut cmd);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     assert!(!got.is_empty(), "Stats output should not be empty");
     assert!(
         got.len() > 1,
@@ -5687,9 +5669,8 @@ fn stats_weighted_modes_cardinality() {
         .arg("data.csv");
 
     // Check command succeeds
-    wrk.assert_success(&mut cmd);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     assert!(!got.is_empty(), "Stats output should not be empty");
     assert!(
         got.len() > 1,
@@ -5781,9 +5762,8 @@ fn stats_weighted_excludes_weight_column() {
     cmd.arg("--weight").arg("weight").arg("data.csv");
 
     // Check command succeeds
-    wrk.assert_success(&mut cmd);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     assert!(!got.is_empty(), "Stats output should not be empty");
     assert!(got.len() > 1, "Should have at least one data row");
 
@@ -5921,9 +5901,8 @@ fn stats_weighted_all_zero_weights() {
     cmd.arg("--weight").arg("weight").arg("data.csv");
 
     // Command should succeed even with all zero weights
-    wrk.assert_success(&mut cmd);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     assert!(!got.is_empty(), "Stats output should not be empty");
     assert!(
         got.len() > 1,
@@ -5965,9 +5944,7 @@ fn stats_weighted_negative_weights() {
     let mut cmd = wrk.command("stats");
     cmd.arg("--weight").arg("weight").arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let headers = &got[0];
     let value_row = &got[1];
 
@@ -6002,9 +5979,7 @@ fn stats_weighted_mixed_zero_and_nonzero_weights() {
     let mut cmd = wrk.command("stats");
     cmd.arg("--weight").arg("weight").arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let headers = &got[0];
     let value_row = &got[1];
 
@@ -6039,9 +6014,8 @@ fn stats_weighted_nan_weights() {
     cmd.arg("--weight").arg("weight").arg("data.csv");
 
     // Command should succeed
-    wrk.assert_success(&mut cmd);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     assert!(!got.is_empty(), "Stats output should not be empty");
 
     let headers = &got[0];
@@ -6078,9 +6052,8 @@ fn stats_weighted_infinity_weights() {
     cmd.arg("--weight").arg("weight").arg("data.csv");
 
     // Command should succeed without overflow
-    wrk.assert_success(&mut cmd);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     assert!(!got.is_empty(), "Stats output should not be empty");
 
     let headers = &got[0];
@@ -6124,9 +6097,7 @@ fn stats_weighted_zero_weights_with_modes() {
         .arg("--mode")
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let headers = &got[0];
     let value_row = &got[1];
 
@@ -6164,9 +6135,7 @@ fn stats_weighted_negative_weights_with_quartiles() {
         .arg("--quartiles")
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     let headers = &got[0];
     let value_row = &got[1];
 
@@ -6215,9 +6184,7 @@ fn stats_weighted_mixed_edge_cases() {
         .arg("--mad")
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     assert!(!got.is_empty(), "Stats output should not be empty");
 
     let headers = &got[0];

--- a/tests/test_stats.rs
+++ b/tests/test_stats.rs
@@ -974,10 +974,6 @@ fn stats_no_rounding() {
         .arg(test_file);
 
     let got2: String = wrk.stdout(&mut cmd);
-    let got: Vec<Vec<String>> = Workdir::csv_from(&got2);
-
-    wrk.create("in2.csv", got);
-
     let expected2 = wrk.load_test_resource("boston311-100-everything-norounding-stats.csv");
 
     // this should NOT BE EQUAL as floats are not rounded, and comparing floats is not reliable
@@ -1074,10 +1070,6 @@ fn stats_with_date_inference_variance_stddev() {
         .args(["--dates-whitelist", "all"]);
 
     let got2: String = wrk.stdout_on_success(&mut cmd);
-    let got: Vec<Vec<String>> = Workdir::csv_from(&got2);
-
-    wrk.create("in2.csv", got);
-
     let expected2 =
         wrk.load_test_resource("boston311-100-everything-date-stats-variance-stddev.csv");
 

--- a/tests/test_stats.rs
+++ b/tests/test_stats.rs
@@ -973,11 +973,11 @@ fn stats_no_rounding() {
         .args(["--round", "9999"])
         .arg(test_file);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got2: String = wrk.stdout(&mut cmd);
+    let got: Vec<Vec<String>> = Workdir::csv_from(&got2);
 
     wrk.create("in2.csv", got);
 
-    let got2: String = wrk.stdout(&mut cmd);
     let expected2 = wrk.load_test_resource("boston311-100-everything-norounding-stats.csv");
 
     // this should NOT BE EQUAL as floats are not rounded, and comparing floats is not reliable
@@ -1073,13 +1073,11 @@ fn stats_with_date_inference_variance_stddev() {
         .arg("--infer-dates")
         .args(["--dates-whitelist", "all"]);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got2: String = wrk.stdout_on_success(&mut cmd);
+    let got: Vec<Vec<String>> = Workdir::csv_from(&got2);
 
     wrk.create("in2.csv", got);
 
-    let got2: String = wrk.stdout(&mut cmd);
     let expected2 =
         wrk.load_test_resource("boston311-100-everything-date-stats-variance-stddev.csv");
 

--- a/tests/test_template.rs
+++ b/tests/test_template.rs
@@ -19,10 +19,9 @@ fn template_basic() {
         .arg("template.txt")
         .arg("data.csv");
 
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = "Hello John from New York!\nHello Jane from Boston!";
 
-    wrk.assert_success(&mut cmd);
     assert_eq!(got, expected);
 }
 
@@ -38,10 +37,9 @@ fn template_no_headers() {
         .arg("data.csv")
         .arg("--no-headers");
 
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = "Name: name, Age: age\nName: John, Age: 30\nName: Jane, Age: 25";
 
-    wrk.assert_success(&mut cmd);
     assert_eq!(got, expected);
 }
 
@@ -55,10 +53,9 @@ fn template_string() {
         .arg("{{name}} is {{age}} years old\n\n")
         .arg("data.csv");
 
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = "John is 30 years old\nJane is 25 years old";
 
-    wrk.assert_success(&mut cmd);
     assert_eq!(got, expected);
 }
 
@@ -77,10 +74,9 @@ fn template_custom_delimiter() {
         .arg("data.csv")
         .args(["--delimiter", ";"]);
 
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = "Name: John, Age: 30\nName: Jane, Age: 25";
 
-    wrk.assert_success(&mut cmd);
     assert_eq!(got, expected);
 }
 
@@ -98,10 +94,9 @@ fn template_with_filters() {
         .arg("template.txt")
         .arg("data.csv");
 
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = "John: $1234.57\nJane: $9876.54";
 
-    wrk.assert_success(&mut cmd);
     assert_eq!(got, expected);
 }
 
@@ -119,10 +114,9 @@ fn template_with_conditionals() {
         .arg("template.txt")
         .arg("data.csv");
 
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = "John is a minor\nJane is an adult";
 
-    wrk.assert_success(&mut cmd);
     assert_eq!(got, expected);
 }
 
@@ -140,10 +134,9 @@ fn template_missing_field() {
         .arg("template.txt")
         .arg("data.csv");
 
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = "John (N/A)\nJane (N/A)";
 
-    wrk.assert_success(&mut cmd);
     assert_eq!(got, expected);
 }
 
@@ -158,10 +151,9 @@ fn template_empty_input() {
         .arg("template.txt")
         .arg("data.csv");
 
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = "";
 
-    wrk.assert_success(&mut cmd);
     assert_eq!(got, expected);
 }
 
@@ -183,10 +175,9 @@ fn template_with_loops() {
         .arg("template.txt")
         .arg("data.csv");
 
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = "John's hobbies: reading, gaming, cooking\nJane's hobbies: hiking, painting";
 
-    wrk.assert_success(&mut cmd);
     assert_eq!(got, expected);
 }
 
@@ -232,10 +223,9 @@ fn template_with_whitespace_control() {
         .arg("template.txt")
         .arg("data.csv");
 
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = "Items:\n  - a\n  - b\n  - c";
 
-    wrk.assert_success(&mut cmd);
     assert_eq!(got, expected);
 }
 
@@ -847,9 +837,7 @@ fn template_to_bool_filter() {
         .arg("{% if value|to_bool %}true{% else %}false{% endif %}\n\n")
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = r#"true
 true
 true
@@ -940,9 +928,7 @@ fn template_lookup_filter_simple() {
         .arg("<not found>")
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = concat!(
         "1: apple - A red fruit\n",
         "2: banana - A yellow fruit\n",
@@ -992,9 +978,7 @@ fn template_lookup_filter_invalid_field() {
         .arg("<not found>")
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = concat!(
         r#"1: apple - <not found> - lookup: "products-non_existent_column" not found for: "1"
 "#,
@@ -1017,9 +1001,7 @@ fn template_lookup_filter_errors() {
         .arg("{{id|lookup('', 'name')}}")
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     assert!(got.contains("RENDERING ERROR"));
 
     // Test missing field name
@@ -1037,9 +1019,7 @@ fn template_lookup_filter_errors() {
         .arg("{{id|lookup('non_existent lookup', 'name')}}")
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     assert_eq!(
         got,
         "<FILTER_ERROR> - lookup: \"non_existent lookup-name\" not found for: \"1\""
@@ -1158,8 +1138,7 @@ fn template_lookup_key_normalization() {
         ))
         .arg("data.csv");
 
-    wrk.assert_success(&mut cmd);
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     assert_eq!(got, "answer\ncentury\nperson");
 }
 
@@ -1355,8 +1334,7 @@ fn template_regex_replace() {
         .arg("{{ phone|regex_replace(\"[^0-9]\", \"\") }}\n\n")
         .arg("data.csv");
 
-    let got: String = wrk.stdout(&mut cmd);
-    wrk.assert_success(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     assert_eq!(got, "2125550100\n8005550199");
 }
 
@@ -1370,8 +1348,7 @@ fn template_regex_replace_captures() {
         .arg("{{ zip|regex_replace(\"([0-9]{3})([0-9]{4})$\", \"${1}-${2}\") }}\n\n")
         .arg("data.csv");
 
-    let got: String = wrk.stdout(&mut cmd);
-    wrk.assert_success(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     assert_eq!(got, "212555-0100");
 }
 
@@ -1388,8 +1365,7 @@ fn template_regex_match_and_find() {
         )
         .arg("data.csv");
 
-    let got: String = wrk.stdout(&mut cmd);
-    wrk.assert_success(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     assert_eq!(got, "OK 123\nNO");
 }
 
@@ -1404,8 +1380,7 @@ fn template_floor_ceil() {
         .arg("data.csv");
 
     // floor/ceil return floats; pipe |int (next test) for clean integers.
-    let got: String = wrk.stdout(&mut cmd);
-    wrk.assert_success(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     assert_eq!(got, "42.0/43.0\n42.0/43.0");
 }
 
@@ -1419,8 +1394,7 @@ fn template_floor_ceil_int() {
         .arg("{{ v|floor|int }}/{{ v|ceil|int }}\n\n")
         .arg("data.csv");
 
-    let got: String = wrk.stdout(&mut cmd);
-    wrk.assert_success(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     assert_eq!(got, "42/43");
 }
 
@@ -1446,8 +1420,7 @@ fn template_floor_ceil_large_integers() {
         .arg("{{ v|floor }}/{{ v|ceil }}\n\n")
         .arg("data.csv");
 
-    let got: String = wrk.stdout(&mut cmd);
-    wrk.assert_success(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = values
         .iter()
         .map(|v| format!("{v}/{v}"))
@@ -1504,8 +1477,7 @@ fn template_datefmt() {
         .arg("{{ d|datefmt(\"%Y-%m-%d\") }}\n\n")
         .arg("data.csv");
 
-    let got: String = wrk.stdout(&mut cmd);
-    wrk.assert_success(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     assert_eq!(got, "2022-03-04\n2022-03-04");
 }
 
@@ -1519,8 +1491,7 @@ fn template_datefmt_prefer_dmy() {
         .arg("{{ d|datefmt(\"%Y-%m-%d\", true) }}\n\n")
         .arg("data.csv");
 
-    let got: String = wrk.stdout(&mut cmd);
-    wrk.assert_success(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     assert_eq!(got, "2022-04-03");
 }
 
@@ -1534,8 +1505,7 @@ fn template_padding() {
         .arg("[{{ v|zfill(5) }}][{{ v|lpad(5) }}][{{ v|rpad(5, \"*\") }}]\n\n")
         .arg("data.csv");
 
-    let got: String = wrk.stdout(&mut cmd);
-    wrk.assert_success(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     assert_eq!(got, "[00042][   42][42***]");
 }
 
@@ -1549,8 +1519,7 @@ fn template_slugify() {
         .arg("{{ title|slugify }}\n\n")
         .arg("data.csv");
 
-    let got: String = wrk.stdout(&mut cmd);
-    wrk.assert_success(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     assert_eq!(got, "nyc-311-data");
 }
 
@@ -1564,8 +1533,7 @@ fn template_blake3() {
         .arg("{{ v|blake3 }}\n\n")
         .arg("data.csv");
 
-    let got: String = wrk.stdout(&mut cmd);
-    wrk.assert_success(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let lines: Vec<&str> = got.lines().collect();
     assert_eq!(lines.len(), 3);
     // deterministic + 64-char hex digest
@@ -1585,8 +1553,7 @@ fn template_fromjson() {
         .arg("{{ (j|fromjson).a }}-{{ (j|parse_json).b }}\n\n")
         .arg("data.csv");
 
-    let got: String = wrk.stdout(&mut cmd);
-    wrk.assert_success(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     assert_eq!(got, "1-2");
 }
 
@@ -1600,8 +1567,7 @@ fn template_coalesce() {
         .arg("{{ coalesce(a, b, \"fallback\") }}\n\n")
         .arg("data.csv");
 
-    let got: String = wrk.stdout(&mut cmd);
-    wrk.assert_success(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     assert_eq!(got, "x\nfallback");
 }
 

--- a/tests/test_to.rs
+++ b/tests/test_to.rs
@@ -40,10 +40,8 @@ fn to_xlsx_roundtrip() {
     let mut cmd = wrk.command("excel");
     cmd.arg(xlsx_file);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     assert_eq!(got, thedata);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -76,10 +74,8 @@ fn to_xlsx_roundtrip_all_strings() {
     let mut cmd = wrk.command("excel");
     cmd.arg(xlsx_file);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     assert_eq!(got, thedata);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -121,18 +117,14 @@ fn to_xlsx_dir() {
     let mut cmd = wrk.command("excel");
     cmd.arg(xlsx_file.clone()).args(["--sheet", "cities"]);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     assert_eq!(got, cities);
-
-    wrk.assert_success(&mut cmd);
 
     let mut cmd = wrk.command("excel");
     cmd.arg(xlsx_file).args(["--sheet", "places"]);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     assert_eq!(got, places);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -166,9 +158,7 @@ fn to_datapackage() {
         .arg(generateddp_json_filename.clone())
         .arg("in.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected: String = r#"Table 'in' (8 rows)
 
 Field Name   Field Type  Field Format
@@ -473,10 +463,8 @@ fn to_ods_roundtrip() {
     let mut cmd = wrk.command("excel");
     cmd.arg(ods_file);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     assert_eq!(got, thedata);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]
@@ -515,19 +503,15 @@ fn to_ods_dir() {
     let mut cmd = wrk.command("excel");
     cmd.arg(ods_file.clone()).args(["--sheet", "file1"]);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     assert_eq!(got, file1_data);
-
-    wrk.assert_success(&mut cmd);
 
     // Verify the content of the second sheet
     let mut cmd = wrk.command("excel");
     cmd.arg(ods_file).args(["--sheet", "file2"]);
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
     assert_eq!(got, file2_data);
-
-    wrk.assert_success(&mut cmd);
 }
 
 #[test]

--- a/tests/test_tojsonl.rs
+++ b/tests/test_tojsonl.rs
@@ -20,9 +20,7 @@ fn tojsonl_simple() {
     let mut cmd = wrk.command("tojsonl");
     cmd.arg("in.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = r#"{"id":1,"father":"Mark","mother":"Charlotte","oldest_child":"Tom","boy":true,"weight":150.2}
 {"id":2,"father":"John","mother":"Ann","oldest_child":"Jessika","boy":false,"weight":175.5}
 {"id":3,"father":"Bob","mother":"Monika","oldest_child":"Jerry","boy":true,"weight":199.5}"#;
@@ -49,9 +47,7 @@ fn tojsonl_2579() {
     let mut cmd = wrk.command("tojsonl");
     cmd.arg("in.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = r#"{"Date":"1937-01-01","Product":"Milk","Unit":"1 gallon","Price":0.1}
 {"Date":"1937-01-01","Product":"Bread","Unit":"1 loaf","Price":0.09}
 {"Date":"1937-01-01","Product":"Movie ticket","Unit":"1 ticket","Price":0.25}
@@ -560,9 +556,7 @@ fn tojsonl_number_empty_field_is_null() {
     let mut cmd = wrk.command("tojsonl");
     cmd.arg("in.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = r#"{"id":1,"weight":150.2}
 {"id":2,"weight":null}
 {"id":3,"weight":199.5}"#;
@@ -591,9 +585,7 @@ fn tojsonl_number_non_finite_is_null() {
     let mut cmd = wrk.command("tojsonl");
     cmd.arg("in.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = r#"{"id":1,"magnitude":1.5}
 {"id":2,"magnitude":null}
 {"id":3,"magnitude":null}
@@ -624,9 +616,7 @@ fn tojsonl_number_nan_infinity_literal_is_null() {
     let mut cmd = wrk.command("tojsonl");
     cmd.arg("in.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = r#"{"id":1,"score":1.5}
 {"id":2,"score":null}
 {"id":3,"score":null}
@@ -654,9 +644,7 @@ fn tojsonl_4410() {
     let mut cmd = wrk.command("tojsonl");
     cmd.arg("in.csv");
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = r#"{"a":1,"":2,"c":3}
 {"a":4,"":5,"c":6}"#;
     assert_eq!(got, expected);
@@ -717,9 +705,8 @@ fn tojsonl_4410_legacy_cache_missing_field_key() {
     // the consumer must load that cache and still map the empty header correctly
     let mut cmd = wrk.command("tojsonl");
     cmd.arg("in.csv");
-    wrk.assert_success(&mut cmd);
 
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = r#"{"a":1,"":2,"c":3}
 {"a":4,"":5,"c":6}"#;
     assert_eq!(got, expected);

--- a/tests/test_transpose.rs
+++ b/tests/test_transpose.rs
@@ -59,7 +59,7 @@ fn transpose_long_format() {
     let mut cmd = wrk.command("transpose");
     cmd.args(["--long", "1"]).arg("in.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
 
     // Expected long format: field, attribute, value
     // Empty values should be skipped
@@ -75,7 +75,6 @@ fn transpose_long_format() {
         svec!["age", "max", "53"],
     ];
 
-    wrk.assert_success(&mut cmd);
     assert_eq!(got, expected);
 }
 
@@ -91,12 +90,11 @@ fn transpose_long_format_empty_csv() {
     let mut cmd = wrk.command("transpose");
     cmd.args(["--long", "1"]).arg("in.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
 
     // Should only have headers, no data rows
     let expected = vec![svec!["field", "attribute", "value"]];
 
-    wrk.assert_success(&mut cmd);
     assert_eq!(got, expected);
 }
 
@@ -115,12 +113,11 @@ fn transpose_long_format_all_empty() {
     let mut cmd = wrk.command("transpose");
     cmd.args(["--long", "1"]).arg("in.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
 
     // Should only have headers, all values were empty and skipped
     let expected = vec![svec!["field", "attribute", "value"]];
 
-    wrk.assert_success(&mut cmd);
     assert_eq!(got, expected);
 }
 
@@ -136,12 +133,11 @@ fn transpose_long_format_single_column() {
     let mut cmd = wrk.command("transpose");
     cmd.args(["--long", "1"]).arg("in.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
 
     // Should only have headers, no attribute columns to process
     let expected = vec![svec!["field", "attribute", "value"]];
 
-    wrk.assert_success(&mut cmd);
     assert_eq!(got, expected);
 }
 
@@ -186,7 +182,7 @@ fn transpose_long_format_by_name() {
     let mut cmd = wrk.command("transpose");
     cmd.args(["--long", "field"]).arg("in.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
 
     let expected = vec![
         svec!["field", "attribute", "value"],
@@ -198,7 +194,6 @@ fn transpose_long_format_by_name() {
         svec!["age", "value", "25"],
     ];
 
-    wrk.assert_success(&mut cmd);
     assert_eq!(got, expected);
 }
 
@@ -218,7 +213,7 @@ fn transpose_long_format_by_index() {
     let mut cmd = wrk.command("transpose");
     cmd.args(["--long", "2"]).arg("in.csv"); // Select second column (1-based index)
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
 
     // Expected: second column (field) selected as field column
     let expected = vec![
@@ -231,7 +226,6 @@ fn transpose_long_format_by_index() {
         svec!["age", "value", "25"],
     ];
 
-    wrk.assert_success(&mut cmd);
     assert_eq!(got, expected);
 }
 
@@ -251,7 +245,7 @@ fn transpose_long_format_by_range() {
     let mut cmd = wrk.command("transpose");
     cmd.args(["--long", "2-3"]).arg("in.csv"); // Select columns 2-3 as field columns
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
 
     // Expected: columns 2-3 (category, field) concatenated with | separator
     let expected = vec![
@@ -264,7 +258,6 @@ fn transpose_long_format_by_range() {
         svec!["person|age", "value", "25"],
     ];
 
-    wrk.assert_success(&mut cmd);
     assert_eq!(got, expected);
 }
 
@@ -284,7 +277,7 @@ fn transpose_long_format_by_range_to_end() {
     let mut cmd = wrk.command("transpose");
     cmd.args(["--long", "2-"]).arg("in.csv"); // Select from column 2 to end
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
 
     // Expected: columns 2-4 (category, field, type) concatenated with | separator
     let expected = vec![
@@ -293,7 +286,6 @@ fn transpose_long_format_by_range_to_end() {
         svec!["person|age|Integer", "id", "2"],
     ];
 
-    wrk.assert_success(&mut cmd);
     assert_eq!(got, expected);
 }
 
@@ -313,7 +305,7 @@ fn transpose_long_format_by_regex() {
     let mut cmd = wrk.command("transpose");
     cmd.args(["--long", "/^field/"]).arg("in.csv"); // Select columns starting with "field"
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
 
     // Expected: field_name and field_type concatenated with | separator
     let expected = vec![
@@ -324,7 +316,6 @@ fn transpose_long_format_by_regex() {
         svec!["age|Integer", "value", "25"],
     ];
 
-    wrk.assert_success(&mut cmd);
     assert_eq!(got, expected);
 }
 
@@ -344,7 +335,7 @@ fn transpose_long_format_multiple_fields_by_name() {
     let mut cmd = wrk.command("transpose");
     cmd.args(["--long", "category,field"]).arg("in.csv"); // Select multiple columns by name
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
 
     // Expected: category and field concatenated with | separator
     let expected = vec![
@@ -357,7 +348,6 @@ fn transpose_long_format_multiple_fields_by_name() {
         svec!["person|age", "value", "25"],
     ];
 
-    wrk.assert_success(&mut cmd);
     assert_eq!(got, expected);
 }
 
@@ -377,7 +367,7 @@ fn transpose_long_format_multiple_fields_by_index() {
     let mut cmd = wrk.command("transpose");
     cmd.args(["--long", "2,3"]).arg("in.csv"); // Select multiple columns by index
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
 
     // Expected: columns 2 and 3 (category, field) concatenated with | separator
     let expected = vec![
@@ -390,7 +380,6 @@ fn transpose_long_format_multiple_fields_by_index() {
         svec!["person|age", "value", "25"],
     ];
 
-    wrk.assert_success(&mut cmd);
     assert_eq!(got, expected);
 }
 
@@ -473,12 +462,11 @@ fn transpose_long_format_all_columns_as_fields() {
     let mut cmd = wrk.command("transpose");
     cmd.args(["--long", "1-3"]).arg("in.csv"); // Select all columns as fields
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
 
     // Expected: only headers, no attribute columns to process
     let expected = vec![svec!["field", "attribute", "value"]];
 
-    wrk.assert_success(&mut cmd);
     assert_eq!(got, expected);
 }
 
@@ -498,7 +486,7 @@ fn transpose_long_format_quoted_column_name() {
     let mut cmd = wrk.command("transpose");
     cmd.args(["--long", r#""field name""#]).arg("in.csv"); // Select quoted column name with space
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
 
     // Expected: "field name" column selected as field column
     let expected = vec![
@@ -511,7 +499,6 @@ fn transpose_long_format_quoted_column_name() {
         svec!["age", "value", "25"],
     ];
 
-    wrk.assert_success(&mut cmd);
     assert_eq!(got, expected);
 }
 
@@ -533,12 +520,11 @@ fn transpose_select_by_index() {
     let mut cmd = wrk.command("transpose");
     cmd.args(["--select", "1,3"]).arg("in.csv"); // Select columns 1 and 3 (a and c)
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
 
     // Expected: only columns a and c transposed
     let expected = vec![svec!["a", "1", "4"], svec!["c", "3", "6"]];
 
-    wrk.assert_success(&mut cmd);
     assert_eq!(got, expected);
 }
 
@@ -558,12 +544,11 @@ fn transpose_select_by_name() {
     let mut cmd = wrk.command("transpose");
     cmd.args(["--select", "a,c"]).arg("in.csv"); // Select columns a and c by name
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
 
     // Expected: only columns a and c transposed
     let expected = vec![svec!["a", "1", "4"], svec!["c", "3", "6"]];
 
-    wrk.assert_success(&mut cmd);
     assert_eq!(got, expected);
 }
 
@@ -583,12 +568,11 @@ fn transpose_select_by_range() {
     let mut cmd = wrk.command("transpose");
     cmd.args(["--select", "2-3"]).arg("in.csv"); // Select columns 2-3 (b and c)
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
 
     // Expected: only columns b and c transposed
     let expected = vec![svec!["b", "2", "6"], svec!["c", "3", "7"]];
 
-    wrk.assert_success(&mut cmd);
     assert_eq!(got, expected);
 }
 
@@ -608,12 +592,11 @@ fn transpose_select_by_regex() {
     let mut cmd = wrk.command("transpose");
     cmd.args(["--select", "/^val/"]).arg("in.csv"); // Select columns starting with "val"
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
 
     // Expected: only columns val_a and val_b transposed
     let expected = vec![svec!["val_a", "1", "4"], svec!["val_b", "2", "5"]];
 
-    wrk.assert_success(&mut cmd);
     assert_eq!(got, expected);
 }
 
@@ -633,12 +616,11 @@ fn transpose_select_multipass() {
     let mut cmd = wrk.command("transpose");
     cmd.args(["--multipass", "--select", "a,c"]).arg("in.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
 
     // Expected: only columns a and c transposed
     let expected = vec![svec!["a", "1", "4"], svec!["c", "3", "6"]];
 
-    wrk.assert_success(&mut cmd);
     assert_eq!(got, expected);
 }
 
@@ -660,7 +642,7 @@ fn transpose_select_long_format() {
     cmd.args(["--long", "id", "--select", "val1,val3"])
         .arg("in.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
 
     // Expected: only val1 and val3 become attribute rows
     let expected = vec![
@@ -671,7 +653,6 @@ fn transpose_select_long_format() {
         svec!["2", "val3", "60"],
     ];
 
-    wrk.assert_success(&mut cmd);
     assert_eq!(got, expected);
 }
 
@@ -692,7 +673,7 @@ fn transpose_select_long_format_by_range() {
     // Select columns 3-5 (val1, val2, val3) as attributes, use id as field column
     cmd.args(["--long", "id", "--select", "3-5"]).arg("in.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
 
     // Expected: val1, val2, val3 become attribute rows (name excluded)
     let expected = vec![
@@ -705,7 +686,6 @@ fn transpose_select_long_format_by_range() {
         svec!["2", "val3", "60"],
     ];
 
-    wrk.assert_success(&mut cmd);
     assert_eq!(got, expected);
 }
 
@@ -759,12 +739,11 @@ fn transpose_select_single_column() {
     let mut cmd = wrk.command("transpose");
     cmd.args(["--select", "b"]).arg("in.csv"); // Select only column b
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
 
     // Expected: only column b transposed
     let expected = vec![svec!["b", "2", "5"]];
 
-    wrk.assert_success(&mut cmd);
     assert_eq!(got, expected);
 }
 
@@ -785,7 +764,7 @@ fn transpose_long_format_mixed_empty_values() {
     let mut cmd = wrk.command("transpose");
     cmd.args(["--long", "1"]).arg("in.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
 
     let expected = vec![
         svec!["field", "attribute", "value"],
@@ -795,7 +774,6 @@ fn transpose_long_format_mixed_empty_values() {
         svec!["age", "max", "53"],
     ];
 
-    wrk.assert_success(&mut cmd);
     assert_eq!(got, expected);
 }
 
@@ -850,7 +828,7 @@ fn transpose_select_all_columns() {
     let mut cmd = wrk.command("transpose");
     cmd.args(["--select", "1-"]).arg("in.csv"); // Select all columns (1 to end)
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
 
     // Expected: same as regular transpose
     let expected = vec![
@@ -859,7 +837,6 @@ fn transpose_select_all_columns() {
         svec!["c", "3", "6"],
     ];
 
-    wrk.assert_success(&mut cmd);
     assert_eq!(got, expected);
 }
 

--- a/tests/test_validate.rs
+++ b/tests/test_validate.rs
@@ -587,7 +587,7 @@ fn validate_adur_public_toilets_dataset_with_json_schema() {
     let mut cmd = wrk.command("validate");
     cmd.arg("data.csv").arg("schema.json");
 
-    wrk.output(&mut cmd);
+    wrk.assert_err(&mut cmd);
 
     // check invalid file output
     let invalid_output: String = wrk.from_str(&wrk.path("data.csv.invalid"));
@@ -597,7 +597,6 @@ fn validate_adur_public_toilets_dataset_with_json_schema() {
 
     let validation_error_output: String = wrk.from_str(&wrk.path("data.csv.validation-errors.tsv"));
     assert_eq!(adur_errors(), validation_error_output);
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]
@@ -677,7 +676,7 @@ fn validate_adur_public_toilets_dataset_with_json_schema_url() {
     let mut cmd = wrk.command("validate");
     cmd.arg("data.csv").arg("https://raw.githubusercontent.com/dathere/qsv/master/resources/test/public-toilets-schema.json");
 
-    wrk.output(&mut cmd);
+    wrk.assert_err(&mut cmd);
 
     let invalid_output: String = wrk.from_str(&wrk.path("data.csv.invalid"));
     assert_eq!(adur_invalids().to_string(), invalid_output);
@@ -685,7 +684,6 @@ fn validate_adur_public_toilets_dataset_with_json_schema_url() {
     // check validation error output
     let validation_error_output: String = wrk.from_str(&wrk.path("data.csv.validation-errors.tsv"));
     assert_eq!(adur_errors(), validation_error_output);
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]
@@ -735,8 +733,6 @@ fn validate_dynenum_with_column() {
     // Run validate command
     let mut cmd = wrk.command("validate");
     cmd.arg("data.csv").arg("schema.json");
-    wrk.output(&mut cmd);
-
     wrk.assert_err(&mut cmd);
 
     // Check validation-errors.tsv
@@ -757,8 +753,6 @@ fn validate_dynenum_with_column() {
     let invalid_records: Vec<Vec<String>> = wrk.read_csv("data.csv.invalid");
     let expected_invalid = vec![svec!["3", "Orange", "fruit"], svec!["4", "Grape", "fruit"]];
     assert_eq!(invalid_records, expected_invalid);
-
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]
@@ -808,8 +802,6 @@ fn validate_dynenum_with_column_index() {
     // Run validate command
     let mut cmd = wrk.command("validate");
     cmd.arg("data.csv").arg("schema.json");
-    wrk.output(&mut cmd);
-
     wrk.assert_err(&mut cmd);
 
     // Check validation-errors.tsv
@@ -829,8 +821,6 @@ fn validate_dynenum_with_column_index() {
     let invalid_records: Vec<Vec<String>> = wrk.read_csv("data.csv.invalid");
     let expected_invalid = vec![svec!["2", "vegetable", "D4"], svec!["4", "fruit", "X9"]];
     assert_eq!(invalid_records, expected_invalid);
-
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]
@@ -915,8 +905,6 @@ fn validate_dynenum_with_remote_csv() {
     // Run validate command
     let mut cmd = wrk.command("validate");
     cmd.arg("data.csv").arg("schema.json");
-    wrk.output(&mut cmd);
-
     wrk.assert_err(&mut cmd);
 
     // Check validation-errors.tsv
@@ -938,8 +926,6 @@ fn validate_dynenum_with_remote_csv() {
     let invalid_records: Vec<Vec<String>> = wrk.read_csv("data.csv.invalid");
     let expected_invalid = vec![svec!["2", "mango"], svec!["4", "dragonfruit"]];
     assert_eq!(invalid_records, expected_invalid);
-
-    wrk.assert_err(&mut cmd);
 }
 
 #[cfg(feature = "lite")]
@@ -1098,8 +1084,6 @@ fn validate_unique_combined_with() {
     // Run validate command
     let mut cmd = wrk.command("validate");
     cmd.arg("data.csv").arg("schema.json");
-    wrk.output(&mut cmd);
-
     wrk.assert_err(&mut cmd);
 
     // Check validation-errors.tsv
@@ -1128,8 +1112,6 @@ fn validate_unique_combined_with() {
         svec!["5", "Jane Smith", "jane@example.com", "HR"],
     ];
     assert_eq!(invalid_records, expected_invalid);
-
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]
@@ -1168,8 +1150,6 @@ fn validate_unique_combined_with_indices() {
     // Run validate command
     let mut cmd = wrk.command("validate");
     cmd.arg("data.csv").arg("schema.json");
-    wrk.output(&mut cmd);
-
     wrk.assert_err(&mut cmd);
 
     // Check validation-errors.tsv
@@ -1198,8 +1178,6 @@ fn validate_unique_combined_with_indices() {
         svec!["5", "Jane Smith", "jane@example.com", "HR"],
     ];
     assert_eq!(invalid_records, expected_invalid);
-
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]
@@ -1238,8 +1216,6 @@ fn validate_unique_combined_with_both_names_and_indices() {
     // Run validate command
     let mut cmd = wrk.command("validate");
     cmd.arg("data.csv").arg("schema.json");
-    wrk.output(&mut cmd);
-
     wrk.assert_err(&mut cmd);
 
     // Check validation-errors.tsv
@@ -1268,8 +1244,6 @@ fn validate_unique_combined_with_both_names_and_indices() {
         svec!["5", "Jane Smith", "jane@example.com", "HR"],
     ];
     assert_eq!(invalid_records, expected_invalid);
-
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]
@@ -1318,8 +1292,6 @@ fn validate_unique_combined_with_empty_values() {
     // Run validate command
     let mut cmd = wrk.command("validate");
     cmd.arg("data.csv").arg("schema.json");
-    wrk.output(&mut cmd);
-
     wrk.assert_err(&mut cmd);
 
     // Check validation-errors.tsv
@@ -1345,8 +1317,6 @@ fn validate_unique_combined_with_empty_values() {
     let invalid_records: Vec<Vec<String>> = wrk.read_csv("data.csv.invalid");
     let expected_invalid = vec![svec!["5", "", "", "HR"]];
     assert_eq!(invalid_records, expected_invalid);
-
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]
@@ -1385,8 +1355,6 @@ fn validate_unique_combined_with_special_chars() {
     // Run validate command
     let mut cmd = wrk.command("validate");
     cmd.arg("data.csv").arg("schema.json");
-    wrk.output(&mut cmd);
-
     wrk.assert_err(&mut cmd);
 
     // Check validation-errors.tsv
@@ -1415,8 +1383,6 @@ fn validate_unique_combined_with_special_chars() {
         svec!["5", "Jane-Smith", "jane.smith@example.com", "HR"],
     ];
     assert_eq!(invalid_records, expected_invalid);
-
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]
@@ -1475,8 +1441,6 @@ fn validate_dynenum_with_multiple_columns() {
     // Run validate command
     let mut cmd = wrk.command("validate");
     cmd.arg("data.csv").arg("schema.json");
-    wrk.output(&mut cmd);
-
     wrk.assert_err(&mut cmd);
 
     // Check validation-errors.tsv
@@ -1502,8 +1466,6 @@ fn validate_dynenum_with_multiple_columns() {
     let invalid_records: Vec<Vec<String>> = wrk.read_csv("data.csv.invalid");
     let expected_invalid = vec![svec!["3", "Orange", "fruit", "active"]];
     assert_eq!(invalid_records, expected_invalid);
-
-    wrk.assert_err(&mut cmd);
 }
 
 #[cfg(not(feature = "lite"))]
@@ -1552,8 +1514,6 @@ fn validate_dynenum_with_caching() {
     // Run validate command
     let mut cmd = wrk.command("validate");
     cmd.arg("data.csv").arg("schema.json");
-    wrk.output(&mut cmd);
-
     wrk.assert_err(&mut cmd);
 
     // Check validation-errors.tsv
@@ -1574,8 +1534,6 @@ fn validate_dynenum_with_caching() {
     let invalid_records: Vec<Vec<String>> = wrk.read_csv("data.csv.invalid");
     let expected_invalid = vec![svec!["2", "Orange"]];
     assert_eq!(invalid_records, expected_invalid);
-
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]
@@ -1658,8 +1616,6 @@ fn validate_unique_combined_with_mixed_names_and_indices() {
     // Run validate command
     let mut cmd = wrk.command("validate");
     cmd.arg("data.csv").arg("schema.json");
-    wrk.output(&mut cmd);
-
     wrk.assert_err(&mut cmd);
 
     // Check validation-errors.tsv
@@ -1693,8 +1649,6 @@ fn validate_unique_combined_with_mixed_names_and_indices() {
         svec!["5", "Jane Smith", "jane@example.com", "HR", "Manager"],
     ];
     assert_eq!(invalid_records, expected_invalid);
-
-    wrk.assert_err(&mut cmd);
 }
 
 #[test]
@@ -1752,8 +1706,6 @@ fn validate_no_format_validation() {
     // First, run validation WITH format validation (default behavior)
     let mut cmd = wrk.command("validate");
     cmd.arg("data.csv").arg("schema.json");
-    wrk.output(&mut cmd);
-
     wrk.assert_err(&mut cmd);
 
     // Check that format validation errors are present
@@ -1811,8 +1763,6 @@ fn validate_json_schema_file() {
     // Run validate command
     let mut cmd = wrk.command("validate");
     cmd.arg("schema").arg("schema.json");
-    wrk.output(&mut cmd);
-
     wrk.assert_success(&mut cmd);
 }
 
@@ -2166,8 +2116,6 @@ fn validate_with_no_format_validation_success() {
     // Run validation WITH format validation (should fail)
     let mut cmd_with_format = wrk.command("validate");
     cmd_with_format.arg("data.csv").arg("schema.json");
-    wrk.output(&mut cmd_with_format);
-
     wrk.assert_err(&mut cmd_with_format);
 
     // Check that format validation errors are present
@@ -2240,8 +2188,6 @@ fn validate_with_no_format_validation_mixed_errors() {
     // Run validation WITH format validation
     let mut cmd_with_format = wrk.command("validate");
     cmd_with_format.arg("data.csv").arg("schema.json");
-    wrk.output(&mut cmd_with_format);
-
     wrk.assert_err(&mut cmd_with_format);
 
     // Should have both format and type errors
@@ -2262,8 +2208,6 @@ fn validate_with_no_format_validation_mixed_errors() {
         .arg("--no-format-validation")
         .arg("data.csv")
         .arg("schema.json");
-    wrk.output(&mut cmd_no_format);
-
     wrk.assert_err(&mut cmd_no_format);
 
     // Should only have type errors, no format errors
@@ -2406,8 +2350,6 @@ fn validate_with_no_format_validation_and_dynamic_enum() {
     // Run validation WITH format validation
     let mut cmd_with_format = wrk.command("validate");
     cmd_with_format.arg("data.csv").arg("schema.json");
-    wrk.output(&mut cmd_with_format);
-
     wrk.assert_err(&mut cmd_with_format);
 
     // Should have both dynamicEnum and format errors
@@ -2428,8 +2370,6 @@ fn validate_with_no_format_validation_and_dynamic_enum() {
         .arg("--no-format-validation")
         .arg("data.csv")
         .arg("schema.json");
-    wrk.output(&mut cmd_no_format);
-
     wrk.assert_err(&mut cmd_no_format);
 
     // Should only have dynamicEnum errors, no format errors
@@ -2906,8 +2846,6 @@ fn validate_with_email_format_strict_default() {
     // Run validation WITH format validation (default - strict format validation)
     let mut cmd = wrk.command("validate");
     cmd.arg("data.csv").arg("schema.json");
-    wrk.output(&mut cmd);
-
     wrk.assert_err(&mut cmd);
 
     // Check that format validation errors are present
@@ -2986,8 +2924,6 @@ fn validate_with_email_format_strict_email_options() {
         .arg("--email-domain-literal")
         .arg("data.csv")
         .arg("schema.json");
-    wrk.output(&mut cmd);
-
     wrk.assert_err(&mut cmd);
 
     // Check that format validation errors are present
@@ -3028,8 +2964,6 @@ fn validate_with_email_format_strict_email_options() {
         .args(["--email-min-subdomains", "3"])
         .arg("data.csv")
         .arg("schema.json");
-    wrk.output(&mut cmd);
-
     wrk.assert_err(&mut cmd);
 
     // Check that format validation errors are present
@@ -3102,8 +3036,6 @@ fn validate_with_hostname_format_strict() {
     // Run validation WITH format validation (default - strict format validation)
     let mut cmd = wrk.command("validate");
     cmd.arg("data.csv").arg("schema.json");
-    wrk.output(&mut cmd);
-
     wrk.assert_err(&mut cmd);
 
     // Check that format validation errors are present
@@ -3169,8 +3101,6 @@ fn validate_with_ipv4_format_strict() {
     // Run validation WITH format validation (default - strict format validation)
     let mut cmd = wrk.command("validate");
     cmd.arg("data.csv").arg("schema.json");
-    wrk.output(&mut cmd);
-
     wrk.assert_err(&mut cmd);
 
     // Check that format validation errors are present
@@ -3237,8 +3167,6 @@ fn validate_with_ipv6_format_strict() {
     // Run validation WITH format validation (default - strict format validation)
     let mut cmd = wrk.command("validate");
     cmd.arg("data.csv").arg("schema.json");
-    wrk.output(&mut cmd);
-
     wrk.assert_err(&mut cmd);
 
     // Check that format validation errors are present
@@ -3352,8 +3280,6 @@ fn validate_with_multiple_formats_strict() {
     // Run validation WITH format validation (default - strict format validation)
     let mut cmd = wrk.command("validate");
     cmd.arg("data.csv").arg("schema.json");
-    wrk.output(&mut cmd);
-
     wrk.assert_err(&mut cmd);
 
     // Check that format validation errors are present for each format type

--- a/tests/test_validate.rs
+++ b/tests/test_validate.rs
@@ -25,9 +25,7 @@ fn validate_good_tab() {
     let mut cmd = wrk.command("validate");
     cmd.arg(tabfile);
 
-    wrk.assert_success(&mut cmd);
-
-    let got: String = wrk.stdout(&mut cmd);
+    let got: String = wrk.stdout_on_success(&mut cmd);
     let expected = r#"Valid: 29 Columns: ("case_enquiry_id", "open_dt", "target_dt", "closed_dt", "ontime", "case_status", "closure_reason", "case_title", "subject", "reason", "type", "queue", "department", "submittedphoto", "closedphoto", "location", "fire_district", "pwd_district", "city_council_district", "police_district", "neighborhood", "neighborhood_services_district", "ward", "precinct", "location_street_name", "location_zipcode", "latitude", "longitude", "source"); Records: 100; Delimiter: TAB"#;
     assert_eq!(got, expected);
 }

--- a/tests/workdir.rs
+++ b/tests/workdir.rs
@@ -124,6 +124,13 @@ impl Workdir {
         Csv::from_vecs(records)
     }
 
+    /// Parse an already-captured stdout string as CSV. Use when a test needs the
+    /// same run's stdout in BOTH forms — the raw text and the rows — so it does
+    /// not have to run the command twice to get them.
+    pub fn csv_from<T: Csv>(stdout: &str) -> T {
+        Self::csv_from_stdout(stdout.as_bytes())
+    }
+
     /// Parse captured stdout bytes as `T`. Note the trailing CR/LF trim —
     /// assertions comparing against literals depend on it, so every variant
     /// must go through here rather than parsing the bytes directly.
@@ -254,6 +261,14 @@ impl Workdir {
     /// parseable CSV, silently masking the failure.
     pub fn read_stdout_on_success<T: Csv>(&self, cmd: &mut process::Command) -> T {
         let o = self.run_once(cmd, Some(true));
+        Self::csv_from_stdout(&o.stdout)
+    }
+
+    /// Run `cmd`, assert it exited with a non-zero status, and return its stdout
+    /// parsed as CSV. For commands that emit partial output and THEN fail — the
+    /// rows and the failure must come from the same run to mean anything.
+    pub fn read_stdout_on_error<T: Csv>(&self, cmd: &mut process::Command) -> T {
+        let o = self.run_once(cmd, Some(false));
         Self::csv_from_stdout(&o.stdout)
     }
 

--- a/tests/workdir.rs
+++ b/tests/workdir.rs
@@ -124,13 +124,6 @@ impl Workdir {
         Csv::from_vecs(records)
     }
 
-    /// Parse an already-captured stdout string as CSV. Use when a test needs the
-    /// same run's stdout in BOTH forms — the raw text and the rows — so it does
-    /// not have to run the command twice to get them.
-    pub fn csv_from<T: Csv>(stdout: &str) -> T {
-        Self::csv_from_stdout(stdout.as_bytes())
-    }
-
     /// Parse captured stdout bytes as `T`. Note the trailing CR/LF trim —
     /// assertions comparing against literals depend on it, so every variant
     /// must go through here rather than parsing the bytes directly.


### PR DESCRIPTION
Follow-on to #4415 / #4422 / #4423 / #4424, which eliminated every site where **stderr** came from a different run than the asserted status. This is the same defect class **without** stderr — and it is ~5× bigger. **`scripts/double-run-check.py` now reports 0 remaining sites.**

## What this PR changes

30 sites where the command ran two or three times, the first run's output **discarded entirely**:

```rust
wrk.output(&mut cmd);        // run #1, result thrown away
...file assertions...
wrk.assert_err(&mut cmd);    // run #2, the one actually asserted
```

11 of the 30 ran it three times (two trailing `assert_err` calls).

**The wasted run is not simply deletable.** It is the run whose side effects the file assertions in between observe — deleting it would move execution after those assertions and they would pass vacuously, which is exactly the failure roborev caught in #4423. Instead the surviving `assert_*` call takes the first run's position and the later ones are removed: execution stays put, and the exit status is now asserted on the run that actually produced the files.

**41 executions removed** — 27 sites in `test_validate`, 3 in `test_schema`.

## The rest of the sweep

| batch | sites | fix |
|---|---|---|
| `assert_success` + `read_stdout` / `stdout` | 448 | `read_stdout_on_success` / `stdout_on_success` — **already existed** |
| wasted `wrk.run(&mut cmd)` before `assert_success` | 14 | deleted |
| line forms the first pass's regex missed (`let mut`, trailing `// DevSkim:`, duplicate trailing assert) | 16 | same helpers |
| ordering hazards, hand-converted | 8 | see below |
| `wrk.output(..)` discarded then re-run (this PR's first commit) | 30 | assert takes the discarded run's place |

No new helper was needed for the bulk: `read_stdout_on_success` and `stdout_on_success` already existed and their doc comments describe this exact defect. One small addition: `read_stdout_on_error` (test_jsonl asserts on rows emitted BEFORE a failure).

## The 8 ordering hazards

Each anchored at its **original** execution point, so nothing that observes the command's side effects moved ahead of it:

- **test_extdedup ×3** — the discarded first run is the one that writes the deduped file the assertions read, so it is *bound* rather than deleted, and the later `wrk.output` (kept only for stderr) goes away.
- **test_stats ×2** — read stdout as CSV, wrote it to an unused `in2.csv`, then ran **again** to get the same stdout as a String. Now one run, and the dead `in2.csv` writes are gone: the 12 sibling tests that write `in2.csv` all follow with a second `stats` run over it, these two never did. Removing them also removed the only need for the rows alongside the raw stdout, so the `Workdir::csv_from` helper added for them is gone too.
- **test_luau, test_snappy ×2, test_schema** — trailing `assert_success` on a command already run for its data.

## A real bug this surfaced

`generate_schema_with_defaults_and_validate_trim_with_no_errors` ended with `wrk.assert_success(&mut cmd)` — but `cmd` is the **schema** command, not the `cmd3` **validate** command the surrounding block tests. So `validate --trim`'s exit status was never asserted, and the schema command was re-run for nothing. It now asserts `cmd3`, in the position the discarded run occupied.

## Three analyzer bugs, all caught before merge

**Braces inside string literals** (found via roborev 4283). Brace counting ran over the raw source, so the braces in a fixture like `let expected = r#"[{"case_enquiry_id":...}]"#;` were counted as blocks — corrupting block identity for the rest of the function and silently hiding real sites. **Six double-run sites were invisible this way** (five in `test_excel`, plus `search_indexed_parallel_json`, which runs `search --json` twice). The script now blanks literal and comment *contents* before counting braces, preserving line structure; raw strings with any number of hashes are handled. An earlier commit's "0 sites" was therefore overstated by six — it is now 0 with a scan that can see them.


Both fixed in `scripts/double-run-check.py`, and both would have caused a *wrong* conversion in a less careful pass:

- **if/else arms sit at the same brace depth.** Depth alone called `test_slice::test_slice` a double run — `assert_success` in the `--json` arm, `read_stdout` in the `else`. Each line's enclosing **block** is now identified. Same story for `slice_float_precision`, whose second `cmd` is a `std::process::Command::new("gzip")` that the binding regex missed for its `std::` prefix.
- **Some tests run a command twice on purpose.** `test_fetch`'s disk-cache test exists to prove the *second* request hits the cache. Those now opt out with `// double-run-check: intentional`, so the invariant can be enforced without lying about it.

## Verification

| config | unit | integration | failed |
|---|---|---|---|
| `all_features` | 973 | 3687 (65 ignored) | 0 |
| `lite` | 113 | 2204 (11 ignored) | 0 |
| `datapusher_plus` | 503 | 2462 (39 ignored) | 0 |
| `qsvmcp` | 958 | 3390 (42 ignored) | 0 |

Plus `test_py` under `-F all_features,python` (19 passed). Every converted file was also run individually so a failure would be attributable to one file's conversion. `cargo clippy --tests -F all_features` clean, `cargo +nightly fmt` applied.

~530 fewer `qsv` process spawns per suite run; the `all_features` integration run went from ~185s to ~169s locally (single sample, so treat the timing as indicative, not a benchmark).


