### PR TITLE
fix(stats): parallel stats no longer caches a partial result when a worker dies

### DIFF
--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -2224,6 +2224,75 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     Ok(())
 }
 
+/// Merge per-chunk results in CHUNK order, failing if any chunk never arrives.
+///
+/// Merging in chunk order rather than completion order is required, not stylistic: the
+/// order-dependent stats (`sortiness` / `sort_order` pair counts at chunk boundaries) are only
+/// deterministic - and only equal to the sequential result - when chunks are folded in file
+/// order. Completion-order merging made `sortiness` vary from run to run.
+///
+/// Merging happens INCREMENTALLY as results arrive: each chunk is folded in (and freed) as soon
+/// as every earlier chunk has been merged. Workers start in chunk order, so results arrive
+/// roughly in order and the out-of-order buffer stays small - collecting everything first would
+/// hold all `nchunks` results resident simultaneously.
+///
+/// # The chunk-count check
+///
+/// A worker that panics - a corrupt, stale or concurrently-deleted index is the realistic cause,
+/// and the worker's `expect()`s anticipate exactly that - never sends its chunk. The receive loop
+/// then simply ends when the last sender drops. Without this check that is SILENT: every later
+/// chunk stays stranded in `pending`, `next_chunk` stops at the gap, and the caller gets a prefix
+/// of the file's statistics - or, when chunk 0 is the one that died, an EMPTY result. `run()` then
+/// wrote, printed and CACHED that partial answer with exit code 0, so a subsequent run would reuse
+/// statistics computed from a fraction of the file.
+///
+/// This is live in shipped binaries, not a debug-only artifact: the release profiles build with
+/// `panic = "unwind"`, so a panicking pool worker unwinds its own thread and leaves the process
+/// running.
+fn merge_chunks_in_order<T: Commute + Send>(
+    recv: &crossbeam_channel::Receiver<(usize, Vec<T>)>,
+    nchunks: usize,
+) -> CliResult<Vec<T>> {
+    let mut pending: HashMap<usize, Vec<T>> = HashMap::default();
+    let mut next_chunk = 0_usize;
+    let mut merged: Option<Vec<T>> = None;
+
+    for (i, chunk_stats) in recv {
+        pending.insert(i, chunk_stats);
+        while let Some(chunk_stats) = pending.remove(&next_chunk) {
+            match merged {
+                // Merge column-by-column in parallel: columns are independent, and each
+                // column still sees chunks in file order, so results are identical to a
+                // serial merge. This keeps the merge from becoming a serial tail - merging
+                // a high-cardinality column's Frequencies map hash-inserts every unique
+                // value of the incoming chunk.
+                Some(ref mut m) => m
+                    .par_iter_mut()
+                    .zip(chunk_stats)
+                    .for_each(|(acc, chunk_col)| acc.merge(chunk_col)),
+                None => merged = Some(chunk_stats),
+            }
+            next_chunk += 1;
+        }
+    }
+
+    if next_chunk != nchunks {
+        return fail_clierror!(
+            "Parallel stats is incomplete - only {next_chunk} of {nchunks} chunks were merged \
+             ({stranded} arrived but could not be merged in order). A worker failed, most likely \
+             because the index is corrupt, stale, or was deleted while stats was running. \
+             Refusing to write partial statistics. Re-create the index with `qsv index` or re-run \
+             with --jobs 1.",
+            stranded = pending.len()
+        );
+    }
+
+    // unreachable while nchunks >= 1 (the caller routes idx_count == 0 to sequential_stats), but
+    // returning an error beats the `unwrap_or_default()` this replaced, which turned "no chunks
+    // at all" into a silently empty - and cacheable - result.
+    merged.ok_or_else(|| CliError::Other("Parallel stats produced no chunks to merge.".to_string()))
+}
+
 impl Args {
     /// Computes statistics for CSV data using a single-threaded sequential approach.
     ///
@@ -2497,30 +2566,7 @@ impl Args {
         // Workers start in chunk order, so results arrive roughly in order and
         // the out-of-order buffer stays small - collecting everything before
         // merging would hold all nchunks results resident simultaneously.
-        let mut pending: HashMap<usize, Vec<Stats>> = HashMap::default();
-        let mut next_chunk = 0_usize;
-        let mut merged: Option<Vec<Stats>> = None;
-        for (i, chunk_stats) in &recv {
-            pending.insert(i, chunk_stats);
-            while let Some(chunk_stats) = pending.remove(&next_chunk) {
-                match merged {
-                    // Merge column-by-column in parallel: columns are
-                    // independent, and each column still sees chunks in file
-                    // order, so results are identical to a serial merge. This
-                    // keeps the merge from becoming a serial tail - merging a
-                    // high-cardinality column's Frequencies map hash-inserts
-                    // every unique value of the incoming chunk.
-                    Some(ref mut m) => m
-                        .par_iter_mut()
-                        .zip(chunk_stats)
-                        .for_each(|(acc, chunk_col)| acc.merge(chunk_col)),
-                    None => merged = Some(chunk_stats),
-                }
-                next_chunk += 1;
-            }
-        }
-        // in the event of a channel error, we will return an empty vector
-        Ok((headers, merged.unwrap_or_default()))
+        Ok((headers, merge_chunks_in_order(&recv, nchunks)?))
     }
 
     /// Converts a vector of `Stats` objects into CSV records for output.
@@ -6316,5 +6362,91 @@ impl Commute for TypedMinMax {
         self.dates.merge(other.dates);
         self.strings.merge(other.strings);
         self.str_len.merge(other.str_len);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use stats::Commute;
+
+    use super::merge_chunks_in_order;
+
+    /// Minimal `Commute` stand-in: merging sums, so the merged total tells us exactly which
+    /// chunks were folded in. Using a toy type rather than `Stats` keeps the test about the
+    /// merge loop's completeness accounting, which is what F3 is about.
+    #[derive(Debug, PartialEq)]
+    struct Count(u64);
+
+    impl Commute for Count {
+        fn merge(&mut self, other: Self) {
+            self.0 += other.0;
+        }
+    }
+
+    /// Send `chunks` as (index, one-column vec) pairs, then close the channel.
+    fn chunks_channel(chunks: &[(usize, u64)]) -> crossbeam_channel::Receiver<(usize, Vec<Count>)> {
+        let (send, recv) = crossbeam_channel::bounded(chunks.len().max(1));
+        for &(i, v) in chunks {
+            send.send((i, vec![Count(v)])).unwrap();
+        }
+        drop(send);
+        recv
+    }
+
+    #[test]
+    fn merge_chunks_in_order_merges_every_chunk() {
+        // all 4 chunks present, delivered OUT of order - the merge must still be in chunk order
+        // and must fold in all of them
+        let recv = chunks_channel(&[(2, 4), (0, 1), (3, 8), (1, 2)]);
+        let merged = merge_chunks_in_order(&recv, 4).unwrap();
+        assert_eq!(merged, vec![Count(15)], "1+2+4+8: every chunk merged");
+    }
+
+    #[test]
+    fn merge_chunks_in_order_rejects_a_missing_middle_chunk() {
+        // chunk 2 never arrives - the worker panicked. Chunk 3 is stranded in `pending`, and
+        // the old code returned the 0..=1 PREFIX with exit 0, which run() then cached.
+        let recv = chunks_channel(&[(0, 1), (1, 2), (3, 8)]);
+        let err = merge_chunks_in_order(&recv, 4)
+            .expect_err("a missing chunk must not yield a partial result");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("only 2 of 4 chunks"),
+            "the error should say how much of the file was actually merged, got: {msg}"
+        );
+        assert!(
+            msg.contains("1 arrived but could not be merged"),
+            "the error should account for stranded chunks, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn merge_chunks_in_order_rejects_a_missing_first_chunk() {
+        // the worst case: chunk 0 died, so `merged` stays None and the old
+        // `merged.unwrap_or_default()` returned an EMPTY Vec<Stats> - statistics for zero rows,
+        // written and cached with exit code 0.
+        let recv = chunks_channel(&[(1, 2), (2, 4)]);
+        let err = merge_chunks_in_order(&recv, 3)
+            .expect_err("a missing first chunk must not yield an empty result");
+        assert!(err.to_string().contains("only 0 of 3 chunks"), "got: {err}");
+    }
+
+    #[test]
+    fn merge_chunks_in_order_rejects_a_missing_last_chunk() {
+        // the subtlest case: every chunk that arrives merges cleanly and `pending` is EMPTY at
+        // the end, so nothing looks wrong locally - only the count reveals the truncation.
+        let recv = chunks_channel(&[(0, 1), (1, 2)]);
+        let err = merge_chunks_in_order(&recv, 3).expect_err("a truncated tail must be caught");
+        assert!(err.to_string().contains("only 2 of 3 chunks"), "got: {err}");
+    }
+
+    #[test]
+    fn merge_chunks_in_order_accepts_a_single_chunk() {
+        let recv = chunks_channel(&[(0, 42)]);
+        assert_eq!(
+            merge_chunks_in_order(&recv, 1).unwrap(),
+            vec![Count(42)],
+            "the common small-file case must not trip the completeness check"
+        );
     }
 }


### PR DESCRIPTION
Batch C of the `src/cmd/stats.rs` review, starting with **F3** — the last remaining finding that can produce a *wrong cache with exit code 0*. Follows Batch A (#4438), Batch B (#4439) and the date-coercion fix (#4441). Branched off `master` and independent of #4441.

## The bug

`parallel_stats` merged chunk results by draining the channel until the last sender dropped, with no check that every chunk actually arrived:

```rust
for (i, chunk_stats) in &recv { ... }
// in the event of a channel error, we will return an empty vector
Ok((headers, merged.unwrap_or_default()))
```

A worker that panics never sends its chunk, so the loop simply ends early. Later chunks stay stranded in `pending`, `next_chunk` stops at the gap, and the caller gets a **prefix** of the file's statistics — or, when chunk 0 is the one that died, an **empty** vector. `run()` then wrote, printed and **cached** that partial answer with exit code 0, so subsequent runs reused statistics computed from a fraction of the file.

This is live in shipped binaries, not a debug-only artifact: the release profiles build with `panic = "unwind"`, so a panicking pool worker unwinds its own thread and leaves the process running.

## Reproduced end-to-end

Not taken on faith. A real worker panic was induced via the TOCTOU the worker's own `expect()` already anticipates — deleting the index while `stats` was running, on a 400k-row file chunked into 28 pieces:

| | master | with this fix |
|---|---|---|
| exit code | **0** | 1 |
| cache written | **3 artifacts** | none |
| reported `id` max | **353183** | — |
| true `id` max | 399999 | 399999 |

master cached statistics from 24 of 28 chunks and reported success. `nullcount` was `0`, so nothing in the output hinted that the file had been truncated.

(Reproducing this deterministically needs many more chunks than threads — with a plain `--jobs 8` there are only ~8 chunks and every worker opens the index before the deletion lands. `QSV_STATS_CHUNK_MEMORY_MB=1` forces 28.)

## The fix

The merge loop moves into `merge_chunks_in_order`, generic over `Commute + Send` so the completeness accounting is unit-testable without inducing a real panic, and now fails when `next_chunk != nchunks`:

```
Parallel stats is incomplete - only 24 of 28 chunks were merged (0 arrived but could not be
merged in order). A worker failed, most likely because the index is corrupt, stale, or was
deleted while stats was running. Refusing to write partial statistics. Re-create the index
with `qsv index` or re-run with --jobs 1.
```

An `Err` here propagates through the `?` in `run()` **before** any of the three write sites — verified by reading that path rather than assuming it, since the review separately records (R2) that the `stats.csv` install is not gated the way one would expect.

Chunk-**order** merging is preserved exactly, including its rationale: the order-dependent stats (`sortiness` / `sort_order` pair counts at chunk boundaries) are only deterministic, and only equal to the sequential result, when chunks are folded in file order. Only the completeness check is new.

Threading `CliResult` through the channel was considered and skipped: `compute()` returns `Vec<Stats>`, not a `Result`, so there is no error to propagate — the failure mode is a *missing* chunk, which the count check catches regardless of cause (panic, dropped sender, send failure).

## Deliberately not the rayon rewrite

The review floated replacing the hand-rolled `ThreadPool` with rayon as the vehicle for this fix. Declined: that lead was never adversarially verified, carries no verdict, and would rewrite the merge whose ordering was **already gotten wrong once** — completion-order merging previously made `sortiness` vary from run to run. Five lines of accounting close the exit-0-wrong-cache hole without touching the part that is hard to get right.

## Tests

Five unit tests in a new `mod tests` in `stats.rs` (the file had none), covering a missing **first**, **middle** and **last** chunk plus the all-present and single-chunk cases. The missing-last case is the subtle one: every chunk that arrives merges cleanly and `pending` ends empty, so nothing looks wrong locally — only the count reveals the truncation.

Full suite green (3722 integration + 983 unit), clippy identical to master's pre-existing warnings.

Remaining in Batch C after this: F9, F10, R7, R8, R9, R13, R14, R16 — all wrong-results findings, none of which can produce a wrong cache with exit 0. **F10** is now reproduced rather than merely confirmed: a 5-row file containing `1970-01-01` reports `min=2020-01-15` while the same run's `percentiles` shows the epoch row is in the data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
