### PR TITLE
fix(stats): panic, UB, and tempfile-leak fixes (stats.rs review, Batch A)

### DIFF
--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -6022,18 +6022,17 @@ impl TypedMinMax {
                     });
 
                     let (min_str, max_str) = if let Some(max_len) = *max_length {
-                        (
-                            if min_str.len() > max_len {
-                                format!("{}...", &min_str[..max_len])
-                            } else {
-                                min_str
-                            },
-                            if max_str.len() > max_len {
-                                format!("{}...", &max_str[..max_len])
-                            } else {
-                                max_str
-                            },
-                        )
+                        // Truncate on a char boundary at or below max_len. Slicing at a raw
+                        // byte index panics when the min/max value is multibyte UTF-8.
+                        let truncate_at_boundary = |mut s: String| -> String {
+                            if s.len() > max_len {
+                                let boundary = s.floor_char_boundary(max_len);
+                                s.truncate(boundary);
+                                s.push_str("...");
+                            }
+                            s
+                        };
+                        (truncate_at_boundary(min_str), truncate_at_boundary(max_str))
                     } else {
                         (min_str, max_str)
                     };
@@ -6067,7 +6066,12 @@ impl TypedMinMax {
                     Some((
                         itoa::Buffer::new().format(*min).to_owned(),
                         itoa::Buffer::new().format(*max).to_owned(),
-                        itoa::Buffer::new().format(*max - *min).to_owned(),
+                        // subtract in i128: a column spanning more than i64::MAX
+                        // (e.g. i64::MIN..=i64::MAX) overflows a raw i64 subtraction,
+                        // which panics under overflow-checks and wraps to -1 in release
+                        itoa::Buffer::new()
+                            .format(i128::from(*max) - i128::from(*min))
+                            .to_owned(),
                         sort_order.to_string(),
                         util::round_num(sortiness, round_places),
                     ))

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -1427,6 +1427,12 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             .keep()
             .or(Err("Cannot keep temporary file".to_string()))?;
 
+        // Take ownership of cleanup the instant keep() disables the tempfile's own
+        // auto-delete. The delimiter sniffing below seeks and reads the file, and an
+        // error from either would otherwise return before the guard existed - leaking
+        // the very spill this guard is here to reap.
+        stdin_tempfile_guard = Some(StdinTempFile(tempfile_path.clone()));
+
         // Only infer delimiter if QSV_DEFAULT_DELIMITER is not set
         if std::env::var("QSV_DEFAULT_DELIMITER").is_err() {
             // Seek to start of file before reading
@@ -1471,7 +1477,6 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             }
         }
 
-        stdin_tempfile_guard = Some(StdinTempFile(tempfile_path.clone()));
         args.arg_input = Some(tempfile_path.to_string_lossy().to_string());
         rconfig.path = Some(tempfile_path);
     } else {

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -1154,6 +1154,26 @@ fn try_enable_approx_sketches(
 /// * Handles CSV parsing errors gracefully
 /// * Manages temporary file creation and cleanup
 /// * Provides detailed error messages for configuration issues
+/// RAII guard for the temp file that stdin is spilled to.
+///
+/// Removing the file on Drop guarantees cleanup on *every* exit path from `run()`.
+/// There are a dozen fallible operations between the spill and the end of the run
+/// (sniffing, compute, flush, cache install); an early return from any of them used
+/// to leak a full copy of stdin - which for a piped multi-GB input filled the disk.
+///
+/// Only the path is held, deliberately: the write handle must still be dropped before
+/// any reader re-opens the path by name (Windows/ARM64 deadlocks otherwise).
+struct StdinTempFile(PathBuf);
+
+impl Drop for StdinTempFile {
+    fn drop(&mut self) {
+        if std::fs::remove_file(&self.0).is_err() {
+            // fails silently if it can't remove the temp file
+            log::warn!("Could not remove stdin temp file: {}", self.0.display());
+        }
+    }
+}
+
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let mut args: Args = util::get_args(USAGE, argv)?;
 
@@ -1389,7 +1409,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
     // infer delimiter when we're getting input from stdin
     // as the stats engine needs to know the delimiter or it will panic
-    let mut stdin_tempfile_path = None;
+    let mut stdin_tempfile_guard: Option<StdinTempFile> = None;
     if rconfig.is_stdin() {
         // read from stdin and write to a temp file
         log::info!("Reading from stdin");
@@ -1433,21 +1453,25 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             let inferred = if tab_count > 0
                 || (space_groups > 2 && comma_count == 0 && semicolon_count == 0)
             {
-                "\t"
+                b'\t'
             } else if semicolon_count > 0 && semicolon_count >= comma_count {
-                ";"
+                b';'
             } else {
-                ","
+                b','
             };
 
-            // Set QSV_DEFAULT_DELIMITER environment variable
-            // this is only for the current process. When qsv exits, it will not persist
-            // safety: we wrap the set_var in an unsafe block because it's an unsafe function,
-            // as it assumes a single-threaded environment, which we still are at this point
-            unsafe { std::env::set_var("QSV_DEFAULT_DELIMITER", inferred) };
+            // Thread the inferred delimiter through args rather than mutating the
+            // process environment. rconfig() applies flag_delimiter to every Config
+            // it builds, so this reaches the stats engine exactly the way the
+            // QSV_DEFAULT_DELIMITER env var did - without an unsafe global mutation
+            // that is UB if any other thread reads the environment concurrently.
+            // An explicit --delimiter always wins.
+            if args.flag_delimiter.is_none() {
+                args.flag_delimiter = Some(Delimiter(inferred));
+            }
         }
 
-        stdin_tempfile_path = Some(tempfile_path.clone());
+        stdin_tempfile_guard = Some(StdinTempFile(tempfile_path.clone()));
         args.arg_input = Some(tempfile_path.to_string_lossy().to_string());
         rconfig.path = Some(tempfile_path);
     } else {
@@ -1858,10 +1882,11 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         .flag_dates_whitelist_raw
         .clone_from(&args.flag_dates_whitelist);
 
-    if let Some(pb) = stdin_tempfile_path {
-        // remove the temp file we created to store stdin
-        std::fs::remove_file(pb)?;
-    }
+    // remove the temp file we created to store stdin. Dropping the guard here keeps
+    // the removal at exactly the same point as before on the success path, while the
+    // guard itself still cleans up on any early return above. Removal is best-effort:
+    // an externally-reaped temp file must not fail a run whose stats already succeeded.
+    drop(stdin_tempfile_guard);
 
     let mut currstats_filename = if compute_stats {
         // we computed the stats, use the stats temp file

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -2299,16 +2299,15 @@ impl Args {
             let (send, args, sel) = (send.clone(), Arc::clone(&args), sel.clone());
             let weight_idx: Option<usize> = weight_col_idx;
             pool.execute(move || {
-                // safety: indexed() is safe as we know we have an index file
-                // and we know it will return an Ok
-                // arguably, there is still a very small risk of a TOCTOU here,
-                // but it's unlikely
-                let mut idx = unsafe {
-                    args.rconfig()
-                        .indexed()
-                        .unwrap_unchecked()
-                        .unwrap_unchecked()
-                };
+                // The parent verified the index exists before chunking, but it can be
+                // deleted or invalidated in between (TOCTOU) - notably by a concurrent
+                // run cleaning up its autoindex. Fail loudly with actionable info like
+                // the seek() below, rather than hitting undefined behavior.
+                let mut idx = args
+                    .rconfig()
+                    .indexed()
+                    .expect("Failed to re-open index for parallel stats.")
+                    .expect("Index is no longer available for parallel stats.");
                 // safety: seek() is safe as we know we have an index file
                 // we do an expect() here so that it triggers a human-panic
                 // with some actionable info if the index is corrupted
@@ -2319,14 +2318,13 @@ impl Args {
                 // chunk_size doubles as the capacity hint: each worker only ever
                 // accumulates one chunk's worth of values, so hinting the full
                 // file row count here would balloon RSS x nchunks.
-                // safety: send will only return an Error if the channel has been disconnected
-                unsafe {
-                    send.send((
-                        i,
-                        args.compute(&sel, &mut idx, chunk_size, chunk_size, weight_idx),
-                    ))
-                    .unwrap_unchecked();
-                }
+                // send only fails if the receiver is already gone, in which case the
+                // merge loop has ended and there is nobody left to hand this chunk to.
+                // Drop it deliberately instead of relying on an unchecked unwrap.
+                let _ = send.send((
+                    i,
+                    args.compute(&sel, &mut idx, chunk_size, chunk_size, weight_idx),
+                ));
             });
         }
         drop(send);

--- a/tests/test_stats.rs
+++ b/tests/test_stats.rs
@@ -7647,3 +7647,64 @@ fn stats_invalid_zip_with_skip_format_check_does_not_error() {
     cmd.env("QSV_SKIP_FORMAT_CHECK", "1").arg("bad.zip");
     wrk.assert_success(&mut cmd);
 }
+
+#[test]
+fn stats_string_max_length_multibyte_utf8() {
+    // Regression: QSV_STATS_STRING_MAX_LENGTH truncated min/max by slicing at a raw byte
+    // index, which panics when that index lands inside a multibyte character.
+    let wrk = Workdir::new("stats_string_max_length_multibyte_utf8");
+    wrk.create(
+        "data.csv",
+        vec![svec!["jp"], svec!["日本語テキスト"], svec!["zzz"]],
+    );
+
+    // 4 falls inside the 3-byte "日" / "本" boundary - the panic case
+    let mut cmd = wrk.command("stats");
+    cmd.arg("data.csv").env("QSV_STATS_STRING_MAX_LENGTH", "4");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+
+    // field,type,is_ascii,sum,min,max -> max is index 5
+    let mut max_value = String::new();
+    for row in &got {
+        if !row.is_empty() && row[0] == "jp" && row.len() > 5 {
+            max_value = row[5].clone();
+            break;
+        }
+    }
+
+    // truncated on a char boundary at or below 4 bytes, not mid-character
+    assert_eq!(max_value, "日...");
+}
+
+#[test]
+fn stats_integer_range_no_i64_overflow() {
+    // Regression: range was computed as max - min in i64, which overflows for a column
+    // spanning more than i64::MAX - panicking under overflow-checks and wrapping to -1
+    // in release builds. It is now computed in i128.
+    let wrk = Workdir::new("stats_integer_range_no_i64_overflow");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["n"],
+            svec!["-9223372036854775808"],
+            svec!["9223372036854775807"],
+        ],
+    );
+
+    let mut cmd = wrk.command("stats");
+    cmd.arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+
+    // field,type,is_ascii,sum,min,max,range -> range is index 6
+    let mut range_value = String::new();
+    for row in &got {
+        if !row.is_empty() && row[0] == "n" && row.len() > 6 {
+            range_value = row[6].clone();
+            break;
+        }
+    }
+
+    assert_eq!(range_value, "18446744073709551615");
+}

--- a/tests/test_stats.rs
+++ b/tests/test_stats.rs
@@ -7662,7 +7662,9 @@ fn stats_string_max_length_multibyte_utf8() {
     let mut cmd = wrk.command("stats");
     cmd.arg("data.csv").env("QSV_STATS_STRING_MAX_LENGTH", "4");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    // on_success: the regression being guarded is a panic, so a clean exit is as much
+    // the assertion as the truncated value itself
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
 
     // field,type,is_ascii,sum,min,max -> max is index 5
     let mut max_value = String::new();
@@ -7695,7 +7697,9 @@ fn stats_integer_range_no_i64_overflow() {
     let mut cmd = wrk.command("stats");
     cmd.arg("data.csv");
 
-    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    // on_success: the regression being guarded is an overflow panic, so a clean exit is
+    // as much the assertion as the range value itself
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
 
     // field,type,is_ascii,sum,min,max,range -> range is index 6
     let mut range_value = String::new();


### PR DESCRIPTION
First batch from a whole-file review of `src/cmd/stats.rs`. Five localized correctness
fixes, each independently verified. **No cache-schema or consumer-visible behavior
changes** — the stats-cache validity cluster is deliberately held back for a separate PR,
since it needs a sidecar-lifecycle design pass rather than piecemeal patches.

Three commits, each of which builds on its own.

## What's fixed

| Commit | Fix |
|---|---|
| `605fcb8` | **Multibyte UTF-8 panic** — `QSV_STATS_STRING_MAX_LENGTH` truncated min/max by slicing at a raw byte index. Now cuts on a char boundary, mirroring the antimodes path that already did this correctly. |
| `605fcb8` | **i64 range overflow** — the integer range computed `max - min` in i64, which panics under overflow-checks and silently wraps to `-1` in release for a column spanning more than `i64::MAX`. Now subtracts in i128; `range` is consumed as `f64` downstream, so nothing else changes. |
| `7989ae2` | **TOCTOU with UB as the failure mode** — each parallel worker re-opened the index via `indexed().unwrap_unchecked().unwrap_unchecked()`. An index deleted between the parent's check and worker execution was undefined behavior rather than an error. Now `expect()`, matching the `seek().expect()` on the very next line. Runs once per chunk, not per row — no hot-loop cost. |
| `e2ecf29` | **`unsafe env::set_var` removed** — stdin delimiter inference mutated the process environment. Now threaded through `args.flag_delimiter`, which `rconfig()` applies to every `Config` it builds, so it reaches the engine by the same route with no global mutation. |
| `e2ecf29` | **stdin tempfile leak + spurious error** — the spill file leaked on ~13 early-return paths, while the cleanup itself used `?`, so an externally-reaped temp file could fail a run whose stats were already computed and cached. Now an RAII guard, with best-effort removal. |

## Notes for reviewers

**The tempfile guard holds only the path, not a live `NamedTempFile`.** That is deliberate:
a live `NamedTempFile` keeps its write handle open for the whole run, which conflicts with
releasing the handle before a reader re-opens the path by name (Windows/ARM64). The
original code scoped `preview_file` inside the `is_stdin()` block for the same reason.
`drop(guard)` sits at the previous removal point, so success-path timing is unchanged; the
guard only adds cleanup on the error paths.

**Leak severity, corrected.** The tempfile leak is user-visible only in builds *without*
the `polars` feature. `util::log_end` does `remove_dir_all(TEMP_FILE_DIR)` and is called on
every dispatch arm, but it is `#[cfg(feature = "polars")]`, and `lite = []` — so it is
compiled out of **qsvlite**, which does ship `stats`. Verified empirically on the same
command: before, the spill remained; after, it does not. The spurious-error half affected
every build.

**Ragged-CSV `unwrap_unchecked` intentionally left alone.** The review also flagged the
`read_byte_record().unwrap_unchecked()` in the per-row loop. That is the hot loop and qsv
assumes valid CSV (a pre-existing, documented invariant), so it is out of scope here by
design, not by oversight.

## Verification

- `cargo t stats -F all_features` — **831 passed, 0 failed**, identical to the pre-change baseline
- `cargo test -F lite` — **2204 passed, 0 failed**
- consumers: `schema` 63, `frequency` 186, `tojsonl` 28 — all 0 failed
- `cargo clippy -F all_features --bin qsv` — no new warnings
- `cargo +nightly fmt` applied; the diff contains only these five fixes

Repros confirming each fix, before and after:

```sh
# multibyte truncation: was a panic, now emits a boundary-safe prefix
QSV_STATS_STRING_MAX_LENGTH=4 qsv stats japanese.csv

# i64 range: was a debug panic / release -1, now 18446744073709551615
printf 'n\n-9223372036854775808\n9223372036854775807\n' | qsv stats

# tempfile leak (qsvlite): temp dir held the spill before, is empty after
printf 'a,b\n1,2\n' | TMPDIR=/tmp/t qsvlite stats --select nosuchcol; find /tmp/t -type f
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
