### PR TITLE
fix(stats): stats-cache validity cluster (Batch B of the stats.rs review)

### DIFF
--- a/docs/contributor/STATS_QUICK_REFERENCE.md
+++ b/docs/contributor/STATS_QUICK_REFERENCE.md
@@ -10,7 +10,7 @@ The `stats` command in qsv is a high-performance CSV statistics engine that:
 - **Computes up to 48 summary statistics** per column (beyond the `field`/`type` identifiers)
 
 ## File Location
-`src/cmd/stats.rs` (~6,052 lines)
+`src/cmd/stats.rs` (~6,320 lines)
 
 ## Key Entry Points
 
@@ -175,7 +175,7 @@ Bob,25,87.2" | ./target/release/qsv stats
 - Full technical guide: `STATS_TECHNICAL_GUIDE.md` (this repo)
 - qsv wiki: https://github.com/dathere/qsv/wiki
 - stats command docs: `/docs/PERFORMANCE.md`
-- Test cases: `/tests/test_stats.rs` (~7,396 lines)
+- Test cases: `/tests/test_stats.rs` (~8,338 lines)
 
 ## Quick Debugging
 
@@ -200,11 +200,11 @@ cat file.stats.csv.data.jsonl | jq . | head
 
 | File | Purpose |
 |------|---------|
-| `src/cmd/stats.rs` | Main implementation (~6,052 lines) |
+| `src/cmd/stats.rs` | Main implementation (~6,320 lines) |
 | `src/config.rs` | CSV reader configuration |
 | `src/select.rs` | Column selection logic |
 | `src/util.rs` | Utility functions |
-| `tests/test_stats.rs` | Comprehensive test suite (~7,396 lines) |
+| `tests/test_stats.rs` | Comprehensive test suite (~8,338 lines) |
 | `Cargo.toml` | Dependencies (see `stats` and `csv` crates) |
 
 ---

--- a/src/cmd/frequency.rs
+++ b/src/cmd/frequency.rs
@@ -3705,10 +3705,23 @@ impl Args {
         // Most datasets have relatively few all-unique columns (e.g. ID columns), so
         // pre-allocate space for 5 as a reasonable default capacity.
         let mut all_unique_headers_vec: Vec<usize> = Vec::with_capacity(5);
-        for &orig_idx in sel.iter() {
-            let cardinality = col_cardinality_by_pos.get(orig_idx).copied().unwrap_or(0);
-            if cardinality == row_count {
-                all_unique_headers_vec.push(orig_idx);
+        // An APPROXIMATE (HyperLogLog) cardinality must never be compared for equality against
+        // an exact row count - the estimate carries ~1.5% error, so the test fails both ways: a
+        // genuine ID column almost never lands exactly on the row count (losing the very
+        // short-circuit this exists for), and a merely near-unique column whose estimate happens
+        // to land on it is wrongly collapsed to one sentinel, DROPPING real frequency rows.
+        // Fall back to counting such columns normally, which is correct, just slower.
+        if util::stats_cache_cardinality_is_approx(self.arg_input.as_deref()) {
+            log::info!(
+                "stats cache was built with --cardinality-method approx; skipping the \
+                 <ALL_UNIQUE> shortcut, whose equality test is invalid for an estimate."
+            );
+        } else {
+            for &orig_idx in sel.iter() {
+                let cardinality = col_cardinality_by_pos.get(orig_idx).copied().unwrap_or(0);
+                if cardinality == row_count {
+                    all_unique_headers_vec.push(orig_idx);
+                }
             }
         }
 

--- a/src/cmd/moarstats.rs
+++ b/src/cmd/moarstats.rs
@@ -4333,10 +4333,17 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         // For single dataset, use normal stats CSV path
         let path = get_stats_csv_path(input_path)?;
 
-        // Check if stats CSV exists, if not, run stats command
-        if args.flag_force || !path.exists() {
+        // Check if the stats CSV exists AND is newer than the input; if not, run stats.
+        // Existence alone is not enough: a stats CSV left over from an earlier version of
+        // the input would otherwise be used as the baseline for every derived statistic.
+        if args.flag_force || !util::stats_csv_is_current(&path, input_path) {
             if args.flag_force {
                 winfo!("Force flag set: recomputing stats...");
+            } else if path.exists() {
+                wwarn!(
+                    "Stats CSV file is older than the input: {}\nRecomputing baseline stats...",
+                    path.display()
+                );
             } else {
                 wwarn!(
                     "Stats CSV file not found: {}\nComputing baseline stats...",

--- a/src/cmd/pragmastat.rs
+++ b/src/cmd/pragmastat.rs
@@ -395,11 +395,20 @@ fn run_cache_append(args: &Args) -> CliResult<()> {
 
     // Auto-generate stats if missing (--force only recomputes ps_* columns,
     // it does NOT regenerate the baseline stats to avoid clobbering moarstats columns).
-    if !stats_csv_path.exists() {
-        wwarn!(
-            "Stats CSV file not found: {}\nComputing baseline stats...",
-            stats_csv_path.display()
-        );
+    // existence alone is not enough - a stats CSV older than the input describes data that
+    // is no longer there, and every ps_* statistic derived from it would inherit that
+    if !util::stats_csv_is_current(&stats_csv_path, input_path) {
+        if stats_csv_path.exists() {
+            wwarn!(
+                "Stats CSV file is older than the input: {}\nRecomputing baseline stats...",
+                stats_csv_path.display()
+            );
+        } else {
+            wwarn!(
+                "Stats CSV file not found: {}\nComputing baseline stats...",
+                stats_csv_path.display()
+            );
+        }
         let mut stats_args_vec: Vec<&str> = args.flag_stats_options.split_whitespace().collect();
         // Pass through input-shaping flags so the stats command matches the input format
         let delim_str;

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -691,6 +691,16 @@ pub struct StatsData {
     pub n_positive: Option<u64>,
     pub max_precision: Option<u32>,
     pub sparsity: Option<f64>,
+    // `stats --median` (without --quartiles/--everything) emits a `median` column that is
+    // NOT the same key as `q2_median`. It was absent from both this struct and
+    // STATSDATA_TYPES_MAP, so serde silently dropped it - the same drift that hid
+    // sortiness/geometric_mean/harmonic_mean/percentiles.
+    //
+    // Deliberately its OWN field rather than a serde alias onto q2_median:
+    // stats_satisfy_mode() infers quartile availability from `q2_median.is_some()`, so
+    // aliasing would make a --median-only cache (no q1/q3) falsely satisfy ProfileSchema.
+    #[serde(default)]
+    pub median: Option<f64>,
     pub mad: Option<f64>,
     pub lower_outer_fence: Option<f64>,
     pub lower_inner_fence: Option<f64>,
@@ -784,6 +794,7 @@ pub static STATSDATA_TYPES_MAP: phf::Map<&'static str, JsonTypes> = phf_map! {
     "n_positive" => JsonTypes::Int,
     "max_precision" => JsonTypes::Int,
     "sparsity" => JsonTypes::Float,
+    "median" => JsonTypes::Float,
     "mad" => JsonTypes::Float,
     "lower_outer_fence" => JsonTypes::Float,
     "lower_inner_fence" => JsonTypes::Float,
@@ -2101,11 +2112,30 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             // despite the flag documenting that it preemptively creates that file for the
             // "smart" commands (schema, frequency, tojsonl).
             //
-            // Create it ONLY when absent. An existing one must never be rebuilt from the
-            // cached stats CSV here: `moarstats` rewrites this file from its EXTENDED stats,
-            // and regenerating it would silently downgrade that richer cache.
+            // Regenerate when the jsonl is ABSENT, or when it PREDATES the sidecar beside it -
+            // an earlier run can refresh <FILESTEM>.stats.csv and its sidecar without
+            // --stats-jsonl, leaving a jsonl that no longer describes them. Keeping that one
+            // would hand back a stale cache from a flag whose whole purpose is to produce a
+            // current one.
+            //
+            // A jsonl NEWER than the sidecar is preserved, as is one with no sidecar at all:
+            // that is the stats-then-moarstats ordering, where `moarstats` has rewritten this
+            // file from its EXTENDED stats and rebuilding it would silently downgrade the
+            // richer cache. Same rule as util::stats_jsonl_predates_stats_cache applies on the
+            // read side, so the two cannot disagree about what "stale" means.
             let stats_jsonl_pathbuf = stats_pathbuf.with_extension("csv.data.jsonl");
-            if !stats_jsonl_pathbuf.exists() {
+            let sidecar_pathbuf = stats_pathbuf.with_extension("csv.json");
+            let mtime_of = |p: &std::path::Path| fs::metadata(p).and_then(|m| m.modified()).ok();
+            let regenerate_jsonl =
+                match (mtime_of(&stats_jsonl_pathbuf), mtime_of(&sidecar_pathbuf)) {
+                    // absent - the R1 case the flag exists for
+                    (None, _) => true,
+                    // predates the cache it claims to describe
+                    (Some(jsonl), Some(sidecar)) => sidecar > jsonl,
+                    // no sidecar provenance - decline to judge, preserve (moarstats)
+                    (Some(_), None) => false,
+                };
+            if regenerate_jsonl {
                 util::csv_to_jsonl(
                     &currstats_filename,
                     &STATSDATA_TYPES_MAP,

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -1410,7 +1410,12 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     // infer delimiter when we're getting input from stdin
     // as the stats engine needs to know the delimiter or it will panic
     let mut stdin_tempfile_guard: Option<StdinTempFile> = None;
-    if rconfig.is_stdin() {
+    // rconfig.path is repointed at the stdin spill temp file below, after which
+    // rconfig.is_stdin() is false for the remainder of run(). Capture the true origin
+    // now: the cache-install stage needs it to know the input has no stable path to
+    // key a cache on.
+    let input_was_stdin = rconfig.is_stdin();
+    if input_was_stdin {
         // read from stdin and write to a temp file
         log::info!("Reading from stdin");
 
@@ -1520,7 +1525,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     if let Some(path) = rconfig.path.clone() {
         //safety: we know the path is a valid PathBuf, so we can use unwrap
         let path_file_stem = path.file_stem().unwrap().to_str().unwrap();
-        let stats_file = stats_path(&path, false, args.flag_weight.is_some())?;
+        let stats_file = stats_path(&path, args.flag_weight.is_some())?;
         // check if <FILESTEM>.stats.csv file already exists.
         // If it does, check if it was compiled using the same args.
         // However, if the --force flag is set,
@@ -1535,8 +1540,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                             "Could not read {path_file_stem}.stats.csv.json: {e:?}, recomputing..."
                         );
                         // remove stats cache files silently even if they don't exists
-                        let _ = fs::remove_file(&stats_file);
-                        let _ = fs::remove_file(&stats_args_json_file);
+                        remove_stats_cache_pair(&stats_file);
                         String::new()
                     },
                 };
@@ -1554,8 +1558,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                                     "Could not deserialize {path_file_stem}.stats.csv.json: \
                                      {e:?}, recomputing..."
                                 );
-                                let _ = fs::remove_file(&stats_file);
-                                let _ = fs::remove_file(&stats_args_json_file);
+                                remove_stats_cache_pair(&stats_file);
                                 StatsArgs::default()
                             },
                         };
@@ -1570,8 +1573,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                                         "Could not deserialize {path_file_stem}.stats.csv.json: \
                                          {e:?}, recomputing..."
                                     );
-                                    let _ = fs::remove_file(&stats_file);
-                                    let _ = fs::remove_file(&stats_args_json_file);
+                                    remove_stats_cache_pair(&stats_file);
                                     StatsArgs::default()
                                 },
                             },
@@ -1580,8 +1582,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                                     "Could not parse {path_file_stem}.stats.csv.json: {e:?}, \
                                      recomputing..."
                                 );
-                                let _ = fs::remove_file(&stats_file);
-                                let _ = fs::remove_file(&stats_args_json_file);
+                                remove_stats_cache_pair(&stats_file);
                                 StatsArgs::default()
                             },
                         }
@@ -1665,9 +1666,19 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                         "{path_file_stem}.stats.csv already exists, but is older than the input \
                          file or the args have changed, recomputing...",
                     );
-                    let _ = fs::remove_file(&stats_file);
+                    // remove the sidecar TOGETHER with the stats CSV. Removing only the
+                    // CSV leaves behind a sidecar describing the OLD args, which the next
+                    // run validates against and trusts - serving stats computed with
+                    // entirely different args as if they matched.
+                    remove_stats_cache_pair(&stats_file);
                 }
             }
+        } else if stats_file.exists() {
+            // --force: recompute unconditionally. Drop the stale pair FIRST - otherwise
+            // the fresh stats.csv installed below ends up standing behind the previous
+            // run's sidecar, which the next run then validates and trusts. That is the
+            // same poisoning mechanism the args-changed path above guards against.
+            remove_stats_cache_pair(&stats_file);
         }
         if compute_stats {
             let start_time = std::time::Instant::now();
@@ -1899,37 +1910,24 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     } else {
         // we didn't compute the stats, re-use the existing stats file
         // safety: we know the path is a valid PathBuf, so we can use unwrap
-        stats_path(
-            rconfig.path.as_ref().unwrap(),
-            false,
-            args.flag_weight.is_some(),
-        )?
-        .to_str()
-        .unwrap()
-        .to_owned()
+        stats_path(rconfig.path.as_ref().unwrap(), args.flag_weight.is_some())?
+            .to_str()
+            .unwrap()
+            .to_owned()
     };
 
-    if rconfig.is_stdin() {
-        // if we read from stdin, copy the temp stats file to "stdin.stats.csv" or
-        // "stdin.stats.weighted.csv" safety: we know the path is a valid PathBuf, so we can
-        // use unwrap
-        let mut stats_pathbuf = stats_path(
-            rconfig.path.as_ref().unwrap(),
-            true,
-            args.flag_weight.is_some(),
-        )?;
-        fs::copy(currstats_filename.clone(), stats_pathbuf.clone())?;
-
-        // save the stats args to "stdin.stats.csv.json"
-        stats_pathbuf.set_extension("csv.json");
-        // Use platform-appropriate JSON serialization
-        let json_string =
-            cfg_select! {
-                target_endian = "little" => simd_json::to_string_pretty(&current_stats_args)?,
-                _ => serde_json::to_string_pretty(&current_stats_args)?,
-            };
-        std::fs::write(stats_pathbuf, json_string)?;
-    } else if let Some(path) = rconfig.path {
+    // A stdin input has no stable path to key a cache on: the spill temp file gets a
+    // fresh random name every run, so a cache written beside it can never be located
+    // again, let alone reused. Writing one only orphans a <tempname>.stats.csv pair in
+    // the temp dir - permanently so on builds without polars, which is where that dir
+    // gets reaped.
+    //
+    // NOTE: the branch that used to stand here, keyed on rconfig.is_stdin(), was
+    // unreachable - rconfig.path is repointed at the spill temp file far above this
+    // point, so is_stdin() is always false by the time we get here.
+    if let Some(path) = rconfig.path
+        && !input_was_stdin
+    {
         // if we read from a file, copy the temp stats file to "<FILESTEM>.stats.csv" or
         // "<FILESTEM>.stats.weighted.csv"
         let mut stats_pathbuf = path.clone();
@@ -1938,6 +1936,16 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         } else {
             stats_pathbuf.set_extension("stats.csv");
         }
+        // <FILESTEM>.stats.csv is installed unconditionally, by design: the usage text
+        // documents `qsv stats nyc311.csv` as CREATING nyc311.stats.csv, and `moarstats`
+        // reads that file directly rather than through the sidecar. --cache-threshold
+        // governs the SIDECAR (the validity metadata), not this artifact.
+        //
+        // Installing it without a sidecar is safe only because every path that reaches
+        // here with a fresh recompute has already removed any stale sidecar via
+        // remove_stats_cache_pair() - so a fresh stats.csv can never end up standing
+        // behind a PREVIOUS run's sidecar. Do not install without preserving that.
+        //
         // safety: we know the path is a valid PathBuf, so we can use unwrap
         if currstats_filename != stats_pathbuf.to_str().unwrap() {
             // if the stats file is not the same as the input file, copy it
@@ -1968,23 +1976,9 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                 currstats_filename = stats_csv_tempfile_fname;
             }
 
-            // remove the stats cache file
-            if fs::remove_file(stats_pathbuf.clone()).is_err() {
-                // fails silently if it can't remove the stats file
-                log::warn!(
-                    "Could not remove stats cache file: {}",
-                    stats_pathbuf.display()
-                );
-            }
-            // remove the stats cache JSON sidecar too, to avoid leaving an
-            // orphaned sidecar from a prior run.
-            let stats_json_pathbuf = stats_pathbuf.with_extension("csv.json");
-            if stats_json_pathbuf.exists() && fs::remove_file(&stats_json_pathbuf).is_err() {
-                log::warn!(
-                    "Could not remove stats cache JSON sidecar: {}",
-                    stats_json_pathbuf.display()
-                );
-            }
+            // remove the stats cache file AND its sidecar, so no orphan of either is
+            // left behind from a prior run
+            remove_stats_cache_pair(&stats_pathbuf);
             create_cache = false;
         }
 
@@ -3139,28 +3133,44 @@ fn calculate_memory_aware_chunk_size(
     }
 }
 
-/// Determines the path for the statistics output file.
+/// Removes a stats cache pair - the `<FILESTEM>.stats.csv` file and its
+/// `<FILESTEM>.stats.csv.json` sidecar - as a unit.
 ///
-/// This function constructs the appropriate file path for the statistics output
-/// based on the input file path and whether the input is from stdin. It handles
-/// both regular file inputs and stdin input cases.
+/// The two MUST be removed together. Deleting the stats CSV while leaving the sidecar
+/// behind lets a later run pass the sidecar's args comparison and be served stats that
+/// were computed with entirely different args - e.g. `--typesonly` output returned as
+/// if it were `--everything`.
+///
+/// Best-effort: a cache file we cannot delete is logged, never fatal, since the current
+/// run's own stats are unaffected.
+fn remove_stats_cache_pair(stats_file: &Path) {
+    for f in [
+        stats_file.to_path_buf(),
+        stats_file.with_extension("csv.json"),
+    ] {
+        if f.exists()
+            && let Err(e) = fs::remove_file(&f)
+        {
+            log::warn!("Could not remove stats cache file {}: {e:?}", f.display());
+        }
+    }
+}
+
+/// Determines the path for the stats cache file.
 ///
 /// # Arguments
 ///
 /// * `stats_csv_path` - The path to the input CSV file
-/// * `stdin_flag` - Whether the input is from stdin
+/// * `weighted` - Whether the stats were computed with `--weight`
 ///
 /// # Returns
 ///
-/// * `Ok(PathBuf)` - The path where statistics should be written
-/// * `Err(io::Error)` - If the path construction fails
+/// * `Ok(PathBuf)` - `<FILESTEM>.stats.csv` (or `<FILESTEM>.stats.weighted.csv`) beside the input
+/// * `Err(io::Error)` - If the input path has no parent directory or file name
 ///
-/// # Behavior
-///
-/// * **Regular Files**: Creates a `.stats.csv` file in the same directory as the input
-/// * **Stdin Input**: Creates a `stdin.stats.csv` file in the current directory
-/// * **Path Validation**: Validates that the input path has a parent directory and filename
-fn stats_path(stats_csv_path: &Path, stdin_flag: bool, weighted: bool) -> io::Result<PathBuf> {
+/// NOTE: there is deliberately no stdin variant. A stdin input is spilled to a randomly
+/// named temp file, so any cache keyed on that path is unfindable on the next run.
+fn stats_path(stats_csv_path: &Path, weighted: bool) -> io::Result<PathBuf> {
     let parent = stats_csv_path
         .parent()
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "Invalid path"))?;
@@ -3168,13 +3178,7 @@ fn stats_path(stats_csv_path: &Path, stdin_flag: bool, weighted: bool) -> io::Re
         .file_stem()
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "Invalid file name"))?;
 
-    let new_fname = if stdin_flag {
-        if weighted {
-            "stdin.stats.weighted.csv".to_string()
-        } else {
-            "stdin.stats.csv".to_string()
-        }
-    } else if weighted {
+    let new_fname = if weighted {
         format!("{}.stats.weighted.csv", fstem.to_string_lossy())
     } else {
         format!("{}.stats.csv", fstem.to_string_lossy())
@@ -3277,7 +3281,7 @@ fn resolve_sniff_whitelist_cached(input_path: &std::path::Path, args: &Args) -> 
 /// built), and its whitelist was itself derived from "sniff" (recorded in
 /// `flag_dates_whitelist_raw`). Returns `None` otherwise, signalling that a fresh sniff is needed.
 fn read_current_sniff_whitelist(input_path: &std::path::Path, args: &Args) -> Option<String> {
-    let stats_file = stats_path(input_path, false, args.flag_weight.is_some()).ok()?;
+    let stats_file = stats_path(input_path, args.flag_weight.is_some()).ok()?;
     if !stats_file.exists() {
         return None;
     }

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -700,7 +700,7 @@ pub struct StatsData {
     // stats_satisfy_mode() infers quartile availability from `q2_median.is_some()`, so
     // aliasing would make a --median-only cache (no q1/q3) falsely satisfy ProfileSchema.
     #[serde(default)]
-    pub median: Option<f64>,
+    pub median: Option<String>,
     pub mad: Option<f64>,
     pub lower_outer_fence: Option<f64>,
     pub lower_inner_fence: Option<f64>,
@@ -794,7 +794,12 @@ pub static STATSDATA_TYPES_MAP: phf::Map<&'static str, JsonTypes> = phf_map! {
     "n_positive" => JsonTypes::Int,
     "max_precision" => JsonTypes::Int,
     "sparsity" => JsonTypes::Float,
-    "median" => JsonTypes::Float,
+    // String, like `min`/`max` and NOT like `q1`/`q3`: the median cell is a
+    // type-dependent RENDERING. For a Date/DateTime column stats_to_records() emits an
+    // RFC3339 string, and typing this Float makes the JSON conversion coerce that to 0.0 -
+    // silently corrupting date medians. String is lossless for both cases; a consumer that
+    // wants a number parses it, using the row's `type` to know that is meaningful.
+    "median" => JsonTypes::String,
     "mad" => JsonTypes::Float,
     "lower_outer_fence" => JsonTypes::Float,
     "lower_inner_fence" => JsonTypes::Float,

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -2089,6 +2089,30 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                     orphaned_sidecar.display()
                 );
             }
+        } else if write_stats_jsonl && create_cache {
+            // Cache HIT with --stats-jsonl. The jsonl is written only inside the
+            // compute-and-cache branch above, and StatsArgs has no flag_stats_jsonl field, so
+            // the args comparison passes and compute_stats stays false. That made the flag a
+            // silent no-op on a warm cache:
+            //
+            //   qsv stats -c 1 foo.csv                 # builds a valid cache
+            //   qsv stats -c 1 --stats-jsonl foo.csv   # cache hit -> no .data.jsonl at all
+            //
+            // despite the flag documenting that it preemptively creates that file for the
+            // "smart" commands (schema, frequency, tojsonl).
+            //
+            // Create it ONLY when absent. An existing one must never be rebuilt from the
+            // cached stats CSV here: `moarstats` rewrites this file from its EXTENDED stats,
+            // and regenerating it would silently downgrade that richer cache.
+            let stats_jsonl_pathbuf = stats_pathbuf.with_extension("csv.data.jsonl");
+            if !stats_jsonl_pathbuf.exists() {
+                util::csv_to_jsonl(
+                    &currstats_filename,
+                    &STATSDATA_TYPES_MAP,
+                    &stats_jsonl_pathbuf,
+                    b',', // cache is always CSV (comma-delimited)
+                )?;
+            }
         }
     }
 

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -663,6 +663,11 @@ pub struct StatsData {
     pub max: Option<String>,
     pub range: Option<f64>,
     pub sort_order: Option<String>,
+    // emitted by stats_headers() and typed in STATSDATA_TYPES_MAP, but was missing from this
+    // struct - so serde silently dropped it on every get_stats_records() deserialize and the
+    // value, though present in the .data.jsonl cache, was unreachable to every consumer.
+    #[serde(default)]
+    pub sortiness: Option<f64>,
     pub min_length: Option<usize>,
     pub max_length: Option<usize>,
     pub sum_length: Option<usize>,
@@ -672,6 +677,11 @@ pub struct StatsData {
     pub cv_length: Option<f64>,
     pub mean: Option<f64>,
     pub sem: Option<f64>,
+    // same drift as `sortiness` above: emitted and typed, but absent here
+    #[serde(default)]
+    pub geometric_mean: Option<f64>,
+    #[serde(default)]
+    pub harmonic_mean: Option<f64>,
     pub stddev: Option<f64>,
     pub variance: Option<f64>,
     pub cv: Option<f64>,
@@ -699,6 +709,12 @@ pub struct StatsData {
     pub antimode: Option<String>,
     pub antimode_count: Option<u64>,
     pub antimode_occurrences: Option<u64>,
+    // `percentiles` was absent from BOTH this struct and STATSDATA_TYPES_MAP. It is a
+    // pipe-separated rendering (e.g. "5: 249|10: 499|..."), so String is the correct type -
+    // which is also what the map's unmapped-column fallback already produced, making the map
+    // entry a no-op for serialization and this a read-side fix only.
+    #[serde(default)]
+    pub percentiles: Option<String>,
     // `Some(true)` when the column is a zero-padded numeric code (zip/FIPS/ICD-9 style — see
     // the `--zero-padded-numeric` flag); `None` otherwise (the stats CSV emits an empty cell
     // for non-flagged columns, which the jsonl conversion drops entirely, and older caches
@@ -786,6 +802,7 @@ pub static STATSDATA_TYPES_MAP: phf::Map<&'static str, JsonTypes> = phf_map! {
     "antimode" => JsonTypes::String,
     "antimode_count" => JsonTypes::Int,
     "antimode_occurrences" => JsonTypes::Int,
+    "percentiles" => JsonTypes::String,
     "zero_padded_numeric" => JsonTypes::Bool,
     // moarstats fields
     "kurtosis" => JsonTypes::Float,

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -1599,7 +1599,12 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                     time_saved = stat_args.compute_duration_ms;
                     stat_args.compute_duration_ms = 0;
                     stat_args.field_count = 0;
-                    stat_args.filesize_bytes = 0;
+                    // filesize_bytes is deliberately NOT zeroed - it is compared below.
+                    //
+                    // `hash` is zeroed because it CANNOT be validated here: it fingerprints
+                    // the stats OUTPUT (see the stats_hash block further down), not the input
+                    // file, so checking it would mean recomputing the very stats we are
+                    // trying to reuse.
                     stat_args.hash = FileHash::default();
                     stat_args
                 };
@@ -1618,7 +1623,15 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                 // added can still be served without it. The package version MUST therefore be
                 // bumped on any release that changes the --everything column set, so old caches
                 // are recomputed.
-                let input_file_modified = fs::metadata(&path)?.modified()?;
+                let input_metadata = fs::metadata(&path)?;
+                let input_file_modified = input_metadata.modified()?;
+                // Validate SIZE as well as mtime. mtime alone is defeated by any
+                // mtime-preserving content replacement - cp -p, tar -x, git checkout,
+                // rsync -t, mv from an archive - each of which would otherwise serve the
+                // PREVIOUS file's statistics as current, to stats and to every cache
+                // consumer. Comparing the recorded size costs one stat() call we have
+                // already made.
+                current_stats_args.filesize_bytes = input_metadata.len();
                 let stats_file_modified = fs::metadata(&stats_file)
                     .and_then(|m| m.modified())
                     .unwrap_or(input_file_modified);
@@ -1641,6 +1654,22 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                                 == current_stats_args.flag_weight
                             && existing_stats_args_json.flag_percentile_list
                                 == current_stats_args.flag_percentile_list
+                            // the three method flags below change the VALUES --everything
+                            // produces, not just which columns appear, so a cache built
+                            // with approximations must not be served to an exact run:
+                            //   --quantile-method approx    -> t-digest quartiles/percentiles
+                            //   --cardinality-method approx -> HLL cardinality, MAD disabled
+                            //   --mode-cardinality-cap      -> mode/antimode suppressed above
+                            //                                  the cap
+                            && existing_stats_args_json.flag_quantile_method
+                                == current_stats_args.flag_quantile_method
+                            && existing_stats_args_json.flag_cardinality_method
+                                == current_stats_args.flag_cardinality_method
+                            && existing_stats_args_json.flag_mode_cardinality_cap
+                                == current_stats_args.flag_mode_cardinality_cap
+                            // the input must be the same SIZE, not merely older (see above)
+                            && existing_stats_args_json.filesize_bytes
+                                == current_stats_args.filesize_bytes
                             && existing_stats_args_json.flag_select
                                 == current_stats_args.flag_select
                             && existing_stats_args_json.flag_round == current_stats_args.flag_round

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -2961,7 +2961,15 @@ impl Args {
         if self.flag_median && !self.flag_quartiles && !everything {
             fields.push("median");
         }
-        if self.flag_mad || everything {
+        // Ask which_stats() rather than re-deriving the condition here. which_stats() turns
+        // MAD off for --quantile-method approx (a t-digest cannot do median(|x - median|),
+        // which needs a second pass over the deviations), while this site re-derived it as
+        // `flag_mad || everything` and so emitted a "mad" HEADER for records that carry no
+        // mad FIELD. The csv writer rejects that arity change, making
+        // `qsv stats --everything --quantile-method approx` fail outright with
+        // "found record with 48 fields, but the previous record has 49 fields" - exit 1, no
+        // output at all, once the input is large enough to reach the write.
+        if self.which_stats().mad {
             fields.push("mad");
         }
         if self.flag_quartiles || everything {

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -3371,6 +3371,16 @@ fn read_current_sniff_whitelist(input_path: &std::path::Path, args: &Args) -> Op
     #[cfg(target_endian = "big")]
     let cached: StatsArgs = serde_json::from_str(&json_str).ok()?;
 
+    // The input must also be the same SIZE, not merely older. mtime alone is defeated by any
+    // mtime-preserving replacement (cp -p, tar -x, git checkout, rsync -t): the main stats cache
+    // is correctly invalidated by its own size check, but reusing this sniff-resolved whitelist
+    // would still apply the PREVIOUS file's date-inference choices to the new content.
+    if cached.filesize_bytes != 0
+        && fs::metadata(input_path).map(|m| m.len()).ok()? != cached.filesize_bytes
+    {
+        return None;
+    }
+
     // Only reuse when the cache actually performed sniff-based date inference. A cache built
     // WITHOUT --infer-dates stores the unresolved literal "sniff" keyword in flag_dates_whitelist
     // (resolution is gated on --infer-dates), and reusing that would skip sniffing and leave the

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -2014,6 +2014,35 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                     b',', // cache is always CSV (comma-delimited)
                 )?;
             }
+        } else if compute_stats {
+            // We just recomputed and installed a stats.csv but are NOT writing a sidecar
+            // for it. Any sidecar still on disk describes a DIFFERENT run's args, and the
+            // next run would validate against it and trust it - serving these stats as if
+            // they had been computed with those args.
+            //
+            // The upstream recompute paths already drop the pair, but they are all gated
+            // on `stats_file.exists()`, so a LONE sidecar (its CSV removed externally, or
+            // by an interrupted run) is never inspected and never cleaned:
+            //
+            //   qsv stats f.csv -E -c 1      # pair written
+            //   rm f.stats.csv               # lone sidecar survives
+            //   qsv stats f.csv --typesonly  # validation skipped, sidecar untouched
+            //   qsv stats f.csv -E           # sidecar validates -> typesonly served as -E
+            //
+            // Enforcing the invariant HERE, where the two files are actually written,
+            // closes that hole and keeps it closed for any recompute path added later.
+            //
+            // Guarded on compute_stats: when the cache was reused (compute_stats false)
+            // the sidecar is the one we just validated, and must survive.
+            let orphaned_sidecar = stats_pathbuf.with_extension("csv.json");
+            if orphaned_sidecar.exists()
+                && let Err(e) = fs::remove_file(&orphaned_sidecar)
+            {
+                log::warn!(
+                    "Could not remove orphaned stats cache sidecar {}: {e:?}",
+                    orphaned_sidecar.display()
+                );
+            }
         }
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -3206,6 +3206,32 @@ fn stats_cache_lacks_infer_dates(bases: [&Path; 2]) -> bool {
     })
 }
 
+/// Does the stats cache's metadata sidecar record an input SIZE that disagrees with the input
+/// on disk right now?
+///
+/// `stats` itself compares this before reusing its CSV cache, because mtime alone is defeated by
+/// any mtime-preserving replacement (`cp -p`, `tar -x`, `git checkout`, `rsync -t`). Cache
+/// CONSUMERS read the `.stats.csv.data.jsonl` through `get_stats_records`, which judged it by
+/// mtime and parsing options only - so the same swap that `stats` now rejects still served
+/// consumers the previous file's statistics.
+///
+/// Same convention as its siblings: only a positive, readable disagreement counts. A missing or
+/// unparseable sidecar, or one without `filesize_bytes`, means "no opinion", so the deliberate
+/// sidecar-less `moarstats` cache is never discarded on these grounds.
+fn stats_cache_filesize_conflict(input_path: &str, bases: [&Path; 2]) -> bool {
+    let Ok(input_len) = std::fs::metadata(input_path).map(|m| m.len()) else {
+        return false;
+    };
+
+    bases.iter().any(|base| {
+        std::fs::read_to_string(base.with_extension("stats.csv.json"))
+            .ok()
+            .and_then(|t| serde_json::from_str::<serde_json::Value>(&t).ok())
+            .and_then(|m| m.get("filesize_bytes").and_then(serde_json::Value::as_u64))
+            .is_some_and(|recorded| recorded != 0 && recorded != input_len)
+    })
+}
+
 /// Does the stats cache's metadata sidecar POSTDATE the `.stats.csv.data.jsonl` beside it?
 ///
 /// If it does, the JSONL was produced by an earlier stats run and no longer describes the stats
@@ -3334,6 +3360,32 @@ pub fn get_stats_records(
 
         let statsdata_mtime = FileTime::from_last_modification_time(&statsdata_metadata);
         let input_mtime = FileTime::from_last_modification_time(&input_metadata);
+        // Does THIS mode actually infer dates? Mirrors the per-mode argv built below: Schema
+        // and ProfileSchema always pass --infer-dates, PolarsSchema only when it has a
+        // whitelist (i.e. sniff found date columns), and the Frequency modes never do.
+        //
+        // Used for both date-sensitive checks below. A mode that does not infer dates cannot
+        // be affected by --prefer-dmy or by a date-blind cache, so neither may force it to
+        // regenerate.
+        let mode_infers_dates = match requested_mode {
+            StatsMode::Schema | StatsMode::ProfileSchema => true,
+            #[cfg(feature = "polars")]
+            StatsMode::PolarsSchema => !args.flag_dates_whitelist.is_empty(),
+            _ => false,
+        };
+
+        // Compare the EFFECTIVE dmy preference. The stats subprocess folds QSV_PREFER_DMY in
+        // (stats.rs does `flag_prefer_dmy || get_envvar_flag("QSV_PREFER_DMY")`), so a sidecar
+        // written under that env var records `true` -- while consumers that build SchemaArgs
+        // literally (frequency, joinp, pivotp, sample) hardcode `flag_prefer_dmy: false`.
+        // Comparing the raw flag made every one of those runs mismatch its own cache and
+        // regenerate it, on every invocation, forever.
+        let effective_prefer_dmy = if mode_infers_dates {
+            Some(args.flag_prefer_dmy || get_envvar_flag("QSV_PREFER_DMY"))
+        } else {
+            None
+        };
+
         if statsdata_mtime > input_mtime {
             // mtime alone is not sufficient: the cache is NOT keyed by parsing options, so a
             // cache written by an earlier run with a different --no-headers/--delimiter would
@@ -3343,7 +3395,7 @@ pub fn get_stats_records(
                 &canonical_input_path,
                 args.flag_no_headers,
                 args.flag_delimiter,
-                Some(args.flag_prefer_dmy),
+                effective_prefer_dmy,
             ) {
                 info!(
                     "stats.csv.data.jsonl file was built with different parsing options \
@@ -3359,7 +3411,20 @@ pub fn get_stats_records(
                      stats jsonl."
                 );
                 false
-            } else if matches!(requested_mode, StatsMode::Schema | StatsMode::ProfileSchema)
+            } else if stats_cache_filesize_conflict(
+                input_path,
+                [Path::new(input_path), &canonical_input_path],
+            ) {
+                // the input was replaced by content of a DIFFERENT size while keeping its
+                // mtime (cp -p, tar -x, git checkout, rsync -t). `qsv stats` itself now
+                // rejects its CSV cache on this, but consumers read the jsonl through this
+                // path and would otherwise still be served the pre-swap statistics.
+                info!(
+                    "stats.csv.data.jsonl file describes an input of a different size. \
+                     Regenerating stats jsonl."
+                );
+                false
+            } else if mode_infers_dates
                 && stats_cache_lacks_infer_dates([Path::new(input_path), &canonical_input_path])
             {
                 info!(

--- a/src/util.rs
+++ b/src/util.rs
@@ -3251,7 +3251,25 @@ pub fn stats_cache_cardinality_is_approx(input_path: Option<&str>) -> bool {
         // stdin has no stable path to key a cache on
         return false;
     };
-    let path = Path::new(raw);
+
+    // Resolve a `dc:<name>` disk-cache handle to its materialized CSV path, exactly as
+    // get_stats_records does before loading the cache. Without this the caller looks beside the
+    // literal "dc:name" string, finds no sidecar, and concludes the cardinality is exact - so a
+    // `dc:` input silently kept the invalid shortcut this check exists to suppress.
+    #[cfg(feature = "get")]
+    let resolved: String = if let Some(dc_name) = raw.strip_prefix("dc:") {
+        match crate::diskcache::resolve_dc_path(dc_name) {
+            Ok(p) => p.to_string_lossy().into_owned(),
+            // unresolvable handle: no cache to judge
+            Err(_) => return false,
+        }
+    } else {
+        raw.to_string()
+    };
+    #[cfg(not(feature = "get"))]
+    let resolved: String = raw.to_string();
+
+    let path = Path::new(&resolved);
     let canonical = path.canonicalize().ok();
 
     [Some(path), canonical.as_deref()]

--- a/src/util.rs
+++ b/src/util.rs
@@ -3269,6 +3269,30 @@ pub fn stats_cache_cardinality_is_approx(input_path: Option<&str>) -> bool {
         })
 }
 
+/// Is a `<FILESTEM>.stats.csv` present AND newer than the input it describes?
+///
+/// `moarstats` and `pragmastat` locate the baseline stats CSV by path and regenerate it when
+/// absent - but they checked EXISTENCE only. A stats CSV left over from an earlier version of the
+/// input was therefore accepted as the baseline for every statistic they derive, silently
+/// describing data that is no longer there. This is the same first gate `stats` applies to its
+/// own cache.
+///
+/// mtime only: the recorded-size cross-check lives in the `.stats.csv.json` sidecar, which these
+/// callers do not require (`moarstats` deliberately writes none).
+///
+/// A stats CSV we cannot stat is "not current" - regenerate rather than trust it. An INPUT we
+/// cannot stat leaves the prior behavior alone, so a transient failure cannot trigger an
+/// expensive rebuild.
+pub fn stats_csv_is_current(stats_csv_path: &Path, input_path: &Path) -> bool {
+    let Ok(stats_modified) = std::fs::metadata(stats_csv_path).and_then(|m| m.modified()) else {
+        return false;
+    };
+    let Ok(input_modified) = std::fs::metadata(input_path).and_then(|m| m.modified()) else {
+        return true;
+    };
+    stats_modified > input_modified
+}
+
 /// Does the stats cache's metadata sidecar POSTDATE the `.stats.csv.data.jsonl` beside it?
 ///
 /// If it does, the JSONL was produced by an earlier stats run and no longer describes the stats
@@ -3485,12 +3509,15 @@ pub fn get_stats_records(
         false
     };
 
-    if requested_mode == StatsMode::Frequency && env_mode != "auto" && !stats_data_current {
-        // if the stats.data file is not current,
-        // we're also doing frequency old school w/o cardinality
-        // unless env_mode auto overrides
-        return Ok((ByteRecord::new(), Vec::new()));
-    }
+    // NOTE: Frequency mode used to bail out here with empty stats when the cache was not
+    // current and `env_mode != "auto"`. env_mode is validated to auto/force/none and "none"
+    // already returned above, so that condition meant exactly "force" - making
+    // QSV_STATSCACHE_MODE=force STRICTLY WEAKER than the default: it skipped regeneration,
+    // returned no cardinality (losing frequency's <ALL_UNIQUE> short-circuit) and created no
+    // cache, while plain auto-mode regenerated and cached. That inverts the documented
+    // contract ("force - if the cache does not exist, create it by running stats").
+    // Both auto and force now fall through to the regeneration block below, which already
+    // adds --force to the stats args for force mode. Only "none" skips the cache.
 
     // Use qsv's Config system to properly detect delimiter based on file extension
     let rconfig = Config::new(Some(input_path))

--- a/src/util.rs
+++ b/src/util.rs
@@ -3134,6 +3134,7 @@ fn stats_cache_parsing_opts_match(
     input_path: &Path,
     no_headers: bool,
     delimiter: Option<Delimiter>,
+    prefer_dmy: Option<bool>,
 ) -> bool {
     // --no-headers determines whether the header row is part of the data (and therefore whether
     // field names are real or positional), so it must match the consuming command.
@@ -3142,6 +3143,24 @@ fn stats_cache_parsing_opts_match(
         .and_then(serde_json::Value::as_bool)
         .unwrap_or(false)
         != no_headers
+    {
+        return false;
+    }
+
+    // --prefer-dmy decides how AMBIGUOUS dates are parsed: 01/02/2020 is Jan 2 under mdy and
+    // Feb 1 under dmy. A cache built under one must not be served to a command using the
+    // other, or its date min/max (and everything derived from them) describes different
+    // instants than the consumer believes. stats.rs's own reuse path already compares this;
+    // this check exists because get_stats_records short-circuits before that path ever runs.
+    //
+    // `None` means the consumer does no date inference (extsort, sortcheck), so the flag is
+    // irrelevant to it and must not force needless cache regeneration.
+    if let Some(prefer_dmy) = prefer_dmy
+        && metadata
+            .get("flag_prefer_dmy")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false)
+            != prefer_dmy
     {
         return false;
     }
@@ -3159,6 +3178,62 @@ fn stats_cache_parsing_opts_match(
     };
     let cmd_delim = delimiter.map_or(ext_delim, |d| d.as_byte());
     cache_delim == cmd_delim
+}
+
+/// Was the stats cache beside `bases` built WITHOUT `--infer-dates`?
+///
+/// The `Frequency` and `FrequencyForceStats` modes run `stats --cardinality --stats-jsonl` with
+/// no `--infer-dates`, so the cache they leave behind types every date column as `String`. That
+/// cache is keyed only by input path and mtime, so a later `qsv schema` / `qsv tojsonl` on the
+/// same unchanged file reused it and emitted `string` with no format for genuine date columns -
+/// silently disagreeing with what those commands produce on a cold cache, and contradicting
+/// tojsonl's own usage text, which promises reuse only of caches built with `--cardinality` AND
+/// `--infer-dates`.
+///
+/// Consistent with `stats_cache_parsing_opts_conflict`: only a positive, readable
+/// `"flag_infer_dates": false` counts. A missing or unparseable sidecar means "no opinion", so a
+/// sidecar-less `moarstats`-built cache is never discarded on these grounds.
+fn stats_cache_lacks_infer_dates(bases: [&Path; 2]) -> bool {
+    bases.iter().any(|base| {
+        std::fs::read_to_string(base.with_extension("stats.csv.json"))
+            .ok()
+            .and_then(|t| serde_json::from_str::<serde_json::Value>(&t).ok())
+            .and_then(|m| {
+                m.get("flag_infer_dates")
+                    .and_then(serde_json::Value::as_bool)
+            })
+            == Some(false)
+    })
+}
+
+/// Does the stats cache's metadata sidecar POSTDATE the `.stats.csv.data.jsonl` beside it?
+///
+/// If it does, the JSONL was produced by an earlier stats run and no longer describes the stats
+/// now on disk. A recompute that does not pass `--stats-jsonl` refreshes `<stem>.stats.csv` and
+/// `<stem>.stats.csv.json` but leaves the JSONL untouched - and since the JSONL is judged current
+/// by mtime against the INPUT, which a recompute never touches, it would otherwise be served
+/// indefinitely. Observed: an `--infer-dates` JSONL saying `when=Date` surviving beside a freshly
+/// computed `stats.csv` saying `when=String`, and being consumed by `schema`.
+///
+/// Two cases deliberately do NOT count as stale, both for the same reason `moarstats` writes the
+/// JSONL from its EXTENDED stats and writes no sidecar of its own:
+///   * **no sidecar at all** - no opinion, never "stale". Treating a sidecar-less JSONL as unusable
+///     would discard that richer externally-built cache and regenerate a leaner one.
+///   * **JSONL newer than the sidecar** - that is exactly the `stats` then `moarstats` ordering,
+///     where the JSONL is the later and richer artifact.
+///
+/// Both locations are checked for the same reason `stats_cache_parsing_opts_conflict` checks
+/// both: for a symlinked input they differ.
+fn stats_jsonl_predates_stats_cache(statsdata_path: &Path, bases: [&Path; 2]) -> bool {
+    let Ok(jsonl_meta) = std::fs::metadata(statsdata_path) else {
+        return false;
+    };
+    let jsonl_mtime = FileTime::from_last_modification_time(&jsonl_meta);
+
+    bases.iter().any(|base| {
+        std::fs::metadata(base.with_extension("stats.csv.json"))
+            .is_ok_and(|m| FileTime::from_last_modification_time(&m) > jsonl_mtime)
+    })
 }
 
 /// Does a stats cache's metadata sidecar record parsing options that CONFLICT with the consuming
@@ -3179,6 +3254,7 @@ fn stats_cache_parsing_opts_conflict(
     canonical_input_path: &Path,
     no_headers: bool,
     delimiter: Option<Delimiter>,
+    prefer_dmy: Option<bool>,
 ) -> bool {
     // Both locations must be checked, because for a SYMLINKED input they differ: the JSONL cache
     // is looked up beside the canonicalized target, but the `stats` subprocess is invoked with the
@@ -3197,7 +3273,8 @@ fn stats_cache_parsing_opts_conflict(
         let Ok(metadata) = serde_json::from_str::<serde_json::Value>(&text) else {
             continue;
         };
-        if !stats_cache_parsing_opts_match(&metadata, input_path, no_headers, delimiter) {
+        if !stats_cache_parsing_opts_match(&metadata, input_path, no_headers, delimiter, prefer_dmy)
+        {
             return true;
         }
     }
@@ -3266,10 +3343,28 @@ pub fn get_stats_records(
                 &canonical_input_path,
                 args.flag_no_headers,
                 args.flag_delimiter,
+                Some(args.flag_prefer_dmy),
             ) {
                 info!(
                     "stats.csv.data.jsonl file was built with different parsing options \
-                     (--no-headers/--delimiter). Regenerating stats jsonl."
+                     (--no-headers/--delimiter/--prefer-dmy). Regenerating stats jsonl."
+                );
+                false
+            } else if stats_jsonl_predates_stats_cache(
+                &statsdata_path,
+                [Path::new(input_path), &canonical_input_path],
+            ) {
+                info!(
+                    "stats.csv.data.jsonl file predates the stats cache beside it. Regenerating \
+                     stats jsonl."
+                );
+                false
+            } else if matches!(requested_mode, StatsMode::Schema | StatsMode::ProfileSchema)
+                && stats_cache_lacks_infer_dates([Path::new(input_path), &canonical_input_path])
+            {
+                info!(
+                    "stats.csv.data.jsonl file was built without --infer-dates, so date columns \
+                     are typed as strings. Regenerating stats jsonl."
                 );
                 false
             } else {
@@ -3695,6 +3790,9 @@ pub fn get_stats_records_readonly(
         Path::new(&input_path_owned),
         no_headers,
         delimiter,
+        // extsort/sortcheck do no date inference, so --prefer-dmy cannot affect what they
+        // read out of the cache
+        None,
     ) {
         return None;
     }
@@ -5119,9 +5217,13 @@ mod tests {
         let input = Path::new("data.csv");
         let meta = serde_json::json!({"flag_no_headers": true, "flag_delimiter": ","});
         // cache built headerless, consumer wants headers -> reject
-        assert!(!stats_cache_parsing_opts_match(&meta, input, false, None));
+        assert!(!stats_cache_parsing_opts_match(
+            &meta, input, false, None, None
+        ));
         // same setting on both sides -> accept
-        assert!(stats_cache_parsing_opts_match(&meta, input, true, None));
+        assert!(stats_cache_parsing_opts_match(
+            &meta, input, true, None, None
+        ));
     }
 
     #[test]
@@ -5129,12 +5231,15 @@ mod tests {
         let input = Path::new("data.csv");
         let meta = serde_json::json!({"flag_no_headers": false, "flag_delimiter": ";"});
         // cache built semicolon-delimited, consumer resolves ',' from the .csv extension
-        assert!(!stats_cache_parsing_opts_match(&meta, input, false, None));
+        assert!(!stats_cache_parsing_opts_match(
+            &meta, input, false, None, None
+        ));
         assert!(stats_cache_parsing_opts_match(
             &meta,
             input,
             false,
-            Some(Delimiter(b';'))
+            Some(Delimiter(b';')),
+            None
         ));
     }
 
@@ -5147,6 +5252,7 @@ mod tests {
             &meta,
             Path::new("data.csv"),
             false,
+            None,
             None
         ));
         // ... and a .tsv input resolves to tab on both sides
@@ -5154,6 +5260,7 @@ mod tests {
             &meta,
             Path::new("data.tsv"),
             false,
+            None,
             None
         ));
         // but an explicit comma against a .tsv input is a genuine mismatch
@@ -5161,7 +5268,8 @@ mod tests {
             &meta,
             Path::new("data.tsv"),
             false,
-            Some(Delimiter(b','))
+            Some(Delimiter(b',')),
+            None
         ));
     }
 
@@ -5172,12 +5280,12 @@ mod tests {
         // No sidecar at all: NOT a conflict. `moarstats` writes the JSONL cache without one, and
         // rejecting those would discard a rich cache and regenerate a leaner one.
         assert!(!stats_cache_parsing_opts_conflict(
-            &input, &input, false, None
+            &input, &input, false, None, None
         ));
         // Present but unparseable: same — decline to judge rather than discard.
         std::fs::write(dir.path().join("data.stats.csv.json"), b"{not json").unwrap();
         assert!(!stats_cache_parsing_opts_conflict(
-            &input, &input, false, None
+            &input, &input, false, None, None
         ));
         // Readable and matching: no conflict.
         std::fs::write(
@@ -5186,7 +5294,7 @@ mod tests {
         )
         .unwrap();
         assert!(!stats_cache_parsing_opts_conflict(
-            &input, &input, false, None
+            &input, &input, false, None, None
         ));
         // Readable and mismatched: the case this exists to catch.
         std::fs::write(
@@ -5195,7 +5303,7 @@ mod tests {
         )
         .unwrap();
         assert!(stats_cache_parsing_opts_conflict(
-            &input, &input, false, None
+            &input, &input, false, None, None
         ));
     }
 
@@ -5214,7 +5322,7 @@ mod tests {
         )
         .unwrap();
         assert!(stats_cache_parsing_opts_conflict(
-            &link, &canonical, false, None
+            &link, &canonical, false, None, None
         ));
         // and the agreeing case is still not a conflict
         std::fs::write(
@@ -5223,8 +5331,65 @@ mod tests {
         )
         .unwrap();
         assert!(!stats_cache_parsing_opts_conflict(
-            &link, &canonical, false, None
+            &link, &canonical, false, None, None
         ));
+    }
+
+    #[test]
+    fn stats_cache_parsing_opts_match_rejects_mismatched_prefer_dmy() {
+        let input = Path::new("data.csv");
+        let meta = serde_json::json!({
+            "flag_no_headers": false, "flag_delimiter": ",", "flag_prefer_dmy": true
+        });
+        // cache built dmy, consumer parses mdy -> reject: 01/02/2020 is a different instant
+        assert!(!stats_cache_parsing_opts_match(
+            &meta,
+            input,
+            false,
+            None,
+            Some(false)
+        ));
+        // same setting on both sides -> accept
+        assert!(stats_cache_parsing_opts_match(
+            &meta,
+            input,
+            false,
+            None,
+            Some(true)
+        ));
+        // a consumer that does no date inference (extsort, sortcheck) opts out entirely, so
+        // the flag must not force it to regenerate
+        assert!(stats_cache_parsing_opts_match(
+            &meta, input, false, None, None
+        ));
+    }
+
+    #[test]
+    fn stats_jsonl_predates_stats_cache_only_when_the_sidecar_is_newer() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("data.csv");
+        let jsonl = dir.path().join("data.stats.csv.data.jsonl");
+        let sidecar = dir.path().join("data.stats.csv.json");
+
+        // no JSONL at all: nothing to judge
+        assert!(!stats_jsonl_predates_stats_cache(&jsonl, [&input, &input]));
+
+        std::fs::write(&jsonl, b"{}\n").unwrap();
+        // JSONL but NO sidecar: deliberately NOT stale. `moarstats` writes the JSONL from its
+        // extended stats and writes no sidecar; discarding that would downgrade consumers.
+        assert!(!stats_jsonl_predates_stats_cache(&jsonl, [&input, &input]));
+
+        // sidecar OLDER than the JSONL: exactly the `stats` then `moarstats` ordering, where
+        // the JSONL is the later and richer artifact. Still not stale.
+        std::fs::write(&sidecar, b"{}").unwrap();
+        filetime::set_file_mtime(&sidecar, FileTime::from_unix_time(1_000, 0)).unwrap();
+        filetime::set_file_mtime(&jsonl, FileTime::from_unix_time(2_000, 0)).unwrap();
+        assert!(!stats_jsonl_predates_stats_cache(&jsonl, [&input, &input]));
+
+        // sidecar NEWER than the JSONL: a recompute refreshed the stats and left the JSONL
+        // behind. This is the case that silently poisoned consumers.
+        filetime::set_file_mtime(&sidecar, FileTime::from_unix_time(3_000, 0)).unwrap();
+        assert!(stats_jsonl_predates_stats_cache(&jsonl, [&input, &input]));
     }
 
     #[cfg(test)]

--- a/src/util.rs
+++ b/src/util.rs
@@ -3232,6 +3232,43 @@ fn stats_cache_filesize_conflict(input_path: &str, bases: [&Path; 2]) -> bool {
     })
 }
 
+/// Was the stats cache beside `input_path` built with APPROXIMATE cardinality
+/// (`--cardinality-method approx`, i.e. `HyperLogLog`)?
+///
+/// HLL carries roughly +/-1.5% error, so a cached cardinality must not be compared for EQUALITY
+/// against an exact row count. `frequency` does exactly that to detect all-unique (ID) columns and
+/// collapse them to a single `<ALL_UNIQUE>` sentinel. Against an approximate cardinality that
+/// comparison fails both ways: a genuine ID column almost never lands exactly on the row count, so
+/// the short-circuit is lost and a full per-column hashmap is built (a performance cliff on the
+/// very columns the short-circuit exists for); and a merely near-unique column whose estimate
+/// happens to land on the row count is wrongly collapsed, **dropping real frequency rows**.
+///
+/// Same convention as the sibling sidecar checks: only a positive, readable `"approx"` counts. A
+/// missing or unparseable sidecar means "no opinion", so a cache without provenance is treated as
+/// exact - which is what it was before `--cardinality-method` existed.
+pub fn stats_cache_cardinality_is_approx(input_path: Option<&str>) -> bool {
+    let Some(raw) = input_path else {
+        // stdin has no stable path to key a cache on
+        return false;
+    };
+    let path = Path::new(raw);
+    let canonical = path.canonicalize().ok();
+
+    [Some(path), canonical.as_deref()]
+        .into_iter()
+        .flatten()
+        .any(|base| {
+            std::fs::read_to_string(base.with_extension("stats.csv.json"))
+                .ok()
+                .and_then(|t| serde_json::from_str::<serde_json::Value>(&t).ok())
+                .and_then(|m| {
+                    m.get("flag_cardinality_method")
+                        .and_then(|v| v.as_str().map(str::to_owned))
+                })
+                .is_some_and(|m| m.eq_ignore_ascii_case("approx"))
+        })
+}
+
 /// Does the stats cache's metadata sidecar POSTDATE the `.stats.csv.data.jsonl` beside it?
 ///
 /// If it does, the JSONL was produced by an earlier stats run and no longer describes the stats
@@ -5476,6 +5513,35 @@ mod tests {
         // behind. This is the case that silently poisoned consumers.
         filetime::set_file_mtime(&sidecar, FileTime::from_unix_time(3_000, 0)).unwrap();
         assert!(stats_jsonl_predates_stats_cache(&jsonl, [&input, &input]));
+    }
+
+    #[test]
+    fn statsdata_carries_every_column_stats_emits() {
+        // StatsData has no deny_unknown_fields, so a column present in the cache but missing
+        // from the struct is SILENTLY DROPPED on deserialize rather than erroring. That is how
+        // sortiness, geometric_mean, harmonic_mean and percentiles stayed unreachable to every
+        // consumer (schema, frequency, tojsonl, viz smart, describegpt) despite `stats` writing
+        // them into every .stats.csv.data.jsonl. Shapes and values below are taken from a real
+        // `stats --everything --stats-jsonl` line.
+        let line = r#"{"field":"id","type":"Integer","nullcount":0,"cardinality":5,
+            "sortiness":1.0,"geometric_mean":2.6052,"harmonic_mean":2.1898,
+            "percentiles":"5: 1|10: 1|40: 2|60: 3|90: 5|95: 5"}"#;
+
+        let s: crate::cmd::stats::StatsData = serde_json::from_str(line).unwrap();
+
+        assert_eq!(s.sortiness, Some(1.0));
+        assert_eq!(s.geometric_mean, Some(2.6052));
+        assert_eq!(s.harmonic_mean, Some(2.1898));
+        assert_eq!(
+            s.percentiles.as_deref(),
+            Some("5: 1|10: 1|40: 2|60: 3|90: 5|95: 5")
+        );
+
+        // and a cache written before these columns existed must still deserialize
+        let legacy = r#"{"field":"id","type":"Integer","nullcount":0,"cardinality":5}"#;
+        let s: crate::cmd::stats::StatsData = serde_json::from_str(legacy).unwrap();
+        assert_eq!(s.sortiness, None);
+        assert_eq!(s.percentiles, None);
     }
 
     #[cfg(test)]

--- a/src/util.rs
+++ b/src/util.rs
@@ -3848,6 +3848,18 @@ pub fn get_stats_records_readonly(
     if metadata.get("flag_select").and_then(|v| v.as_str()) != Some("<All>") {
         return None;
     }
+    // The input must be the same SIZE, not merely older. mtime alone is defeated by any
+    // mtime-preserving replacement (cp -p, tar -x, git checkout, rsync -t), and this cache
+    // carries sort_order: consuming a stale one lets `extsort` skip a sort it still needs and
+    // `sortcheck` report replaced, unsorted input as sorted. Unlike get_stats_records, no
+    // sidecar-less allowance is needed here - this path already fails closed without metadata.
+    if metadata
+        .get("filesize_bytes")
+        .and_then(serde_json::Value::as_u64)
+        .is_some_and(|recorded| recorded != 0 && recorded != input_metadata.len())
+    {
+        return None;
+    }
     // --no-headers and the effective delimiter must match the consuming command; shared with
     // `get_stats_records` so the two cannot drift apart again.
     if !stats_cache_parsing_opts_match(

--- a/src/util.rs
+++ b/src/util.rs
@@ -3851,13 +3851,22 @@ pub fn get_stats_records_readonly(
     // The input must be the same SIZE, not merely older. mtime alone is defeated by any
     // mtime-preserving replacement (cp -p, tar -x, git checkout, rsync -t), and this cache
     // carries sort_order: consuming a stale one lets `extsort` skip a sort it still needs and
-    // `sortcheck` report replaced, unsorted input as sorted. Unlike get_stats_records, no
-    // sidecar-less allowance is needed here - this path already fails closed without metadata.
-    if metadata
-        .get("filesize_bytes")
-        .and_then(serde_json::Value::as_u64)
-        .is_some_and(|recorded| recorded != 0 && recorded != input_metadata.len())
-    {
+    // `sortcheck` report replaced, unsorted input as sorted.
+    //
+    // FAIL CLOSED, unlike the same check in `get_stats_records`. That asymmetry is deliberate:
+    // there, absent metadata must mean "no opinion" so the sidecar-less cache `moarstats`
+    // writes from its extended stats is not discarded. No such case reaches here - this path
+    // already returns None when the sidecar is missing or unreadable, and requires a full-file
+    // (`<All>`) cache - so a sidecar that is present but cannot substantiate the size is simply
+    // unverifiable, and an unverifiable cache must not prove a file sorted. This also refuses a
+    // recorded 0, which is never written (the real size is stored unconditionally before the
+    // sidecar is), and so would only ever be a bypass.
+    if !matches!(
+        metadata
+            .get("filesize_bytes")
+            .and_then(serde_json::Value::as_u64),
+        Some(recorded) if recorded == input_metadata.len()
+    ) {
         return None;
     }
     // --no-headers and the effective delimiter must match the consuming command; shared with

--- a/src/util.rs
+++ b/src/util.rs
@@ -5570,6 +5570,7 @@ mod tests {
         // `stats --everything --stats-jsonl` line.
         let line = r#"{"field":"id","type":"Integer","nullcount":0,"cardinality":5,
             "sortiness":1.0,"geometric_mean":2.6052,"harmonic_mean":2.1898,
+            "median":"2",
             "percentiles":"5: 1|10: 1|40: 2|60: 3|90: 5|95: 5"}"#;
 
         let s: crate::cmd::stats::StatsData = serde_json::from_str(line).unwrap();
@@ -5577,16 +5578,26 @@ mod tests {
         assert_eq!(s.sortiness, Some(1.0));
         assert_eq!(s.geometric_mean, Some(2.6052));
         assert_eq!(s.harmonic_mean, Some(2.1898));
+        assert_eq!(s.median.as_deref(), Some("2"));
         assert_eq!(
             s.percentiles.as_deref(),
             Some("5: 1|10: 1|40: 2|60: 3|90: 5|95: 5")
         );
+
+        // `median` is a type-dependent RENDERING (like min/max), so a Date column carries an
+        // RFC3339 string in the same key. It must survive deserialization verbatim - typing it
+        // as a float coerced this to 0.0 and silently corrupted date medians.
+        let date_line = r#"{"field":"open_dt","type":"Date","nullcount":0,"cardinality":3,
+            "median":"2020-01-15"}"#;
+        let s: crate::cmd::stats::StatsData = serde_json::from_str(date_line).unwrap();
+        assert_eq!(s.median.as_deref(), Some("2020-01-15"));
 
         // and a cache written before these columns existed must still deserialize
         let legacy = r#"{"field":"id","type":"Integer","nullcount":0,"cardinality":5}"#;
         let s: crate::cmd::stats::StatsData = serde_json::from_str(legacy).unwrap();
         assert_eq!(s.sortiness, None);
         assert_eq!(s.percentiles, None);
+        assert_eq!(s.median, None);
     }
 
     #[cfg(test)]

--- a/tests/test_frequency.rs
+++ b/tests/test_frequency.rs
@@ -7234,3 +7234,46 @@ fn frequency_from_zip_parallel_autoindexed() {
     );
     assert!(got[1..].iter().all(|r| r[0] == "source"));
 }
+
+// Regression (R11): frequency detects all-unique (ID) columns by comparing the CACHED cardinality
+// for EQUALITY against the exact row count, then collapses them to one <ALL_UNIQUE> sentinel. That
+// test is invalid against a HyperLogLog estimate (`stats --cardinality-method approx`, a
+// documented speed-up): a merely near-unique column whose estimate happens to land on the row
+// count is wrongly collapsed, DROPPING real frequency rows.
+//
+// Deliberate trade: on small inputs HLL is exact, so the sentinel this now declines to emit would
+// have been correct here. We cannot tell that apart from the wrong case without counting, and
+// under-collapsing only costs verbosity while over-collapsing loses data. Exact cardinality (the
+// default) still gets the sentinel.
+#[test]
+fn frequency_all_unique_shortcut_skipped_on_approx_cardinality_cache() {
+    let wrk = Workdir::new("frequency_all_unique_shortcut_skipped_on_approx_cardinality_cache");
+    let mut rows: Vec<Vec<String>> = vec![vec!["id".to_string(), "grp".to_string()]];
+    for i in 0..200 {
+        rows.push(vec![i.to_string(), (i % 3).to_string()]);
+    }
+    wrk.create("ids.csv", rows);
+
+    // pre-build the cache with APPROX cardinality
+    let mut cmd = wrk.command("stats");
+    cmd.arg("--cardinality")
+        .args(["--cardinality-method", "approx"])
+        .arg("--stats-jsonl")
+        .args(["-c", "1"])
+        .arg("ids.csv");
+    wrk.assert_success(&mut cmd);
+
+    let mut cmd = wrk.command("frequency");
+    cmd.arg("ids.csv");
+    let got: String = wrk.stdout_on_success(&mut cmd);
+
+    assert!(
+        !got.contains("<ALL_UNIQUE>"),
+        "the <ALL_UNIQUE> shortcut was taken from an approximate (HLL) cardinality:\n{got}"
+    );
+    // the column is still reported, just enumerated rather than collapsed
+    assert!(
+        got.lines().any(|l| l.starts_with("id,")),
+        "the id column disappeared entirely:\n{got}"
+    );
+}

--- a/tests/test_frequency.rs
+++ b/tests/test_frequency.rs
@@ -7277,3 +7277,47 @@ fn frequency_all_unique_shortcut_skipped_on_approx_cardinality_cache() {
         "the id column disappeared entirely:\n{got}"
     );
 }
+
+// Regression (R10): QSV_STATSCACHE_MODE=force was STRICTLY WEAKER than the default. env_mode is
+// validated to auto/force/none and "none" returns earlier, so a `env_mode != "auto"` guard meant
+// exactly "force" -- and it made force skip regeneration, return no cardinality and create no
+// cache, while plain auto-mode regenerated and cached. The documented contract is the opposite:
+// "force - if the cache does not exist, create it by running stats".
+#[test]
+fn frequency_statscache_mode_force_creates_the_cache() {
+    let wrk = Workdir::new("frequency_statscache_mode_force_creates_the_cache");
+    let mut rows: Vec<Vec<String>> = vec![vec!["id".to_string(), "grp".to_string()]];
+    for i in 0..200 {
+        rows.push(vec![i.to_string(), (i % 3).to_string()]);
+    }
+    wrk.create("ids.csv", rows);
+
+    let mut cmd = wrk.command("frequency");
+    cmd.env("QSV_STATSCACHE_MODE", "force").arg("ids.csv");
+    let got: String = wrk.stdout_on_success(&mut cmd);
+
+    assert!(
+        wrk.path("ids.stats.csv.data.jsonl").exists(),
+        "force mode did not create the stats cache"
+    );
+    // with cardinality available, the all-unique id column collapses to one sentinel
+    assert!(
+        got.contains("<ALL_UNIQUE>"),
+        "force mode produced no cardinality, losing the <ALL_UNIQUE> short-circuit:\n{got}"
+    );
+
+    // "none" must still skip the cache entirely
+    let wrk2 = Workdir::new("frequency_statscache_mode_none_skips_the_cache");
+    let mut rows: Vec<Vec<String>> = vec![vec!["id".to_string(), "grp".to_string()]];
+    for i in 0..200 {
+        rows.push(vec![i.to_string(), (i % 3).to_string()]);
+    }
+    wrk2.create("ids.csv", rows);
+    let mut cmd = wrk2.command("frequency");
+    cmd.env("QSV_STATSCACHE_MODE", "none").arg("ids.csv");
+    wrk2.assert_success(&mut cmd);
+    assert!(
+        !wrk2.path("ids.stats.csv.data.jsonl").exists(),
+        "none mode created a stats cache"
+    );
+}

--- a/tests/test_get.rs
+++ b/tests/test_get.rs
@@ -2121,3 +2121,46 @@ fn get_literal_filename_with_glob_metachars() {
         "a real file with glob chars in its name should fetch as one file"
     );
 }
+
+// Regression: frequency's guard against taking the <ALL_UNIQUE> shortcut from an APPROXIMATE
+// (HyperLogLog) cardinality looked beside the raw input string, while get_stats_records resolves
+// a `dc:` handle to its materialized CSV first. So for a `dc:` input the guard found no sidecar,
+// concluded the cardinality was exact, and let the invalid equality shortcut run anyway.
+#[test]
+fn get_dc_approx_cardinality_does_not_take_all_unique_shortcut() {
+    let wrk = Workdir::new("get_dc_approx_cardinality_does_not_take_all_unique_shortcut");
+    let cache_dir = wrk.path("qsvcache");
+    let src = wrk.path("ids.csv");
+
+    let mut body = String::from("id,grp\n");
+    for i in 0..200 {
+        body.push_str(&format!("{i},{}\n", i % 3));
+    }
+    std::fs::write(&src, body).unwrap();
+
+    let mut g = wrk.command("get");
+    g.env("QSV_CACHE_DIR", &cache_dir)
+        .args(["--name", "ids.csv"])
+        .arg(src.to_str().unwrap());
+    wrk.assert_success(&mut g);
+
+    // build the stats cache for the dc: handle with APPROX cardinality
+    let mut s = wrk.command("stats");
+    s.env("QSV_CACHE_DIR", &cache_dir)
+        .arg("--cardinality")
+        .args(["--cardinality-method", "approx"])
+        .arg("--stats-jsonl")
+        .args(["-c", "1"])
+        .arg("dc:ids.csv");
+    wrk.assert_success(&mut s);
+
+    let mut f = wrk.command("frequency");
+    f.env("QSV_CACHE_DIR", &cache_dir).arg("dc:ids.csv");
+    let got = wrk.stdout::<String>(&mut f);
+
+    assert!(
+        !got.contains("<ALL_UNIQUE>"),
+        "the <ALL_UNIQUE> shortcut was taken from an approximate cardinality for a dc: \
+         input:\n{got}"
+    );
+}

--- a/tests/test_moarstats.rs
+++ b/tests/test_moarstats.rs
@@ -6582,3 +6582,69 @@ fn moarstats_outlier_counts_populated() {
         "Did not find 'value' field in moarstats output"
     );
 }
+
+// INVARIANT LOCK (not a reproduction of a past failure -- it passes on the code that had the
+// bug, see below). `moarstats` writes <FILESTEM>.stats.csv.data.jsonl from its EXTENDED stats
+// and writes no .stats.csv.json sidecar of its own, and util.rs deliberately trusts sidecar-less
+// jsonl so that richer cache is not discarded. Every stats-cache check added to the consumer
+// read path must preserve that.
+//
+// A date-blind-cache guard added to that path did regenerate this file and silently downgrade it
+// to the lean column set, costing `viz smart` its moarstats hints -- but only when the BASE stats
+// were themselves date-blind. Standalone `qsv moarstats` passes --infer-dates in its own default
+// --stats-options, so this path was never affected and this test would NOT have caught it.
+// It is here to stop a future check from ignoring the sidecar-less/enriched case wholesale.
+#[test]
+fn moarstats_rich_jsonl_survives_a_schema_run() {
+    let wrk = Workdir::new("moarstats_rich_jsonl_survives_a_schema_run");
+    let mut rows: Vec<Vec<String>> =
+        vec![vec!["id".to_string(), "v".to_string(), "cat".to_string()]];
+    for i in 0..300 {
+        rows.push(vec![
+            i.to_string(),
+            ((i * 7919) % 997).to_string(),
+            ((b'a' + (i % 5) as u8) as char).to_string(),
+        ]);
+    }
+    wrk.create("m.csv", rows);
+
+    let mut cmd = wrk.command("moarstats");
+    cmd.arg("m.csv");
+    wrk.assert_success(&mut cmd);
+
+    let jsonl = wrk.path("m.stats.csv.data.jsonl");
+    let cols_after_moarstats = serde_json::from_str::<serde_json::Value>(
+        std::fs::read_to_string(&jsonl)
+            .unwrap()
+            .lines()
+            .next()
+            .unwrap(),
+    )
+    .unwrap()
+    .as_object()
+    .unwrap()
+    .len();
+
+    // a consumer that reads the stats cache must not downgrade it
+    let mut cmd = wrk.command("schema");
+    cmd.arg("m.csv");
+    wrk.assert_success(&mut cmd);
+
+    let cols_after_schema = serde_json::from_str::<serde_json::Value>(
+        std::fs::read_to_string(&jsonl)
+            .unwrap()
+            .lines()
+            .next()
+            .unwrap(),
+    )
+    .unwrap()
+    .as_object()
+    .unwrap()
+    .len();
+
+    assert_eq!(
+        cols_after_moarstats, cols_after_schema,
+        "schema downgraded moarstats' extended stats jsonl from {cols_after_moarstats} columns to \
+         {cols_after_schema}"
+    );
+}

--- a/tests/test_moarstats.rs
+++ b/tests/test_moarstats.rs
@@ -6594,6 +6594,7 @@ fn moarstats_outlier_counts_populated() {
 // were themselves date-blind. Standalone `qsv moarstats` passes --infer-dates in its own default
 // --stats-options, so this path was never affected and this test would NOT have caught it.
 // It is here to stop a future check from ignoring the sidecar-less/enriched case wholesale.
+#[cfg(any(feature = "feature_capable", feature = "lite"))]
 #[test]
 fn moarstats_rich_jsonl_survives_a_schema_run() {
     let wrk = Workdir::new("moarstats_rich_jsonl_survives_a_schema_run");

--- a/tests/test_moarstats.rs
+++ b/tests/test_moarstats.rs
@@ -6648,3 +6648,49 @@ fn moarstats_rich_jsonl_survives_a_schema_run() {
          {cols_after_schema}"
     );
 }
+
+// Regression: moarstats located the baseline <FILESTEM>.stats.csv by path and regenerated it only
+// when ABSENT -- existence alone, never compared against the input. A stats CSV left over from an
+// earlier version of the input was therefore used as the baseline for every statistic moarstats
+// derives, silently describing data that is no longer there.
+#[test]
+fn moarstats_regenerates_a_stale_baseline_stats_csv() {
+    let wrk = Workdir::new("moarstats_regenerates_a_stale_baseline_stats_csv");
+    let mut rows: Vec<Vec<String>> = vec![vec!["id".to_string(), "v".to_string()]];
+    for i in 0..200 {
+        rows.push(vec![i.to_string(), "1".to_string()]);
+    }
+    wrk.create("st.csv", rows);
+
+    // baseline stats over v = all 1s  -> sum 200
+    let mut cmd = wrk.command("stats");
+    cmd.arg("--everything").arg("st.csv");
+    wrk.assert_success(&mut cmd);
+    let baseline = std::fs::read_to_string(wrk.path("st.stats.csv")).unwrap();
+    assert!(
+        baseline.lines().any(|l| l.starts_with("v,")),
+        "setup: expected a v row in the baseline stats"
+    );
+
+    // now change the input so the cached baseline no longer describes it
+    let mut rows: Vec<Vec<String>> = vec![vec!["id".to_string(), "v".to_string()]];
+    for i in 0..200 {
+        rows.push(vec![i.to_string(), "1000".to_string()]);
+    }
+    wrk.create("st.csv", rows);
+
+    let mut cmd = wrk.command("moarstats");
+    cmd.arg("st.csv");
+    wrk.assert_success(&mut cmd);
+
+    // the baseline must have been recomputed against the NEW data (sum 200000, not 200)
+    let after = std::fs::read_to_string(wrk.path("st.stats.csv")).unwrap();
+    let v_row = after
+        .lines()
+        .find(|l| l.starts_with("v,"))
+        .expect("no v row in regenerated stats");
+    assert!(
+        v_row.contains("200000"),
+        "moarstats used a stale baseline stats CSV; v row was: {v_row}"
+    );
+}

--- a/tests/test_sortcheck.rs
+++ b/tests/test_sortcheck.rs
@@ -595,3 +595,52 @@ fn sortcheck_statscache_missing_metadata_no_shortcircuit() {
     cmd.args(["--select", "name"]).arg("in.csv");
     wrk.assert_err(&mut cmd);
 }
+
+// Regression: sortcheck's stats-cache short-circuit reads the cache through
+// get_stats_records_readonly(), which validated mtime, --select, --no-headers and the delimiter
+// but NOT the recorded input size. An mtime-preserving replacement (cp -p, tar -x, git checkout,
+// rsync -t) therefore let a cached "Ascending" sort_order prove an entirely different file
+// sorted: sortcheck exited 0 on descending input.
+#[test]
+fn sortcheck_rejects_stale_cache_after_same_mtime_content_swap() {
+    let wrk = Workdir::new("sortcheck_rejects_stale_cache_after_same_mtime_content_swap");
+    wrk.create(
+        "sc.csv",
+        vec![
+            svec!["id", "v"],
+            svec!["1", "10"],
+            svec!["2", "20"],
+            svec!["3", "30"],
+            svec!["4", "40"],
+            svec!["5", "50"],
+        ],
+    );
+    let input = wrk.path("sc.csv");
+
+    // build the stats cache while the file really is ascending
+    let mut cmd = wrk.command("stats");
+    cmd.arg("--cardinality")
+        .arg("--stats-jsonl")
+        .args(["-c", "1"])
+        .arg("sc.csv");
+    wrk.assert_success(&mut cmd);
+
+    // replace with UNSORTED content of a different size, preserving the original mtime
+    let meta = std::fs::metadata(&input).unwrap();
+    let times = std::fs::FileTimes::new()
+        .set_accessed(meta.accessed().unwrap())
+        .set_modified(meta.modified().unwrap());
+    std::fs::write(&input, "id,v\n9,1\n3,2\n7,3\n").unwrap();
+    std::fs::File::options()
+        .write(true)
+        .open(&input)
+        .unwrap()
+        .set_times(times)
+        .unwrap();
+
+    // --numeric so the cache's Integer sort_order matches the comparator, which is what makes
+    // the short-circuit eligible in the first place
+    let mut cmd = wrk.command("sortcheck");
+    cmd.args(["--select", "id"]).arg("--numeric").arg("sc.csv");
+    wrk.assert_err(&mut cmd);
+}

--- a/tests/test_sortcheck.rs
+++ b/tests/test_sortcheck.rs
@@ -644,3 +644,58 @@ fn sortcheck_rejects_stale_cache_after_same_mtime_content_swap() {
     cmd.args(["--select", "id"]).arg("--numeric").arg("sc.csv");
     wrk.assert_err(&mut cmd);
 }
+
+// Regression: the readonly stats-cache path's filesize check originally failed OPEN when
+// `filesize_bytes` was absent from the sidecar, so a sidecar written by a qsv predating that
+// field (or a truncated one) still let a cached "Ascending" prove a replaced file sorted. The
+// fail-open convention was borrowed from get_stats_records, where absent metadata must mean
+// "no opinion" so moarstats' sidecar-less cache survives -- a case that cannot reach this path,
+// which already refuses a missing sidecar outright.
+#[test]
+fn sortcheck_rejects_cache_whose_sidecar_cannot_prove_input_size() {
+    let wrk = Workdir::new("sortcheck_rejects_cache_whose_sidecar_cannot_prove_input_size");
+    wrk.create(
+        "sc2.csv",
+        vec![
+            svec!["id", "v"],
+            svec!["1", "10"],
+            svec!["2", "20"],
+            svec!["3", "30"],
+            svec!["4", "40"],
+            svec!["5", "50"],
+        ],
+    );
+    let input = wrk.path("sc2.csv");
+
+    let mut cmd = wrk.command("stats");
+    cmd.arg("--cardinality")
+        .arg("--stats-jsonl")
+        .args(["-c", "1"])
+        .arg("sc2.csv");
+    wrk.assert_success(&mut cmd);
+
+    // simulate a sidecar from before filesize_bytes was recorded
+    let sidecar = wrk.path("sc2.stats.csv.json");
+    let mut meta: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&sidecar).unwrap()).unwrap();
+    meta.as_object_mut().unwrap().remove("filesize_bytes");
+    std::fs::write(&sidecar, serde_json::to_string_pretty(&meta).unwrap()).unwrap();
+
+    // replace with unsorted content, preserving the original mtime
+    let fmeta = std::fs::metadata(&input).unwrap();
+    let times = std::fs::FileTimes::new()
+        .set_accessed(fmeta.accessed().unwrap())
+        .set_modified(fmeta.modified().unwrap());
+    std::fs::write(&input, "id,v\n5,10\n4,20\n3,30\n2,40\n1,50\n").unwrap();
+    std::fs::File::options()
+        .write(true)
+        .open(&input)
+        .unwrap()
+        .set_times(times)
+        .unwrap();
+
+    // the cache cannot substantiate the input size, so it must not prove the file sorted
+    let mut cmd = wrk.command("sortcheck");
+    cmd.args(["--select", "id"]).arg("--numeric").arg("sc2.csv");
+    wrk.assert_err(&mut cmd);
+}

--- a/tests/test_stats.rs
+++ b/tests/test_stats.rs
@@ -8076,3 +8076,98 @@ fn stats_everything_approx_quantiles_header_matches_records() {
         "approx quantiles cannot compute MAD, so no mad column should be advertised"
     );
 }
+
+// Regression: the stats subprocess folds QSV_PREFER_DMY into flag_prefer_dmy (stats.rs), so a
+// sidecar written under that env var records prefer_dmy=true -- while consumers that build
+// SchemaArgs literally (frequency, joinp, pivotp, sample) hardcode flag_prefer_dmy: false.
+// Comparing the raw flag made every such run mismatch its own freshly written cache and
+// regenerate it, on every invocation, forever.
+#[test]
+fn stats_cache_no_dmy_churn_under_prefer_dmy_envvar() {
+    let wrk = Workdir::new("stats_cache_no_dmy_churn_under_prefer_dmy_envvar");
+    wrk.create(
+        "dmy.csv",
+        vec![
+            svec!["id", "open_dt"],
+            svec!["1", "2020-01-15"],
+            svec!["2", "2021-06-30"],
+            svec!["3", "2019-03-04"],
+        ],
+    );
+
+    let mut cmd = wrk.command("frequency");
+    cmd.env("QSV_PREFER_DMY", "1").arg("dmy.csv");
+    wrk.assert_success(&mut cmd);
+
+    let jsonl = wrk.path("dmy.stats.csv.data.jsonl");
+    let first = std::fs::metadata(&jsonl).unwrap().modified().unwrap();
+
+    // a second identical run must REUSE the cache it just wrote
+    let mut cmd = wrk.command("frequency");
+    cmd.env("QSV_PREFER_DMY", "1").arg("dmy.csv");
+    wrk.assert_success(&mut cmd);
+
+    let second = std::fs::metadata(&jsonl).unwrap().modified().unwrap();
+    assert_eq!(
+        first, second,
+        "the stats cache was regenerated on an identical second run - QSV_PREFER_DMY makes the \
+         cache permanently self-conflicting"
+    );
+}
+
+// Regression: `stats` compares the recorded filesize before reusing its CSV cache, but cache
+// CONSUMERS read the .stats.csv.data.jsonl through get_stats_records, which judged it by mtime
+// and parsing options only. The same mtime-preserving replacement that `stats` correctly rejects
+// therefore still served consumers the PREVIOUS file's statistics.
+#[test]
+fn stats_jsonl_cache_rejected_after_same_mtime_content_swap() {
+    let wrk = Workdir::new("stats_jsonl_cache_rejected_after_same_mtime_content_swap");
+    wrk.create(
+        "sz.csv",
+        vec![
+            svec!["id", "v"],
+            svec!["1", "100"],
+            svec!["2", "200"],
+            svec!["3", "300"],
+        ],
+    );
+    let input = wrk.path("sz.csv");
+
+    let mut cmd = wrk.command("stats");
+    cmd.arg("--infer-dates")
+        .arg("--cardinality")
+        .arg("--stats-jsonl")
+        .args(["-c", "1"])
+        .arg("sz.csv");
+    wrk.assert_success(&mut cmd);
+
+    let jsonl = wrk.path("sz.stats.csv.data.jsonl");
+    assert!(
+        std::fs::read_to_string(&jsonl).unwrap().contains("600"),
+        "setup: sum of v should be 600"
+    );
+
+    // replace the content but keep the original mtime, exactly as `cp -p` would
+    let meta = std::fs::metadata(&input).unwrap();
+    let times = std::fs::FileTimes::new()
+        .set_accessed(meta.accessed().unwrap())
+        .set_modified(meta.modified().unwrap());
+    std::fs::write(&input, "id,v\n9,7\n").unwrap();
+    std::fs::File::options()
+        .write(true)
+        .open(&input)
+        .unwrap()
+        .set_times(times)
+        .unwrap();
+
+    // a consumer must not be served the pre-swap stats
+    let mut cmd = wrk.command("schema");
+    cmd.arg("sz.csv");
+    wrk.assert_success(&mut cmd);
+
+    let after = std::fs::read_to_string(&jsonl).unwrap();
+    assert!(
+        !after.contains("600"),
+        "consumer was served pre-swap stats after an mtime-preserving replacement:\n{after}"
+    );
+}

--- a/tests/test_stats.rs
+++ b/tests/test_stats.rs
@@ -7840,3 +7840,96 @@ fn stats_cache_force_drops_stale_sidecar() {
         "--typesonly output was served as --everything; header was: {header}"
     );
 }
+
+// Regression (F6): the --everything cache-reuse arm compares an itemized list of flags and
+// omitted the three METHOD flags, which change the VALUES produced (approx quantiles via
+// t-digest, approx cardinality via HLL, mode/antimode suppressed above the cap). An exact
+// run could therefore be served an approximate cache.
+#[test]
+fn stats_cache_not_reused_when_cardinality_method_differs() {
+    use serde_json::Value;
+
+    let wrk = Workdir::new("stats_cache_not_reused_when_cardinality_method_differs");
+    let mut rows: Vec<Vec<String>> = vec![vec!["id".to_string(), "v".to_string()]];
+    for i in 0..500 {
+        rows.push(vec![i.to_string(), (i % 97).to_string()]);
+    }
+    wrk.create("cm.csv", rows);
+
+    // build an --everything cache with APPROX cardinality
+    let mut cmd = wrk.command("stats");
+    cmd.arg("--everything")
+        .args(["--cardinality-method", "approx"])
+        .args(["-c", "1"])
+        .arg("cm.csv");
+    wrk.assert_success(&mut cmd);
+
+    let sidecar = wrk.path("cm.stats.csv.json");
+    let json: Value = serde_json::from_str(&std::fs::read_to_string(&sidecar).unwrap()).unwrap();
+    assert_eq!(json["flag_cardinality_method"], "approx", "setup failed");
+
+    // an EXACT --everything run must not reuse it. If it recomputes, the sidecar is
+    // rewritten and records the exact method; if it wrongly reuses, the sidecar is
+    // untouched and still says "approx".
+    let mut cmd = wrk.command("stats");
+    cmd.arg("--everything").args(["-c", "1"]).arg("cm.csv");
+    wrk.assert_success(&mut cmd);
+
+    let json: Value = serde_json::from_str(&std::fs::read_to_string(&sidecar).unwrap()).unwrap();
+    assert_eq!(
+        json["flag_cardinality_method"], "exact",
+        "an exact --everything run was served the approx-cardinality cache"
+    );
+}
+
+// Regression (F5): cache validity was effectively mtime-only, so any mtime-preserving
+// content replacement (cp -p, tar -x, git checkout, rsync -t) silently served the PREVIOUS
+// file's statistics. The recorded filesize is now compared too.
+//
+// NOTE: the sidecar's blake3 `hash` cannot close this - it fingerprints the stats OUTPUT,
+// not the input file, so verifying it would require recomputing the stats being reused.
+#[test]
+fn stats_cache_invalidated_by_same_mtime_content_swap() {
+    let wrk = Workdir::new("stats_cache_invalidated_by_same_mtime_content_swap");
+    wrk.create(
+        "swap.csv",
+        vec![
+            svec!["id", "v"],
+            svec!["1", "100"],
+            svec!["2", "200"],
+            svec!["3", "300"],
+        ],
+    );
+    let input = wrk.path("swap.csv");
+
+    let mut cmd = wrk.command("stats");
+    cmd.args(["-c", "1"]).arg("swap.csv");
+    let first: String = wrk.stdout_on_success(&mut cmd);
+    assert!(first.contains("600"), "setup: sum of v should be 600");
+
+    // preserve the ORIGINAL mtime across a content change, exactly as `cp -p` would
+    let meta = std::fs::metadata(&input).unwrap();
+    let times = std::fs::FileTimes::new()
+        .set_accessed(meta.accessed().unwrap())
+        .set_modified(meta.modified().unwrap());
+    std::fs::write(&input, "id,v\n9,7\n").unwrap();
+    std::fs::File::options()
+        .write(true)
+        .open(&input)
+        .unwrap()
+        .set_times(times)
+        .unwrap();
+
+    // the cached stats describe the OLD content; they must not be served
+    let mut cmd = wrk.command("stats");
+    cmd.args(["-c", "1"]).arg("swap.csv");
+    let second: String = wrk.stdout_on_success(&mut cmd);
+    assert!(
+        second.contains(",7,") || second.contains(",7\n") || second.ends_with(",7"),
+        "stale pre-swap stats were served after an mtime-preserving replacement:\n{second}"
+    );
+    assert!(
+        !second.contains("600"),
+        "stale pre-swap stats were served after an mtime-preserving replacement:\n{second}"
+    );
+}

--- a/tests/test_stats.rs
+++ b/tests/test_stats.rs
@@ -8034,3 +8034,45 @@ fn stats_date_blind_frequency_cache_not_reused_by_schema() {
         "schema reused frequency's date-blind stats cache:\n{after}"
     );
 }
+
+// Regression: `stats_headers()` re-derived the MAD column as `flag_mad || everything`, while
+// which_stats() turns MAD off for --quantile-method approx (a t-digest cannot compute
+// median(|x - median|)). The header therefore advertised a "mad" column that records did not
+// carry, and the csv writer rejects the arity change -- so
+// `qsv stats --everything --quantile-method approx` died with
+// "found record with 48 fields, but the previous record has 49 fields", exit 1 and no output.
+//
+// Needs enough rows to reach the write; a handful of rows does not trip it.
+#[test]
+fn stats_everything_approx_quantiles_header_matches_records() {
+    let wrk = Workdir::new("stats_everything_approx_quantiles_header_matches_records");
+    let mut rows: Vec<Vec<String>> = vec![vec!["id".to_string(), "v".to_string()]];
+    for i in 0..5000 {
+        rows.push(vec![i.to_string(), ((i * 7919) % 9973).to_string()]);
+    }
+    wrk.create("aq.csv", rows);
+
+    let mut cmd = wrk.command("stats");
+    cmd.arg("--everything")
+        .args(["--quantile-method", "approx"])
+        .arg("aq.csv");
+    // read_stdout_on_success asserts a clean exit, which is most of the point here
+    let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
+
+    assert!(
+        got.len() > 1,
+        "expected a header and at least one stats row"
+    );
+    let header = &got[0];
+    for (i, row) in got.iter().enumerate().skip(1) {
+        assert_eq!(
+            header.len(),
+            row.len(),
+            "header/record arity mismatch on row {i}"
+        );
+    }
+    assert!(
+        !header.iter().any(|h| h == "mad"),
+        "approx quantiles cannot compute MAD, so no mad column should be advertised"
+    );
+}

--- a/tests/test_stats.rs
+++ b/tests/test_stats.rs
@@ -8208,3 +8208,92 @@ fn stats_jsonl_flag_creates_the_sidecar_on_a_cache_hit() {
         "--stats-jsonl produced no .data.jsonl on a warm cache hit"
     );
 }
+
+// Regression: `stats --median` (without --quartiles/--everything) emits a `median` column that is
+// a DIFFERENT key from `q2_median`. It was absent from both StatsData and STATSDATA_TYPES_MAP, so
+// it serialized via the map's String fallback ("2") and was then silently dropped on deserialize
+// -- the same drift that hid sortiness/geometric_mean/harmonic_mean/percentiles.
+#[test]
+fn stats_median_column_is_typed_and_not_dropped() {
+    let wrk = Workdir::new("stats_median_column_is_typed_and_not_dropped");
+    wrk.create(
+        "med.csv",
+        vec![
+            svec!["id", "v"],
+            svec!["1", "10"],
+            svec!["2", "20"],
+            svec!["3", "30"],
+        ],
+    );
+
+    let mut cmd = wrk.command("stats");
+    cmd.arg("--median")
+        .arg("--stats-jsonl")
+        .args(["-c", "1"])
+        .arg("med.csv");
+    wrk.assert_success(&mut cmd);
+
+    let jsonl = std::fs::read_to_string(wrk.path("med.stats.csv.data.jsonl")).unwrap();
+    let first: serde_json::Value = serde_json::from_str(jsonl.lines().next().unwrap()).unwrap();
+
+    let median = first
+        .get("median")
+        .expect("no median key in the stats jsonl");
+    assert!(
+        median.is_number(),
+        "median should be a number, not the String fallback: {median}"
+    );
+}
+
+// Regression: on a warm cache hit, --stats-jsonl only created the jsonl when ABSENT, so a jsonl
+// left behind by an earlier run -- one that PREDATES the sidecar beside it, because a later run
+// refreshed stats.csv/.json without --stats-jsonl -- was preserved rather than refreshed. A flag
+// whose whole purpose is to produce a current cache handed back a stale one.
+#[test]
+fn stats_jsonl_flag_refreshes_a_jsonl_older_than_the_sidecar() {
+    let wrk = Workdir::new("stats_jsonl_flag_refreshes_a_jsonl_older_than_the_sidecar");
+    wrk.create(
+        "stale.csv",
+        vec![
+            svec!["id", "v"],
+            svec!["1", "10"],
+            svec!["2", "20"],
+            svec!["3", "30"],
+        ],
+    );
+
+    // 1. cache WITH a jsonl
+    let mut cmd = wrk.command("stats");
+    cmd.args(["-c", "1"])
+        .arg("--cardinality")
+        .arg("--stats-jsonl")
+        .arg("stale.csv");
+    wrk.assert_success(&mut cmd);
+    let jsonl = wrk.path("stale.stats.csv.data.jsonl");
+
+    // 2. different args, no --stats-jsonl: refreshes stats.csv + sidecar, leaves the jsonl behind
+    let mut cmd = wrk.command("stats");
+    cmd.args(["-c", "1"]).arg("stale.csv");
+    wrk.assert_success(&mut cmd);
+
+    let before = std::fs::metadata(&jsonl).unwrap().modified().unwrap();
+    let sidecar_mtime = std::fs::metadata(wrk.path("stale.stats.csv.json"))
+        .unwrap()
+        .modified()
+        .unwrap();
+    assert!(
+        sidecar_mtime > before,
+        "setup: the sidecar should now be newer than the jsonl"
+    );
+
+    // 3. asking for a current jsonl must refresh the stale one
+    let mut cmd = wrk.command("stats");
+    cmd.args(["-c", "1"]).arg("--stats-jsonl").arg("stale.csv");
+    wrk.assert_success(&mut cmd);
+
+    let after = std::fs::metadata(&jsonl).unwrap().modified().unwrap();
+    assert!(
+        after > before,
+        "--stats-jsonl preserved a jsonl that predates the stats cache beside it"
+    );
+}

--- a/tests/test_stats.rs
+++ b/tests/test_stats.rs
@@ -8171,3 +8171,40 @@ fn stats_jsonl_cache_rejected_after_same_mtime_content_swap() {
         "consumer was served pre-swap stats after an mtime-preserving replacement:\n{after}"
     );
 }
+
+// Regression (R1): --stats-jsonl was a silent no-op on a warm cache hit. The .data.jsonl is
+// written only inside the compute-and-cache branch, and StatsArgs has no flag_stats_jsonl field,
+// so the args comparison passes and compute_stats stays false -- meaning the flag documented as
+// preemptively creating that file for the "smart" commands created nothing at all.
+#[test]
+fn stats_jsonl_flag_creates_the_sidecar_on_a_cache_hit() {
+    let wrk = Workdir::new("stats_jsonl_flag_creates_the_sidecar_on_a_cache_hit");
+    wrk.create(
+        "warm.csv",
+        vec![
+            svec!["id", "v"],
+            svec!["1", "10"],
+            svec!["2", "20"],
+            svec!["3", "30"],
+        ],
+    );
+
+    // build a valid cache WITHOUT --stats-jsonl
+    let mut cmd = wrk.command("stats");
+    cmd.args(["-c", "1"]).arg("warm.csv");
+    wrk.assert_success(&mut cmd);
+    assert!(
+        !wrk.path("warm.stats.csv.data.jsonl").exists(),
+        "setup: no jsonl should exist yet"
+    );
+
+    // same args plus --stats-jsonl: a cache hit, but the file must still be produced
+    let mut cmd = wrk.command("stats");
+    cmd.args(["-c", "1"]).arg("--stats-jsonl").arg("warm.csv");
+    wrk.assert_success(&mut cmd);
+
+    assert!(
+        wrk.path("warm.stats.csv.data.jsonl").exists(),
+        "--stats-jsonl produced no .data.jsonl on a warm cache hit"
+    );
+}

--- a/tests/test_stats.rs
+++ b/tests/test_stats.rs
@@ -7946,6 +7946,7 @@ fn stats_cache_invalidated_by_same_mtime_content_swap() {
 // NOTE: the column is named "when" on purpose -- it matches none of schema's --dates-whitelist
 // patterns (date,time,due,open,close,created), so schema's own regeneration types it String.
 // That is what makes the Date -> String transition observable.
+#[cfg(any(feature = "feature_capable", feature = "lite"))]
 #[test]
 fn stats_jsonl_cache_not_served_after_recompute() {
     let wrk = Workdir::new("stats_jsonl_cache_not_served_after_recompute");
@@ -7999,6 +8000,7 @@ fn stats_jsonl_cache_not_served_after_recompute() {
 // it and emitted `string` for genuine date columns -- disagreeing with what schema produces on a
 // cold cache, and contradicting tojsonl's usage text, which promises reuse only of caches built
 // with --cardinality AND --infer-dates.
+#[cfg(any(feature = "feature_capable", feature = "lite"))]
 #[test]
 fn stats_date_blind_frequency_cache_not_reused_by_schema() {
     let wrk = Workdir::new("stats_date_blind_frequency_cache_not_reused_by_schema");
@@ -8119,6 +8121,7 @@ fn stats_cache_no_dmy_churn_under_prefer_dmy_envvar() {
 // CONSUMERS read the .stats.csv.data.jsonl through get_stats_records, which judged it by mtime
 // and parsing options only. The same mtime-preserving replacement that `stats` correctly rejects
 // therefore still served consumers the PREVIOUS file's statistics.
+#[cfg(any(feature = "feature_capable", feature = "lite"))]
 #[test]
 fn stats_jsonl_cache_rejected_after_same_mtime_content_swap() {
     let wrk = Workdir::new("stats_jsonl_cache_rejected_after_same_mtime_content_swap");

--- a/tests/test_stats.rs
+++ b/tests/test_stats.rs
@@ -7933,3 +7933,104 @@ fn stats_cache_invalidated_by_same_mtime_content_swap() {
         "stale pre-swap stats were served after an mtime-preserving replacement:\n{second}"
     );
 }
+
+// Regression: `.stats.csv.data.jsonl` is a THIRD cache file that no invalidation path touches,
+// and get_stats_records judges it current by mtime against the INPUT -- which a recompute never
+// modifies. So a recompute that refreshes stats.csv and its sidecar but does not pass
+// --stats-jsonl left the JSONL describing the PREVIOUS run's args, and consumers ate it.
+//
+// It is deliberately NOT deleted: `moarstats` writes this file from its extended stats and
+// writes no sidecar, so deleting (or blindly regenerating) it would discard a richer cache.
+// Instead, a JSONL older than the sidecar beside it is treated as stale.
+//
+// NOTE: the column is named "when" on purpose -- it matches none of schema's --dates-whitelist
+// patterns (date,time,due,open,close,created), so schema's own regeneration types it String.
+// That is what makes the Date -> String transition observable.
+#[test]
+fn stats_jsonl_cache_not_served_after_recompute() {
+    let wrk = Workdir::new("stats_jsonl_cache_not_served_after_recompute");
+    wrk.create(
+        "jl.csv",
+        vec![
+            svec!["id", "when"],
+            svec!["1", "2020-01-15"],
+            svec!["2", "2021-06-30"],
+            svec!["3", "2019-03-04"],
+        ],
+    );
+
+    // 1. build a date-inferred JSONL cache
+    let mut cmd = wrk.command("stats");
+    cmd.arg("--infer-dates")
+        .arg("--cardinality")
+        .arg("--stats-jsonl")
+        .args(["-c", "1"])
+        .arg("jl.csv");
+    wrk.assert_success(&mut cmd);
+
+    let jsonl = wrk.path("jl.stats.csv.data.jsonl");
+    let before = std::fs::read_to_string(&jsonl).unwrap();
+    assert!(
+        before.contains("\"Date\""),
+        "setup: jsonl should infer dates"
+    );
+
+    // 2. recompute WITHOUT --infer-dates and WITHOUT --stats-jsonl: stats.csv and the sidecar are
+    //    refreshed, the JSONL is left untouched and now contradicts them
+    let mut cmd = wrk.command("stats");
+    cmd.arg("--cardinality").args(["-c", "1"]).arg("jl.csv");
+    wrk.assert_success(&mut cmd);
+
+    // 3. a consumer must not be served the stale JSONL
+    let mut cmd = wrk.command("schema");
+    cmd.arg("jl.csv");
+    wrk.assert_success(&mut cmd);
+
+    let after = std::fs::read_to_string(&jsonl).unwrap();
+    assert!(
+        !after.contains("\"Date\""),
+        "consumer was served the stale date-inferred stats jsonl:\n{after}"
+    );
+}
+
+// Regression (F8): `frequency` auto-builds its stats cache with `stats --cardinality
+// --stats-jsonl` and NO --infer-dates, so every date column is typed String. That cache is
+// keyed only by input path and mtime, so a later `qsv schema` on the same unchanged file reused
+// it and emitted `string` for genuine date columns -- disagreeing with what schema produces on a
+// cold cache, and contradicting tojsonl's usage text, which promises reuse only of caches built
+// with --cardinality AND --infer-dates.
+#[test]
+fn stats_date_blind_frequency_cache_not_reused_by_schema() {
+    let wrk = Workdir::new("stats_date_blind_frequency_cache_not_reused_by_schema");
+    wrk.create(
+        "fd.csv",
+        vec![
+            svec!["id", "open_dt"],
+            svec!["1", "2020-01-15"],
+            svec!["2", "2021-06-30"],
+            svec!["3", "2019-03-04"],
+        ],
+    );
+
+    let mut cmd = wrk.command("frequency");
+    cmd.arg("fd.csv");
+    wrk.assert_success(&mut cmd);
+
+    let jsonl = wrk.path("fd.stats.csv.data.jsonl");
+    let before = std::fs::read_to_string(&jsonl).unwrap();
+    assert!(
+        !before.contains("\"Date\""),
+        "setup: frequency's cache should be date-blind:\n{before}"
+    );
+
+    // schema infers dates; it must not be served frequency's date-blind cache
+    let mut cmd = wrk.command("schema");
+    cmd.arg("fd.csv");
+    wrk.assert_success(&mut cmd);
+
+    let after = std::fs::read_to_string(&jsonl).unwrap();
+    assert!(
+        after.contains("\"Date\""),
+        "schema reused frequency's date-blind stats cache:\n{after}"
+    );
+}

--- a/tests/test_stats.rs
+++ b/tests/test_stats.rs
@@ -8219,29 +8219,48 @@ fn stats_median_column_is_typed_and_not_dropped() {
     wrk.create(
         "med.csv",
         vec![
-            svec!["id", "v"],
-            svec!["1", "10"],
-            svec!["2", "20"],
-            svec!["3", "30"],
+            svec!["id", "open_dt"],
+            svec!["1", "2020-01-15"],
+            svec!["2", "2021-06-30"],
+            svec!["3", "2019-03-04"],
         ],
     );
 
     let mut cmd = wrk.command("stats");
-    cmd.arg("--median")
+    cmd.arg("--infer-dates")
+        .arg("--median")
         .arg("--stats-jsonl")
         .args(["-c", "1"])
         .arg("med.csv");
     wrk.assert_success(&mut cmd);
 
     let jsonl = std::fs::read_to_string(wrk.path("med.stats.csv.data.jsonl")).unwrap();
-    let first: serde_json::Value = serde_json::from_str(jsonl.lines().next().unwrap()).unwrap();
+    let rows: Vec<serde_json::Value> = jsonl
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).unwrap())
+        .collect();
 
-    let median = first
+    // present at all - it used to be dropped entirely
+    let numeric = rows[0]
         .get("median")
-        .expect("no median key in the stats jsonl");
-    assert!(
-        median.is_number(),
-        "median should be a number, not the String fallback: {median}"
+        .expect("no median key for the id column");
+    assert_eq!(
+        numeric.as_str(),
+        Some("2"),
+        "numeric median was not preserved"
+    );
+
+    // and LOSSLESS for a Date column. median is a type-dependent RENDERING, like min/max:
+    // typing it Float made the JSON conversion coerce the RFC3339 string to 0.0, silently
+    // corrupting date medians.
+    let date = rows[1]
+        .get("median")
+        .expect("no median key for the date column");
+    assert_eq!(
+        date.as_str(),
+        Some("2020-01-15"),
+        "date median was corrupted in the stats jsonl: {date}"
     );
 }
 
@@ -8276,11 +8295,26 @@ fn stats_jsonl_flag_refreshes_a_jsonl_older_than_the_sidecar() {
     cmd.args(["-c", "1"]).arg("stale.csv");
     wrk.assert_success(&mut cmd);
 
-    let before = std::fs::metadata(&jsonl).unwrap().modified().unwrap();
+    // Force the jsonl clearly OLDER than the sidecar rather than relying on two real writes
+    // landing in strict order - a filesystem with coarse timestamp resolution can give them the
+    // same mtime and fail this test even when the implementation is correct.
     let sidecar_mtime = std::fs::metadata(wrk.path("stale.stats.csv.json"))
         .unwrap()
         .modified()
         .unwrap();
+    let forced = sidecar_mtime - std::time::Duration::from_secs(10);
+    std::fs::File::options()
+        .write(true)
+        .open(&jsonl)
+        .unwrap()
+        .set_times(
+            std::fs::FileTimes::new()
+                .set_accessed(forced)
+                .set_modified(forced),
+        )
+        .unwrap();
+
+    let before = std::fs::metadata(&jsonl).unwrap().modified().unwrap();
     assert!(
         sidecar_mtime > before,
         "setup: the sidecar should now be newer than the jsonl"

--- a/tests/test_stats.rs
+++ b/tests/test_stats.rs
@@ -7712,3 +7712,131 @@ fn stats_integer_range_no_i64_overflow() {
 
     assert_eq!(range_value, "18446744073709551615");
 }
+
+// Regression (F4): an args-changed recompute must delete the stats cache SIDECAR along
+// with the stats CSV. Leaving the sidecar behind let the next run validate against it and
+// trust it, serving stats computed with entirely different args as if they matched.
+#[test]
+fn stats_cache_sidecar_deleted_with_stats_csv() {
+    let wrk = Workdir::new("stats_cache_sidecar_deleted_with_stats_csv");
+    wrk.create(
+        "poison.csv",
+        vec![
+            svec!["id", "name", "when"],
+            svec!["1", "alpha", "2020-01-15"],
+            svec!["2", "beta", "2021-06-30"],
+            svec!["3", "gamma", "2019-03-04"],
+        ],
+    );
+
+    // 1. cache an --everything run (-c 1 forces cache creation)
+    let mut cmd = wrk.command("stats");
+    cmd.arg("--everything").args(["-c", "1"]).arg("poison.csv");
+    wrk.assert_success(&mut cmd);
+    assert!(
+        wrk.path("poison.stats.csv.json").exists(),
+        "setup failed: --everything sidecar was not created"
+    );
+
+    // 2. recompute with DIFFERENT args, below the cache threshold. The stale --everything sidecar
+    //    must not survive the recompute.
+    let mut cmd = wrk.command("stats");
+    cmd.arg("--typesonly").arg("poison.csv");
+    wrk.assert_success(&mut cmd);
+    assert!(
+        !wrk.path("poison.stats.csv.json").exists(),
+        "stale --everything sidecar survived an args-changed recompute"
+    );
+
+    // 3. --everything must be genuinely recomputed, NOT served from the typesonly cache
+    let mut cmd = wrk.command("stats");
+    cmd.arg("--everything").arg("poison.csv");
+    let got: String = wrk.stdout_on_success(&mut cmd);
+    let header = got.lines().next().unwrap_or_default();
+    assert!(
+        header.contains("cardinality") && header.contains("percentiles"),
+        "--typesonly output was served as --everything; header was: {header}"
+    );
+}
+
+// Regression (F4, lone-sidecar variant): every recompute path that drops the cache pair is
+// gated on the stats CSV existing, so a sidecar whose CSV was removed externally (or by an
+// interrupted run) was never inspected and never cleaned - and still poisoned the next run.
+#[test]
+fn stats_cache_lone_sidecar_not_trusted() {
+    let wrk = Workdir::new("stats_cache_lone_sidecar_not_trusted");
+    wrk.create(
+        "lone.csv",
+        vec![
+            svec!["id", "name", "when"],
+            svec!["1", "alpha", "2020-01-15"],
+            svec!["2", "beta", "2021-06-30"],
+            svec!["3", "gamma", "2019-03-04"],
+        ],
+    );
+
+    let mut cmd = wrk.command("stats");
+    cmd.arg("--everything").args(["-c", "1"]).arg("lone.csv");
+    wrk.assert_success(&mut cmd);
+
+    // remove ONLY the stats CSV, leaving the --everything sidecar orphaned
+    std::fs::remove_file(wrk.path("lone.stats.csv")).unwrap();
+    assert!(wrk.path("lone.stats.csv.json").exists());
+
+    // a --typesonly recompute installs a new stats CSV; the orphaned sidecar describes
+    // --everything and must not be left standing in front of it
+    let mut cmd = wrk.command("stats");
+    cmd.arg("--typesonly").arg("lone.csv");
+    wrk.assert_success(&mut cmd);
+    assert!(
+        !wrk.path("lone.stats.csv.json").exists(),
+        "orphaned --everything sidecar survived in front of freshly installed stats"
+    );
+
+    let mut cmd = wrk.command("stats");
+    cmd.arg("--everything").arg("lone.csv");
+    let got: String = wrk.stdout_on_success(&mut cmd);
+    let header = got.lines().next().unwrap_or_default();
+    assert!(
+        header.contains("cardinality") && header.contains("percentiles"),
+        "--typesonly output was served as --everything; header was: {header}"
+    );
+}
+
+// Regression (F4, --force variant): --force skips cache validation entirely, so it used to
+// reinstall a freshly computed stats CSV while the previous run's sidecar stayed put.
+#[test]
+fn stats_cache_force_drops_stale_sidecar() {
+    let wrk = Workdir::new("stats_cache_force_drops_stale_sidecar");
+    wrk.create(
+        "forced.csv",
+        vec![
+            svec!["id", "name", "when"],
+            svec!["1", "alpha", "2020-01-15"],
+            svec!["2", "beta", "2021-06-30"],
+            svec!["3", "gamma", "2019-03-04"],
+        ],
+    );
+
+    let mut cmd = wrk.command("stats");
+    cmd.arg("--everything").args(["-c", "1"]).arg("forced.csv");
+    wrk.assert_success(&mut cmd);
+    assert!(wrk.path("forced.stats.csv.json").exists());
+
+    let mut cmd = wrk.command("stats");
+    cmd.arg("--typesonly").arg("--force").arg("forced.csv");
+    wrk.assert_success(&mut cmd);
+    assert!(
+        !wrk.path("forced.stats.csv.json").exists(),
+        "--force recomputed but left the previous run's sidecar in place"
+    );
+
+    let mut cmd = wrk.command("stats");
+    cmd.arg("--everything").arg("forced.csv");
+    let got: String = wrk.stdout_on_success(&mut cmd);
+    let header = got.lines().next().unwrap_or_default();
+    assert!(
+        header.contains("cardinality") && header.contains("percentiles"),
+        "--typesonly output was served as --everything; header was: {header}"
+    );
+}

--- a/tests/test_stats.rs
+++ b/tests/test_stats.rs
@@ -8209,13 +8209,18 @@ fn stats_jsonl_flag_creates_the_sidecar_on_a_cache_hit() {
     );
 }
 
-// Regression: `stats --median` (without --quartiles/--everything) emits a `median` column that is
-// a DIFFERENT key from `q2_median`. It was absent from both StatsData and STATSDATA_TYPES_MAP, so
-// it serialized via the map's String fallback ("2") and was then silently dropped on deserialize
-// -- the same drift that hid sortiness/geometric_mean/harmonic_mean/percentiles.
+// Regression: `median` is a type-dependent RENDERING -- numeric for a numeric column, an RFC3339
+// string for a Date one -- so typing it JsonTypes::Float made the CSV-to-JSON conversion coerce
+// date medians to 0.0, silently corrupting them in the stats cache.
+//
+// This asserts the SERIALIZATION half only. That `median` survives DESERIALIZATION into
+// StatsData (the R12 drop it was added for) is covered by the in-crate unit test
+// util::tests::statsdata_carries_every_column_stats_emits -- tests/ is a separate binary and
+// cannot reach StatsData. Verified the split is needed: with StatsData::median deleted, this
+// test still passes.
 #[test]
-fn stats_median_column_is_typed_and_not_dropped() {
-    let wrk = Workdir::new("stats_median_column_is_typed_and_not_dropped");
+fn stats_median_column_not_coerced_for_date_columns() {
+    let wrk = Workdir::new("stats_median_column_not_coerced_for_date_columns");
     wrk.create(
         "med.csv",
         vec![


### PR DESCRIPTION
Batch B of the `src/cmd/stats.rs` code review: the **stats-cache validity cluster**. These findings all funnel silently-wrong statistics into every cache consumer (`schema`, `frequency`, `tojsonl`, `viz smart`, `pivotp`, `describegpt`), so they were fixed as one coherent pass rather than piecemeal — fixing them separately kept re-breaking each other.

Batch A (panics/UB) shipped as #4438. Batches C and D are untouched.

## Fixed

| # | Defect |
|---|---|
| **F4** | An args-changed recompute deleted `<FILESTEM>.stats.csv` but left its `.stats.csv.json` sidecar, so the next run validated against stale args and served, e.g., `--typesonly` output as `--everything`. Fixed at both the recompute paths **and** the install site, which also closes a second hole the review missed: a **lone sidecar** (its CSV removed externally) was never inspected, because every cleanup path is gated on the CSV existing. |
| **F5** | Cache validity was effectively mtime-only — the recorded filesize was zeroed before comparison. Any mtime-preserving replacement (`cp -p`, `tar -x`, `git checkout`, `rsync -t`) served the previous file's statistics. Now compared, on the `stats` path **and** the two consumer read paths. |
| **F6** | The `--everything` reuse arm omitted `--quantile-method`, `--cardinality-method` and `--mode-cardinality-cap`, so an exact run could be served an approximate cache. |
| **F7** | `--prefer-dmy` was not validated on cache reuse, so `qsv schema --prefer-dmy` reused an mdy cache and `01/02/2020` kept the wrong reading. Compares the **effective** preference, since `QSV_PREFER_DMY` is folded in by the stats subprocess. |
| **F8** | `frequency` builds its cache without `--infer-dates`, and Schema-mode consumers accepted it — so date columns came back as `string`. Measured: a plain `qsv stats` run silently degraded a later `qsv schema --strict-dates`, losing `"format": "date"`. |
| **R1** | `--stats-jsonl` was a silent no-op on a warm cache hit. |
| **R10** | `QSV_STATSCACHE_MODE=force` was **strictly weaker than the default** — it skipped regeneration and created no cache, inverting its documented contract. |
| **R11** | `frequency` compared a HyperLogLog cardinality estimate for **equality** against the exact row count to detect all-unique columns; a near-unique column landing on that estimate was collapsed to one sentinel, dropping real frequency rows. |
| **R12** | `sortiness`, `geometric_mean`, `harmonic_mean`, `percentiles` (and `median`) were emitted into the cache but absent from `StatsData`, so serde silently dropped them on every read — present on disk, unreachable to every consumer. |
| — | A stale `.stats.csv.data.jsonl` survived any recompute that did not pass `--stats-jsonl`, because it is judged current by mtime against the **input**, which a recompute never touches. |
| — | `moarstats` and `pragmastat` checked only that a baseline stats CSV **existed**, never that it was newer than the input. |
| — | **`qsv stats --everything --quantile-method approx` failed outright** (exit 1, no output): `stats_headers()` advertised a `mad` column that the records did not carry, and the csv writer rejects the arity change. Found while verifying F6, whose own repro turned out to be unreachable because of it. |

## Deliberately not changed

- **R2** — gating the `<FILESTEM>.stats.csv` install on the cache threshold. Implemented, then reverted: it broke 7 tests. That file is a **documented artifact** (`moarstats` reads it directly, and the usage text promises `qsv stats nyc311.csv` creates it); `--cache-threshold` governs the sidecar, not the artifact.
- **F5's suggested hash check** — unimplementable as written. The sidecar's BLAKE3 fingerprints the stats *output*, not the input, so verifying it requires recomputing the stats being reused. Reduced to the filesize check.
- **F7's `--dates-whitelist` half** — `stats` defaults to `sniff` (resolved column names), `schema` to a substring pattern list. A naive comparison forces regeneration on nearly every schema-after-stats run; a correct one needs pattern resolution this path does not have.

## Accepted trade-offs

- **F8** rejects any cache built without `--infer-dates` for Schema consumers, which is broader than the finding described — `qsv stats big.csv` → `qsv schema big.csv` now re-runs stats. What that buys back is output that was previously wrong; a cache built with `--infer-dates` is still reused.
- **R11** gives up the `<ALL_UNIQUE>` sentinel under approximate cardinality even when the estimate is right (HLL is exact on small inputs). Under-collapsing costs verbosity; over-collapsing loses data. Exact cardinality — the default — is unaffected.

## Known, pre-existing, and NOT addressed here

Every `JsonTypes::Float` column that can hold a **date rendering** — `q1`, `q2_median`, `q3`, `iqr`, `mad` and the four fences — is coerced to `0.0` in the `.data.jsonl` for `Date` columns, while the stats CSV holds the correct RFC3339 string. Long-standing, silent, and read by every cache consumer. `STATSDATA_TYPES_MAP` is keyed per *column* but these values are typed per *row*, so a real fix makes the CSV→JSON typing row-type-aware. Filed for its own change rather than smuggled in here.

## Testing

**16 new tests.** Each was run against the pre-fix code and shown to **fail** there — the three unit tests excepted, whose fields/parameters do not exist pre-fix to compile against.

- `stats` **849** (833 baseline + 16) · `frequency` 189 · `get` 56 · `moarstats` 100 · `pragmastat` 47 · `schema` 65 · `tojsonl` 28 · `profile` 64 · `viz` 494 · `sortcheck` 30 · `extsort` 11 · util unit 21 — all 0 failed
- `cargo test -F lite`: 0 failed
- `cargo clippy -F all_features --bin qsv`: no new warnings
- `cargo +nightly fmt` applied

Cache tests each get their own workdir **and** fixture name — sidecars are written next to the input, so shared fixture names poison each other through the very F4 mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)