### PR TITLE
ci: gate on the double-run check

### DIFF
--- a/.github/workflows/double-run-check.yml
+++ b/.github/workflows/double-run-check.yml
@@ -1,0 +1,58 @@
+# Double-run check — fails when an integration test runs one qsv command more
+# than once and asserts across those separate executions.
+#
+# Each tests/workdir.rs helper spawns the binary, so a test that calls two of
+# them on the same `Command` gets its exit status from one run and its output
+# from another:
+#
+#     wrk.assert_success(&mut cmd);                           // run #1: status
+#     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);  // run #2: data
+#
+# Either direction can be masked — a run that succeeds while emitting the wrong
+# data, or a second run that fails yet still emits parseable output. Issue #4415
+# and PRs #4422/#4423/#4424/#4425 removed ~750 such sites; this keeps the count
+# at zero rather than letting it grow back.
+#
+# A test that runs one command twice ON PURPOSE (caching, idempotence, indexed
+# vs unindexed) opts out with `// double-run-check: intentional -- <why>`.
+#
+# Triggers:
+#   - PRs touching the tests, the helpers they call, the script, or this file
+#   - Nightly cron (catches sites introduced by pushes that bypassed a PR)
+#   - Manual workflow_dispatch
+
+name: Double-run check
+
+on:
+  schedule:
+    - cron: '23 5 * * *'   # nightly @ 05:23 UTC
+  pull_request:
+    paths:
+      - 'tests/**'
+      - 'scripts/double-run-check.py'
+      - '.github/workflows/double-run-check.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: double-run-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
+
+      # stdlib-only; no pip install needed. Runs in well under a second.
+      - name: Run double-run-check
+        run: python3 scripts/double-run-check.py --check

--- a/scripts/double-run-check.py
+++ b/scripts/double-run-check.py
@@ -91,8 +91,10 @@ BIND_RE = re.compile(
 )
 FN_RE = re.compile(r"fn (\w+)\(")
 MUT_RE = re.compile(r"\.\s*(args?|envs?|env_remove|env_clear|current_dir|stdin)\s*\(")
-# start of a method-call statement: `cmd.arg(..)`, and its `.arg(..)` continuations
+# start of a method-call statement: `cmd.arg(..)`, `cmd` alone on its own line
+# (a common style here — 182 occurrences in tests/), and `.arg(..)` continuations
 RECEIVER_RE = re.compile(r"^\s*(\w+)\s*\.")
+BARE_RECEIVER_RE = re.compile(r"^\s*(\w+)\s*$")
 CONTINUATION_RE = re.compile(r"^\s*\.")
 # statements whose meaning depends on whether the command has run yet
 HAZARD_RE = re.compile(
@@ -193,12 +195,18 @@ def mutates(var, code_lines):
     The receiver matters: an intervening `other.arg("x")` on a DIFFERENT command
     says nothing about `var`, and treating it as though it did would exempt a
     real double run of `var` from the gate. Builder chains split across lines
-    (`cmd.args([..])\\n    .arg("x");`) keep the receiver of the line that
-    started the statement.
+    keep the receiver of the line that started the statement, in both styles
+    used here:
+
+        cmd.args([..])          cmd
+            .arg("x");             .arg("x");
+
+    Missing the second style would leave the `.arg()` unattributed and report a
+    site that IS two different commands, i.e. a spurious CI failure.
     """
     receiver = None
     for line in code_lines:
-        if m := RECEIVER_RE.match(line):
+        if m := RECEIVER_RE.match(line) or BARE_RECEIVER_RE.match(line):
             receiver = m.group(1)
         elif not CONTINUATION_RE.match(line):
             receiver = None

--- a/scripts/double-run-check.py
+++ b/scripts/double-run-check.py
@@ -15,13 +15,17 @@ data, or a second run that fails yet still emits parseable output. The `*_on_suc
 This script finds the sites that still don't.
 
 Usage:
-    scripts/double-run-check.py [--json] [--hazards] [PATH ...]
+    scripts/double-run-check.py [--json] [--hazards] [--check] [PATH ...]
 
     (no flags)  summary counts by shape and by file
     --json      one JSON object per site on stdout, for scripted conversion
     --hazards   only sites where converting could change WHEN the command runs
+    --check     CI gate: print offending sites and exit 1 if any need action
 
-Exit status is 0 regardless of findings; this is a reporting tool, not a gate.
+Without --check the exit status is always 0 — it reports, it does not gate.
+With --check it exits 1 when any site needs action. Sites whose two runs are
+separated by an `.arg()`/`.env()` call are deliberately two different commands,
+so they are listed as informational and do NOT fail the check.
 
 Two classes of finding must NOT be blindly converted, and are reported separately:
 
@@ -246,11 +250,54 @@ def scan(path):
             }
 
 
+def rel(path, root):
+    """Repo-relative path, falling back to the raw path for anything outside it."""
+    r = os.path.relpath(path, root)
+    return path if r.startswith("..") else r
+
+
+def gate(sites, root):
+    """CI mode: report actionable sites and return 1 if there are any."""
+    actionable = [s for s in sites if not s["mutated"]]
+    informational = [s for s in sites if s["mutated"]]
+
+    for s in informational:
+        print(
+            f"note: {rel(s['file'], root)}:{s['line']} {s['fn']} runs "
+            f"`{s['var']}` {s['runs']}x with an arg/env change between them — "
+            "treated as two different commands"
+        )
+    if not actionable:
+        print(f"OK: no test asserts on more than one run of the same command ({len(sites)} noted)")
+        return 0
+
+    for s in actionable:
+        why = "ordering hazard: " + s["hazard"][0] if s["hazard"] else "collapse to a single run"
+        print(
+            f"{rel(s['file'], root)}:{s['line']}: {s['fn']} runs `{s['var']}` "
+            f"{s['runs']}x ({' + '.join(sorted(set(s['runners'])))}) — {why}"
+        )
+    print(
+        f"\n{len(actionable)} site(s) run one command more than once, so the exit status,\n"
+        "stdout and stderr being asserted come from DIFFERENT executions.\n"
+        "Use the single-run helpers in tests/workdir.rs (read_stdout_on_success,\n"
+        "stdout_on_success, stderr_on_error, *_and_stderr_*), anchoring the run at the\n"
+        "EARLIEST original execution point. If a test means to run twice, say so with\n"
+        "`// double-run-check: intentional -- <why>` in the test function."
+    )
+    return 1
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__.split("\n")[1])
     ap.add_argument("paths", nargs="*", default=None)
     ap.add_argument("--json", action="store_true", help="emit one JSON object per site")
     ap.add_argument("--hazards", action="store_true", help="only ordering-hazard sites")
+    ap.add_argument(
+        "--check",
+        action="store_true",
+        help="CI gate: list offending sites and exit 1 if any need action",
+    )
     args = ap.parse_args()
 
     root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -264,6 +311,9 @@ def main():
         for s in sites:
             print(json.dumps(s))
         return
+
+    if args.check:
+        return gate(sites, root)
 
     convertible = [s for s in sites if not s["mutated"] and not s["hazard"]]
     print(f"double-run sites:            {len(sites)}")
@@ -279,7 +329,7 @@ def main():
         print(f"  {n:4d}  {' + '.join(shape)}")
     print("\nby file:")
     for f, n in collections.Counter(s["file"] for s in sites).most_common():
-        print(f"  {n:4d}  {os.path.relpath(f, root)}")
+        print(f"  {n:4d}  {rel(f, root)}")
 
 
 if __name__ == "__main__":

--- a/scripts/double-run-check.py
+++ b/scripts/double-run-check.py
@@ -23,14 +23,19 @@ Usage:
     --check     CI gate: print offending sites and exit 1 if any need action
 
 Without --check the exit status is always 0 — it reports, it does not gate.
-With --check it exits 1 when any site needs action. Sites whose two runs are
-separated by an `.arg()`/`.env()` call are deliberately two different commands,
-so they are listed as informational and do NOT fail the check.
+With --check it exits 1 when any site needs action; combining it with --json
+keeps stdout parseable and still returns that status. Sites where the SAME
+command variable is reconfigured (`.arg()`/`.env()`/...) between its runs are
+deliberately two different commands, so they are listed as informational and do
+NOT fail the check — a mutation of some OTHER command in between does not
+exempt anything.
 
 Two classes of finding must NOT be blindly converted, and are reported separately:
 
-  * `mutated`  — a `.arg()` / `.env()` call sits between the two runs, so they
-    are deliberately two different commands.
+  * `mutated`  — THAT command variable is reconfigured (`.arg()` / `.env()` /
+    ...) between the two runs, so they are deliberately two different commands.
+    The receiver is checked: an intervening `other.arg(..)` on a different
+    command does not exempt anything.
   * `hazard`   — a statement between the two runs observes or alters state
     (`.exists()`, `read_to_string`, `wrk.create*`, `std::fs::`). Collapsing to a
     single run moves WHEN the command executes relative to that statement. The
@@ -86,6 +91,9 @@ BIND_RE = re.compile(
 )
 FN_RE = re.compile(r"fn (\w+)\(")
 MUT_RE = re.compile(r"\.\s*(args?|envs?|env_remove|env_clear|current_dir|stdin)\s*\(")
+# start of a method-call statement: `cmd.arg(..)`, and its `.arg(..)` continuations
+RECEIVER_RE = re.compile(r"^\s*(\w+)\s*\.")
+CONTINUATION_RE = re.compile(r"^\s*\.")
 # statements whose meaning depends on whether the command has run yet
 HAZARD_RE = re.compile(
     r"\.exists\(\)|read_to_string|read_csv|wrk\.path\(|wrk\.from_str|load_test"
@@ -179,6 +187,26 @@ def blank_literals(src):
     return "".join(out)
 
 
+def mutates(var, code_lines):
+    """True if `var` itself is reconfigured (.arg/.env/...) within `code_lines`.
+
+    The receiver matters: an intervening `other.arg("x")` on a DIFFERENT command
+    says nothing about `var`, and treating it as though it did would exempt a
+    real double run of `var` from the gate. Builder chains split across lines
+    (`cmd.args([..])\\n    .arg("x");`) keep the receiver of the line that
+    started the statement.
+    """
+    receiver = None
+    for line in code_lines:
+        if m := RECEIVER_RE.match(line):
+            receiver = m.group(1)
+        elif not CONTINUATION_RE.match(line):
+            receiver = None
+        if receiver == var and MUT_RE.search(line):
+            return True
+    return False
+
+
 def scan(path):
     """Yield one dict per command variable that is run more than once in a test fn."""
     raw = open(path, encoding="utf-8").read()
@@ -235,6 +263,9 @@ def scan(path):
             if any(blocks[k] != blocks[first] for k, _ in evs):
                 continue
             between = body[first + 1 : last]
+            # match on the literal-blanked copy so a ".arg(" inside a fixture
+            # string is not read as a real reconfiguration
+            between_code = code_lines[start + first + 1 : start + last]
             names = [n for _, n in evs]
             yield {
                 "file": path,
@@ -245,7 +276,7 @@ def scan(path):
                 "runners": names,
                 "runs": len(evs),
                 "reads_data": bool({n for n in names} - STATUS),
-                "mutated": bool(MUT_RE.search("\n".join(between))),
+                "mutated": mutates(var, between_code),
                 "hazard": [b.strip()[:100] for b in between if HAZARD_RE.search(b)],
             }
 
@@ -310,7 +341,9 @@ def main():
     if args.json:
         for s in sites:
             print(json.dumps(s))
-        return
+        # --check governs the exit status even here; the human-readable gate
+        # report is suppressed so stdout stays parseable as JSON lines
+        return 1 if args.check and any(not s["mutated"] for s in sites) else 0
 
     if args.check:
         return gate(sites, root)


### PR DESCRIPTION
#4415 and PRs #4422 / #4423 / #4424 / #4425 removed ~750 sites where a test asserted a command's exit status, stdout or stderr across **separate executions** of that command. Nothing keeps the count at zero — the next test written in the old shape quietly restores the defect. This wires the existing `scripts/double-run-check.py` into CI.

## The `--check` flag

```
$ scripts/double-run-check.py --check
OK: no test asserts on more than one run of the same command (0 noted)
```

and when something regresses:

```
tests/test_jsonl.rs:86: jsonl_simple_ignore_error runs `cmd` 2x (assert_success + read_stdout) — collapse to a single run

1 site(s) run one command more than once, so the exit status,
stdout and stderr being asserted come from DIFFERENT executions.
Use the single-run helpers in tests/workdir.rs (read_stdout_on_success,
stdout_on_success, stderr_on_error, *_and_stderr_*), anchoring the run at the
EARLIEST original execution point. If a test means to run twice, say so with
`// double-run-check: intentional -- <why>` in the test function.
```

Without `--check` the script still always exits 0 — it reports, it doesn't gate. Only `--check` returns non-zero, so the exit-code contract is explicit and runnable locally.

## What does NOT fail the check

- **Two genuinely different commands.** A site whose runs are separated by an `.arg()` / `.env()` call is printed as a `note:` and does not fail.
- **Deliberate double runs.** `// double-run-check: intentional -- <why>` anywhere in the test function opts it out. `test_fetch`'s disk-cache test is the current user — its whole point is that the second request hits the cache.

## Workflow

Modeled on `docs-drift.yml`: PRs touching `tests/**`, the script, or the workflow itself; plus a nightly cron at an off-peak minute for pushes that bypass a PR; plus `workflow_dispatch`. Python-stdlib only, no `pip install`, runs in ~0.3s.

## Verification

Both directions, against the real tree rather than a synthetic fixture:

- as-is → `exit=0`
- a double run reintroduced into `tests/test_jsonl.rs` → `exit=1`, naming the file, line, function and shape
- the opted-out test in the same run → listed as a note, does not fail

Only `scripts/double-run-check.py` (new `--check` mode) and the new workflow file change; no test or source file is touched.