### PR TITLE
fix(stats): wrong-results cluster (Batch C of the stats.rs review)

### DIFF
--- a/src/cmd/moarstats.rs
+++ b/src/cmd/moarstats.rs
@@ -4466,6 +4466,26 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             );
         }
 
+        // Truncate to the INTEGER percentile, matching what `stats` actually computes.
+        // `stats --percentile-list` casts each entry `as u8`, so asking it for 33.3 yields p33
+        // and (since the label reports the percentile computed) writes the key "33". These
+        // values are used ONLY to build that lookup key and the winsorized_/trimmed_ column
+        // names - never in a numeric computation - so truncating here keeps both in step.
+        // Without it, `--pct-thresholds 33.3,66.6` searched the percentiles cell for "33.3",
+        // found nothing, and silently emitted 0/empty winsorized and trimmed statistics.
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let (lower, upper) = (lower.trunc(), upper.trunc());
+
+        // truncation can collapse a valid-looking pair (e.g. "33.3,33.6" -> 33, 33), so the
+        // ordering has to be re-checked against the percentiles actually used
+        if lower >= upper {
+            return fail_clierror!(
+                "Percentile thresholds {thresholds_str} both truncate to the same percentile \
+                 ({lower}). `stats` computes whole percentiles, so give thresholds that differ by \
+                 at least 1."
+            );
+        }
+
         (Some(lower), Some(upper))
     } else {
         (None, None)

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -2020,7 +2020,12 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             // if the cache threshold zero or is a negative number ending in 5,
             // delete both the index file and the stats cache file
             if autoindex_set {
-                let index_file = path.with_extension("csv.idx");
+                // `util::idx_path` APPENDS ".idx"; `with_extension("csv.idx")` REPLACED the
+                // input's extension, so a `data.tsv` autoindex (written as `data.tsv.idx`) was
+                // looked for at `data.csv.idx` and survived the cleanup it asked for. The
+                // removal only log::warn!s on failure, so the leak was silent. It happened to
+                // work for `.csv` inputs by coincidence.
+                let index_file = util::idx_path(&path);
                 log::debug!("deleting index file: {}", index_file.display());
                 if std::fs::remove_file(index_file.clone()).is_err() {
                     // fails silently if it can't remove the index file

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -4272,7 +4272,9 @@ fn weighted_percentiles(
 ///
 /// # Behavior
 ///
-/// * **`TDate`**: Returns only the date component (YYYY-MM-DD)
+/// * **`TDate`**: Returns only the date component - normally `YYYY-MM-DD`, but chrono renders a
+///   year outside `0..=9999` in expanded signed form (`+12000-01-01`, `-10000-01-01`), which the
+///   Tukey fences of a wide-spread date column can reach
 /// * **`TDateTime`**: Returns full RFC3339 format with time and timezone
 /// * **Invalid Timestamps**: Returns default RFC3339 format for invalid timestamps
 #[inline]
@@ -5661,7 +5663,9 @@ impl Stats {
         if self.which.percentiles {
             match typ {
                 TInteger | TFloat | TDate | TDateTime => {
-                    // Parse percentile list, preserving both original labels and u8 values
+                    // Parse the percentile list into the u8 percentiles to compute and the
+                    // labels to emit. The label is DERIVED from the truncated percentile, not
+                    // from the token as typed, so the two can never disagree.
                     let (percentile_labels, percentile_list): (Vec<String>, Vec<u8>) = self
                         .which
                         .percentile_list
@@ -5907,6 +5911,11 @@ enum FieldType {
 /// tolerated, though codes are typically unsigned. Pure trailing-zero codes (`7.10`) are out of
 /// scope by design — they're indistinguishable from rounded measurements without the original
 /// string.
+///
+/// A decimal point is NOT required: `+007` is as padded as `007.1`. It reaches this function
+/// because `atoi_simd` rejects a leading `+` (`SKIP_PLUS` is false) so the integer path - and its
+/// leading-zero check - never sees it. When a dot IS present it must still have digits after it,
+/// so `007.` stays rejected.
 #[inline]
 fn is_zero_padded_number(sample: &[u8]) -> bool {
     let b = match sample.first() {

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -1250,12 +1250,29 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         args.flag_percentile_list = "20,40,60,80".to_string();
     }
 
-    // validate percentile list
-    let percentile_list = args.flag_percentile_list.split(',').collect::<Vec<&str>>();
-    for p in percentile_list {
-        if fast_float2::parse::<f64, &[u8]>(p.trim().as_bytes()).is_err() {
+    // Validate the percentile list: every token must be an INTEGER in 1..=100.
+    //
+    // Accepting any parseable f64 was not permissive, it was silently WRONG: `to_record` casts
+    // each token `as u8` (saturating) while the output LABEL keeps the original string, so the
+    // two disagreed and every case exited 0.
+    //   --percentile-list 99.9  -> computed p99, emitted "99.9: <p99 value>" (a label that lies)
+    //   --percentile-list 150   -> rank exceeds total weight, emitted the pre-filled "150: 0"
+    //   --percentile-list nan   -> saturating cast to 0, emitted "nan: <p0>"
+    //   --percentile-list -5    -> likewise "−5: <p0>"
+    // Erroring is the right outcome rather than supporting fractional percentiles end-to-end:
+    // that is a feature, and nobody is relying on today's mislabeled output.
+    //
+    // NOTE: `deciles`/`quintiles` are expanded ABOVE, so they reach this loop already spelled
+    // out as integer lists and keep working.
+    for p in args.flag_percentile_list.split(',') {
+        let token = p.trim();
+        let valid = matches!(
+            fast_float2::parse::<f64, &[u8]>(token.as_bytes()),
+            Ok(pct) if pct.is_finite() && (1.0..=100.0).contains(&pct)
+        );
+        if !valid {
             return fail_incorrectusage_clierror!(
-                "Invalid percentile list: {}: {}",
+                "Invalid percentile list: {}: `{}` is not a percentile between 1 and 100.",
                 args.flag_percentile_list,
                 p
             );

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -4596,7 +4596,7 @@ impl Stats {
         if self.which.zero_padded_numeric && !self.zpn_disqualified && b"" != sample {
             if sample_type == TFloat
                 || sample.iter().all(u8::is_ascii_digit)
-                || is_zero_padded_float(sample)
+                || is_zero_padded_number(sample)
                 || fast_float2::parse::<f64, &[u8]>(sample).is_ok()
             {
                 // numeric-shaped: a freshly-parsed plain float (sample_type == TFloat — the common
@@ -5902,7 +5902,7 @@ enum FieldType {
 /// scope by design — they're indistinguishable from rounded measurements without the original
 /// string.
 #[inline]
-fn is_zero_padded_float(sample: &[u8]) -> bool {
+fn is_zero_padded_number(sample: &[u8]) -> bool {
     let b = match sample.first() {
         Some(b'+' | b'-') => &sample[1..],
         _ => sample,
@@ -5926,7 +5926,12 @@ fn is_zero_padded_float(sample: &[u8]) -> bool {
             _ => return false, // any other byte disqualifies
         }
     }
-    seen_dot && frac_len > 0
+    // A dot is not required. `+007` reaches this function because atoi_simd rejects a leading
+    // '+' (SKIP_PLUS is false) while fast_float2 accepts it, so the integer path above - and its
+    // padding check - never sees it. Requiring a fraction here let `+007` fall through as the
+    // float 7.0, silently numeric-izing a padded code. When a dot IS present it must still have
+    // fraction digits, so `007.` stays disqualified.
+    !seen_dot || frac_len > 0
 }
 
 impl FieldType {
@@ -5958,9 +5963,17 @@ impl FieldType {
         if current_type != FieldType::TFloat
             && let Ok(samp_int) = atoi_simd::parse::<i64, false, false>(sample)
         {
-            // Check for integer, with leading zero check for strings like zip codes
-            // safety: we know sample is not null as we checked earlier
-            if samp_int == 0 || unsafe { *sample.get_unchecked(0) != b'0' } {
+            // Check for integer, with leading zero check for strings like zip codes.
+            //
+            // The sign is stripped first, mirroring `is_zero_padded_number`'s prefix handling: a
+            // sign is not part of the padding, so `-007` is as zero-padded as `007`. Testing
+            // byte 0 directly saw `b'-'`, concluded "not padded", and typed `-007` as the
+            // integer -7 - dropping the padding from min/max and from --zero-padded-numeric.
+            let unsigned = match sample.first() {
+                Some(b'+' | b'-') => &sample[1..],
+                _ => sample,
+            };
+            if samp_int == 0 || unsigned.first().is_none_or(|&b| b != b'0') {
                 // note that we still return samp_int as f64 even if it's an integer
                 // as the qsv-stats crate expects a float value for integer fields
                 #[allow(clippy::cast_precision_loss)]
@@ -5976,9 +5989,9 @@ impl FieldType {
             // Zero-padded floats (007.1, 05.10 — ICD-9 / Dewey / HS codes) are kept as String
             // to preserve their leading zeros, mirroring the zero-padded-integer rule above (a
             // 0-then-digit integer part is padding; a plain 0.5 / 7.1 is a real number). The
-            // first-byte check inside is_zero_padded_float() makes the common (non-padded) case
+            // first-byte check inside is_zero_padded_number() makes the common (non-padded) case
             // a couple of byte comparisons.
-            if is_zero_padded_float(sample) {
+            if is_zero_padded_number(sample) {
                 return (FieldType::TString, 0, 0.0);
             }
             return (FieldType::TFloat, 0, float_sample);

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -2701,11 +2701,23 @@ impl Args {
         infer_boolean: bool,
         prefer_dmy: bool,
     ) {
-        // Extract weight value if weight column is specified
-        // in case of a parse error, invalid weight defaults to 1.0
+        // Extract weight value if weight column is specified.
+        // Per the --weight docs, a missing or non-numeric weight defaults to 1.0.
+        //
+        // NON-FINITE counts as non-numeric here. fast_float2 parses "NaN" and "inf"
+        // SUCCESSFULLY, so `unwrap_or(1.0)` never fired for them and the value flowed into the
+        // accumulators: NaN then slipped past `add_weighted`'s `w <= 0.0` guard (every NaN
+        // comparison is false) and permanently poisoned sum_weights and weighted_mean, so
+        // weighted mean/sem/stddev/variance/cv for the ENTIRE column came out NaN. The sibling
+        // guards (`total_weight` and the weighted-quantile buffer) use `weight > 0.0`, which
+        // NaN fails, so they silently dropped the row instead - the same cell making the
+        // moments disagree with the quantiles.
         let weight = if let Some(widx) = weight_col_idx {
             if widx < row.len() {
-                fast_float2::parse::<f64, &[u8]>(row.get(widx).unwrap_or(b"1.0")).unwrap_or(1.0)
+                match fast_float2::parse::<f64, &[u8]>(row.get(widx).unwrap_or(b"1.0")) {
+                    Ok(w) if w.is_finite() => w,
+                    _ => 1.0,
+                }
             } else {
                 1.0
             }
@@ -3859,7 +3871,13 @@ impl WeightedOnlineStats {
     /// - For harmonic mean: accumulate `w_i` / `x_i` (only if `x_i` != 0)
     #[inline]
     fn add_weighted(&mut self, x: f64, w: f64) {
-        if w <= 0.0 {
+        // `!(w > 0.0)` rather than `w <= 0.0` so a non-finite weight is EXCLUDED like the
+        // sibling sites (`total_weight` and the weighted-quantile buffer both gate on
+        // `weight > 0.0`). NaN fails every comparison, so `w <= 0.0` let it through and one
+        // NaN cell poisoned the column's weighted moments forever. add_row now normalizes
+        // non-finite weights to 1.0 before they get here, so this is the belt to that braces -
+        // but all three guards now read alike, which is what stops them drifting apart again.
+        if !(w > 0.0) {
             return;
         }
 

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -3378,7 +3378,18 @@ fn init_date_inference(
         let whitelist_lower = flag_whitelist.to_lowercase();
         log::info!("inferring dates with date-whitelist: {whitelist_lower}");
 
-        let whitelist: SmallVec<[&str; 8]> = whitelist_lower.split(',').map(str::trim).collect();
+        // Empty tokens are DROPPED, not matched: `"".contains("")` is always true, so a single
+        // stray empty token - `--dates-whitelist "date,"`, a trailing comma being the easy way to
+        // get one - made every column match and silently turned the whitelist into "all". That is
+        // the exact false positive the docs warn about for "all": a `note` column holding
+        // date-like strings gets typed Date even though the user restricted the whitelist to
+        // `date`. The sniff sentinel below already documents this `contains("")` trap; user-
+        // supplied empties were simply never filtered.
+        let whitelist: SmallVec<[&str; 8]> = whitelist_lower
+            .split(',')
+            .map(str::trim)
+            .filter(|item| !item.is_empty())
+            .collect();
         headers
             .iter()
             .map(|header| {

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -3890,13 +3890,14 @@ impl WeightedOnlineStats {
     /// - For harmonic mean: accumulate `w_i` / `x_i` (only if `x_i` != 0)
     #[inline]
     fn add_weighted(&mut self, x: f64, w: f64) {
-        // `!(w > 0.0)` rather than `w <= 0.0` so a non-finite weight is EXCLUDED like the
-        // sibling sites (`total_weight` and the weighted-quantile buffer both gate on
-        // `weight > 0.0`). NaN fails every comparison, so `w <= 0.0` let it through and one
-        // NaN cell poisoned the column's weighted moments forever. add_row now normalizes
-        // non-finite weights to 1.0 before they get here, so this is the belt to that braces -
-        // but all three guards now read alike, which is what stops them drifting apart again.
-        if !(w > 0.0) {
+        // The explicit NaN test is the point: a bare `w <= 0.0` is FALSE for NaN, so one NaN
+        // weight slipped into the accumulator and poisoned the column's weighted moments
+        // forever. This is exactly equivalent to the sibling sites' `weight > 0.0` gate
+        // (`total_weight` and the weighted-quantile buffer), spelled out rather than written
+        // as `!(w > 0.0)` so the NaN case is visible instead of implied. add_row now
+        // normalizes non-finite weights to 1.0 before they reach here, so this is the belt to
+        // that braces - but all three sites now agree, which is what stops them drifting.
+        if w.is_nan() || w <= 0.0 {
             return;
         }
 
@@ -4283,7 +4284,12 @@ fn timestamp_ms_to_rfc3339(timestamp: i64, typ: FieldType) -> String {
     // if type = Date, only return the date component
     // do not return the time component
     if typ == TDate {
-        return date_val[..10].to_string();
+        // Split at the RFC3339 'T' separator rather than slicing a fixed 10 bytes: chrono
+        // renders a year outside 0..=9999 in EXPANDED form (`+12000-01-01T…`, `-10000-01-01T…`),
+        // which is more than 10 bytes before the 'T', so the fixed slice cut it mid-token and
+        // emitted `+12000-01-` as if it were a date. Reachable from ordinary data - a Date
+        // column with a wide spread pushes the Tukey fences (`q3 + 3*IQR`) past year 9999.
+        return date_val.split('T').next().unwrap_or(&date_val).to_string();
     }
     date_val
 }

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -1250,17 +1250,19 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         args.flag_percentile_list = "20,40,60,80".to_string();
     }
 
-    // Validate the percentile list: every token must be an INTEGER in 1..=100.
+    // Validate the percentile list: every token must be a FINITE number in 1..=100.
     //
     // Accepting any parseable f64 was not permissive, it was silently WRONG: `to_record` casts
-    // each token `as u8` (saturating) while the output LABEL keeps the original string, so the
+    // each token `as u8` (saturating) while the output LABEL kept the original string, so the
     // two disagreed and every case exited 0.
-    //   --percentile-list 99.9  -> computed p99, emitted "99.9: <p99 value>" (a label that lies)
     //   --percentile-list 150   -> rank exceeds total weight, emitted the pre-filled "150: 0"
     //   --percentile-list nan   -> saturating cast to 0, emitted "nan: <p0>"
-    //   --percentile-list -5    -> likewise "−5: <p0>"
-    // Erroring is the right outcome rather than supporting fractional percentiles end-to-end:
-    // that is a feature, and nobody is relying on today's mislabeled output.
+    //   --percentile-list -5    -> likewise "-5: <p0>"
+    //   --percentile-list 0     -> p0 is not a percentile
+    //
+    // A FRACTIONAL value in range stays accepted (`99.9`, `50.0`): it is truncated to the
+    // percentile actually computed, and `to_record` now labels it with that percentile instead
+    // of the token as typed, so the label can no longer disagree with the value.
     //
     // NOTE: `deciles`/`quintiles` are expanded ABOVE, so they reach this loop already spelled
     // out as integer lists and keep working.
@@ -5659,9 +5661,17 @@ impl Stats {
                         .percentile_list
                         .split(',')
                         .filter_map(|p: &str| {
-                            fast_float2::parse(p.trim())
-                                .ok()
-                                .map(|p_val: f64| (p.trim().to_string(), p_val as u8))
+                            fast_float2::parse(p.trim()).ok().map(|p_val: f64| {
+                                // Label the percentile ACTUALLY computed, not the token as
+                                // typed. The value is selected by this truncating cast, so
+                                // keeping the original string made the label disagree with it:
+                                // `--percentile-list 99.9` on 1000 rows emitted the p99 value
+                                // (990) under a "99.9" label, and `010` under an "010" label.
+                                // run() has already rejected anything outside 1..=100, so this
+                                // cast cannot saturate.
+                                let pct = p_val as u8;
+                                (pct.to_string(), pct)
+                            })
                         })
                         .unzip();
 

--- a/tests/test_moarstats.rs
+++ b/tests/test_moarstats.rs
@@ -6695,3 +6695,88 @@ fn moarstats_regenerates_a_stale_baseline_stats_csv() {
         "moarstats used a stale baseline stats CSV; v row was: {v_row}"
     );
 }
+
+#[test]
+fn moarstats_fractional_pct_thresholds_find_their_percentiles() {
+    // `stats --percentile-list` casts each entry `as u8`, so asking for 33.3 computes p33 and
+    // labels it "33". moarstats built its lookup key with fmt_pct, which PRESERVES fractions,
+    // so it searched the percentiles cell for "33.3", found nothing, and silently emitted 0 /
+    // empty winsorized and trimmed statistics - a cross-command break that no test covered.
+    let wrk = Workdir::new("moarstats_fractional_pct");
+
+    let mut rows = vec![svec!["v"]];
+    for i in 1..=200 {
+        rows.push(vec![(i * 7 % 1000).to_string()]);
+    }
+    wrk.create("frac.csv", rows);
+
+    let mut stats_cmd = wrk.command("stats");
+    stats_cmd
+        .arg("--force")
+        .arg("--everything")
+        .arg("--percentiles")
+        .args(["--percentile-list", "33.3,66.6"])
+        .arg("frac.csv");
+    wrk.assert_success(&mut stats_cmd);
+
+    let mut cmd = wrk.command("moarstats");
+    cmd.arg("frac.csv")
+        .arg("--use-percentiles")
+        .args(["--pct-thresholds", "33.3,66.6"]);
+    wrk.assert_success(&mut cmd);
+
+    let stats_content = wrk.read_to_string("frac.stats.csv").unwrap();
+    let hdrs: Vec<&str> = stats_content.lines().next().unwrap().split(',').collect();
+    let row: Vec<&str> = stats_content.lines().nth(1).unwrap().split(',').collect();
+
+    // the threshold truncates to the percentile stats actually computed, so the column is
+    // named for that percentile
+    let idx = hdrs
+        .iter()
+        .position(|h| *h == "winsorized_mean_33pct")
+        .unwrap_or_else(|| {
+            panic!("no winsorized_mean_33pct column; headers: {hdrs:?}");
+        });
+    let winsorized = row.get(idx).copied().unwrap_or_default();
+    assert!(
+        !winsorized.is_empty() && winsorized != "0",
+        "winsorized mean should be a real value - an unresolved percentile lookup yields 0 or \
+         empty. got {winsorized:?}"
+    );
+
+    let idx = hdrs
+        .iter()
+        .position(|h| *h == "trimmed_mean_33pct")
+        .expect("no trimmed_mean_33pct column");
+    let trimmed = row.get(idx).copied().unwrap_or_default();
+    assert!(
+        !trimmed.is_empty() && trimmed != "0",
+        "trimmed mean should be a real value, got {trimmed:?}"
+    );
+}
+
+#[test]
+fn moarstats_pct_thresholds_collapsing_to_one_percentile_errors() {
+    // Truncating to whole percentiles can collapse a pair that looked valid: 33.3 and 33.6 both
+    // become 33, which would silently winsorize between a percentile and itself.
+    let wrk = Workdir::new("moarstats_collapsing_pct");
+    let mut rows = vec![svec!["v"]];
+    for i in 1..=50 {
+        rows.push(vec![i.to_string()]);
+    }
+    wrk.create("coll.csv", rows);
+
+    let mut stats_cmd = wrk.command("stats");
+    stats_cmd
+        .arg("--force")
+        .arg("--everything")
+        .arg("--percentiles")
+        .arg("coll.csv");
+    wrk.assert_success(&mut stats_cmd);
+
+    let mut cmd = wrk.command("moarstats");
+    cmd.arg("coll.csv")
+        .arg("--use-percentiles")
+        .args(["--pct-thresholds", "33.3,33.6"]);
+    wrk.assert_err(&mut cmd);
+}

--- a/tests/test_stats.rs
+++ b/tests/test_stats.rs
@@ -8371,3 +8371,49 @@ fn stats_autoindex_cleanup_removes_a_non_csv_index() {
         );
     }
 }
+
+#[test]
+fn stats_dates_whitelist_ignores_empty_tokens() {
+    // `"".contains("")` is always true, so a single stray empty token in --dates-whitelist made
+    // EVERY column match and silently turned the whitelist into "all" - the exact false positive
+    // the docs warn about for "all". A trailing comma is the easy way to get one.
+    let wrk = Workdir::new("stats_dates_whitelist_empty_token");
+    wrk.create(
+        "wl.csv",
+        vec![
+            svec!["date_col", "note"],
+            svec!["2020-01-15", "2019-05-05"],
+            svec!["2021-03-01", "2018-07-07"],
+        ],
+    );
+
+    let typ = |whitelist: &str, run: &str| -> Vec<String> {
+        let mut cmd = wrk.command("stats");
+        cmd.arg("--force")
+            .arg("--infer-dates")
+            .args(["--dates-whitelist", whitelist])
+            .args(["--output", wrk.path(run).to_str().unwrap()])
+            .arg("wl.csv");
+        wrk.assert_success(&mut cmd);
+        let out = std::fs::read_to_string(wrk.path(run)).unwrap();
+        let mut hdrs = out.lines().next().unwrap().split(',');
+        let type_idx = hdrs.position(|h| h == "type").unwrap();
+        out.lines()
+            .skip(1)
+            .map(|l| l.split(',').nth(type_idx).unwrap_or_default().to_string())
+            .collect()
+    };
+
+    // `note` holds date-like strings but is NOT whitelisted, so it must stay a String
+    assert_eq!(typ("date", "a.csv"), vec!["Date", "String"]);
+
+    // the trailing comma must not change that
+    assert_eq!(
+        typ("date,", "b.csv"),
+        vec!["Date", "String"],
+        "an empty --dates-whitelist token silently enabled date inference on every column"
+    );
+
+    // and "all" must still mean all
+    assert_eq!(typ("all", "c.csv"), vec!["Date", "Date"]);
+}

--- a/tests/test_stats.rs
+++ b/tests/test_stats.rs
@@ -8653,3 +8653,62 @@ fn stats_sign_prefixed_zero_padded_codes_stay_strings() {
     let (signed_type, ..) = probe("signed.csv", &["+7", "-7"], "e.csv");
     assert_eq!(signed_type, "Float", "+7 / -7 carry no padding");
 }
+
+#[test]
+fn stats_date_fences_beyond_year_9999_are_not_truncated() {
+    // The date component was taken as a fixed 10-byte slice, which assumes a 4-digit year.
+    // chrono renders a year outside 0..=9999 in EXPANDED form (`+12000-01-01T…`), so the slice
+    // cut it mid-token and emitted `+12000-01-` as if it were a date. This is reachable from
+    // ordinary data: a Date column with a wide spread pushes the Tukey fences (q3 + 3*IQR)
+    // past year 9999.
+    let wrk = Workdir::new("stats_date_fence_overflow");
+    let mut rows = vec![svec!["d"]];
+    for y in [1000, 1500, 2000, 2500, 3000, 3500, 4000, 6000, 8000, 9999] {
+        rows.push(vec![format!("{y:04}-01-01")]);
+    }
+    wrk.create("wide.csv", rows);
+
+    let mut cmd = wrk.command("stats");
+    cmd.arg("--force")
+        .arg("--infer-dates")
+        .arg("--everything")
+        .args(["--output", wrk.path("out.csv").to_str().unwrap()])
+        .arg("wide.csv");
+    wrk.assert_success(&mut cmd);
+
+    let text = std::fs::read_to_string(wrk.path("out.csv")).unwrap();
+    let hdrs: Vec<&str> = text.lines().next().unwrap().split(',').collect();
+    let row: Vec<&str> = text.lines().nth(1).unwrap().split(',').collect();
+    let get = |k: &str| {
+        let i = hdrs.iter().position(|h| *h == k).unwrap();
+        row.get(i).copied().unwrap_or_default()
+    };
+
+    for key in [
+        "lower_outer_fence",
+        "lower_inner_fence",
+        "upper_inner_fence",
+        "upper_outer_fence",
+    ] {
+        let v = get(key);
+        assert!(
+            !v.is_empty(),
+            "{key} should be rendered for this fixture, got empty"
+        );
+        // a truncated expanded year ends mid-token, e.g. "+12000-01-" or "-10000-01-"
+        assert!(
+            !v.ends_with('-'),
+            "{key} was truncated mid-token by the fixed 10-byte slice: {v:?}"
+        );
+        // every rendered date must have a full YYYY-MM-DD tail
+        let parts: Vec<&str> = v.rsplit('-').collect();
+        assert!(
+            parts[0].len() == 2 && parts[1].len() == 2,
+            "{key} should end in -MM-DD, got {v:?}"
+        );
+    }
+
+    // an ordinary 4-digit-year column is unaffected
+    assert_eq!(get("min"), "1000-01-01");
+    assert_eq!(get("q1"), "2000-01-01");
+}

--- a/tests/test_stats.rs
+++ b/tests/test_stats.rs
@@ -2420,7 +2420,7 @@ fn stats_percentiles_floats() {
             "15",
             "",
             "0",
-            "10.5: 2|25.25: 4|50.75: 8|75.6: 12|90.1: 14"
+            "10: 2|25: 4|50: 8|75: 12|90: 14"
         ],
     ];
 
@@ -2870,7 +2870,7 @@ fn stats_percentiles_custom_list() {
             "10",
             "",
             "0",
-            "1: 1|5: 1|33.3: 4|66.6: 7|95: 10|99: 10",
+            "1: 1|5: 1|33: 4|66: 7|95: 10|99: 10",
         ],
     ];
 
@@ -8545,4 +8545,54 @@ fn stats_percentile_list_rejects_out_of_range_and_non_numeric() {
             .arg("pct.csv");
         wrk.assert_success(&mut cmd);
     }
+}
+
+#[test]
+fn stats_percentile_list_label_matches_the_percentile_computed() {
+    // The percentile VALUE is selected by an `as u8` truncation, but the output LABEL used to
+    // keep the token exactly as typed - so `--percentile-list 99.9` on a 1000-row file emitted
+    // the p99 value (990) under a "99.9" label, claiming a p99.9 it never computed. The label
+    // now reports the percentile actually computed, so a fractional token and its truncation
+    // produce identical output.
+    let wrk = Workdir::new("stats_percentile_label");
+    let mut rows = vec![svec!["n"]];
+    for i in 1..=1000 {
+        rows.push(vec![i.to_string()]);
+    }
+    wrk.create("lbl.csv", rows);
+
+    let pctiles = |list: &str, out: &str| -> String {
+        let mut cmd = wrk.command("stats");
+        cmd.arg("--force")
+            .arg("--percentiles")
+            .args(["--percentile-list", list])
+            .args(["--output", wrk.path(out).to_str().unwrap()])
+            .arg("lbl.csv");
+        wrk.assert_success(&mut cmd);
+        let text = std::fs::read_to_string(wrk.path(out)).unwrap();
+        let hdrs: Vec<&str> = text.lines().next().unwrap().split(',').collect();
+        let i = hdrs.iter().position(|h| *h == "percentiles").unwrap();
+        text.lines()
+            .nth(1)
+            .unwrap()
+            .split(',')
+            .nth(i)
+            .unwrap_or_default()
+            .to_string()
+    };
+
+    let fractional = pctiles("99.9", "a.csv");
+    assert_eq!(
+        fractional, "99: 990",
+        "a fractional percentile must be labeled with the percentile actually computed"
+    );
+    assert_eq!(
+        fractional,
+        pctiles("99", "b.csv"),
+        "99.9 truncates to 99, so it must produce output identical to asking for 99"
+    );
+
+    // an integral value written with a decimal point, and a zero-padded one, normalize too
+    assert_eq!(pctiles("50.0", "c.csv"), "50: 500");
+    assert_eq!(pctiles("010", "d.csv"), "10: 100");
 }

--- a/tests/test_stats.rs
+++ b/tests/test_stats.rs
@@ -8339,3 +8339,35 @@ fn stats_jsonl_flag_refreshes_a_jsonl_older_than_the_sidecar() {
         "--stats-jsonl preserved a jsonl that predates the stats cache beside it"
     );
 }
+
+#[test]
+fn stats_autoindex_cleanup_removes_a_non_csv_index() {
+    // A negative --cache-threshold sets the autoindex size; one ending in 5 also asks for the
+    // autoindex and the stats cache to be deleted afterwards. The cleanup built the path with
+    // `with_extension("csv.idx")`, which REPLACES the input's extension, so a `.tsv` input's
+    // autoindex (written by util::idx_path as `data.tsv.idx`) was looked for at `data.csv.idx`
+    // and survived. remove_file only log::warn!s on failure, so the leak was silent - which is
+    // why this asserts on the FILESYSTEM rather than on output or exit code.
+    let wrk = Workdir::new("stats_autoindex_cleanup_tsv");
+
+    // must exceed the autoindex size below (105 bytes) for an index to be created at all
+    let mut rows = vec![svec!["a", "b"]];
+    for i in 0..200 {
+        rows.push(vec![i.to_string(), (i * 2).to_string()]);
+    }
+    wrk.create_with_delim("idxclean.tsv", rows.clone(), b'\t');
+    wrk.create("idxclean.csv", rows);
+
+    for input in ["idxclean.tsv", "idxclean.csv"] {
+        let mut cmd = wrk.command("stats");
+        cmd.arg("-E").args(["--cache-threshold", "-105"]).arg(input);
+        wrk.assert_success(&mut cmd);
+
+        let leaked = wrk.path(&format!("{input}.idx"));
+        assert!(
+            !leaked.exists(),
+            "the autoindex for `{input}` survived the cleanup that --cache-threshold -105 asked \
+             for: {leaked:?}"
+        );
+    }
+}

--- a/tests/test_stats.rs
+++ b/tests/test_stats.rs
@@ -8596,3 +8596,60 @@ fn stats_percentile_list_label_matches_the_percentile_computed() {
     assert_eq!(pctiles("50.0", "c.csv"), "50: 500");
     assert_eq!(pctiles("010", "d.csv"), "10: 100");
 }
+
+#[test]
+fn stats_sign_prefixed_zero_padded_codes_stay_strings() {
+    // A leading zero marks a padded CODE (zip, FIPS, ICD-9, part number), which must stay a
+    // String so the padding survives. The integer path tested byte 0 directly, so a sign made
+    // it conclude "not padded": `-007` was typed as the integer -7. `+007` was worse - atoi
+    // rejects a leading '+' (SKIP_PLUS is false) so it never reached that check at all, while
+    // fast_float2 parsed it, and the float branch's padding check required a decimal point.
+    // Either way the padding was silently dropped from min/max and --zero-padded-numeric.
+    let wrk = Workdir::new("stats_signed_zero_padded");
+
+    let probe = |file: &str, values: &[&str], out: &str| -> (String, String, String) {
+        let mut rows = vec![svec!["code"]];
+        for v in values {
+            rows.push(vec![(*v).to_string()]);
+        }
+        wrk.create(file, rows);
+        let mut cmd = wrk.command("stats");
+        cmd.arg("--force")
+            .arg("--everything")
+            .arg("--zero-padded-numeric")
+            .args(["--output", wrk.path(out).to_str().unwrap()])
+            .arg(file);
+        wrk.assert_success(&mut cmd);
+        let text = std::fs::read_to_string(wrk.path(out)).unwrap();
+        let hdrs: Vec<&str> = text.lines().next().unwrap().split(',').collect();
+        let row: Vec<&str> = text.lines().nth(1).unwrap().split(',').collect();
+        let get = |k: &str| {
+            let i = hdrs.iter().position(|h| *h == k).unwrap();
+            row.get(i).unwrap_or(&"").to_string()
+        };
+        (get("type"), get("min"), get("zero_padded_numeric"))
+    };
+
+    // unsigned padded codes were always handled correctly - the baseline
+    assert_eq!(
+        probe("plain.csv", &["007", "008", "009"], "a.csv"),
+        ("String".into(), "007".into(), "true".into())
+    );
+    // ...and a sign must not change that
+    assert_eq!(
+        probe("neg.csv", &["-007", "-008", "-009"], "b.csv"),
+        ("String".into(), "-007".into(), "true".into()),
+        "`-007` was typed as the integer -7, dropping the padding"
+    );
+    assert_eq!(
+        probe("pos.csv", &["+007", "+008", "+009"], "c.csv"),
+        ("String".into(), "+007".into(), "true".into()),
+        "`+007` was typed as the float 7.0, dropping the padding"
+    );
+
+    // regression guards: genuine numbers must NOT become padded strings
+    let (plain_type, ..) = probe("real.csv", &["0.5", "7.1"], "d.csv");
+    assert_eq!(plain_type, "Float", "0.5 / 7.1 are real numbers, not codes");
+    let (signed_type, ..) = probe("signed.csv", &["+7", "-7"], "e.csv");
+    assert_eq!(signed_type, "Float", "+7 / -7 carry no padding");
+}

--- a/tests/test_stats.rs
+++ b/tests/test_stats.rs
@@ -8417,3 +8417,95 @@ fn stats_dates_whitelist_ignores_empty_tokens() {
     // and "all" must still mean all
     assert_eq!(typ("all", "c.csv"), vec!["Date", "Date"]);
 }
+
+#[test]
+fn stats_nan_weight_defaults_to_one_instead_of_poisoning() {
+    // fast_float2 parses "NaN" and "inf" SUCCESSFULLY, so the `unwrap_or(1.0)` fallback never
+    // fired for them. NaN then slipped past add_weighted's `w <= 0.0` guard (every NaN
+    // comparison is false) and poisoned sum_weights/weighted_mean permanently, so the whole
+    // column's weighted mean/sem/stddev/variance/cv came out NaN - while the sibling guards
+    // (`weight > 0.0`) silently DROPPED the same row from total_weight and the weighted
+    // quantiles. One cell made the moments and the quantiles disagree.
+    //
+    // The documented contract is "missing or non-numeric weights default to 1.0", so the fix is
+    // pinned against a reference file with an explicit 1.0 in place of the bad cell.
+    let wrk = Workdir::new("stats_nan_weight");
+
+    let run = |file: &str, rows: Vec<Vec<String>>, out: &str| -> Vec<String> {
+        wrk.create(file, rows);
+        let mut cmd = wrk.command("stats");
+        cmd.arg("--force")
+            .args(["--weight", "w"])
+            .arg("--everything")
+            .args(["--output", wrk.path(out).to_str().unwrap()])
+            .arg(file);
+        wrk.assert_success(&mut cmd);
+        let text = std::fs::read_to_string(wrk.path(out)).unwrap();
+        let hdrs: Vec<&str> = text.lines().next().unwrap().split(',').collect();
+        let row: Vec<&str> = text.lines().nth(1).unwrap().split(',').collect();
+        [
+            "mean",
+            "stddev",
+            "variance",
+            "cv",
+            "sem",
+            "q1",
+            "q2_median",
+            "q3",
+        ]
+        .iter()
+        .map(|k| {
+            let i = hdrs.iter().position(|h| h == k).unwrap();
+            row.get(i).unwrap_or(&"").to_string()
+        })
+        .collect()
+    };
+
+    let nan_weighted = run(
+        "nanw.csv",
+        vec![
+            svec!["v", "w"],
+            svec!["10", "1"],
+            svec!["20", "NaN"],
+            svec!["30", "2"],
+        ],
+        "nan.csv",
+    );
+    let reference = run(
+        "refw.csv",
+        vec![
+            svec!["v", "w"],
+            svec!["10", "1"],
+            svec!["20", "1"],
+            svec!["30", "2"],
+        ],
+        "ref.csv",
+    );
+
+    assert_eq!(
+        nan_weighted, reference,
+        "a NaN weight must behave exactly like the documented 1.0 default, for the moments AND \
+         the quantiles"
+    );
+    assert!(
+        !nan_weighted[0].is_empty() && nan_weighted[0] != "NaN",
+        "the weighted mean must be a real number, got {:?}",
+        nan_weighted[0]
+    );
+
+    // "inf" is non-finite too and must take the same path
+    let inf_weighted = run(
+        "infw.csv",
+        vec![
+            svec!["v", "w"],
+            svec!["10", "1"],
+            svec!["20", "inf"],
+            svec!["30", "2"],
+        ],
+        "inf.csv",
+    );
+    assert_eq!(
+        inf_weighted, reference,
+        "an infinite weight must also fall back to 1.0"
+    );
+}

--- a/tests/test_stats.rs
+++ b/tests/test_stats.rs
@@ -8509,3 +8509,40 @@ fn stats_nan_weight_defaults_to_one_instead_of_poisoning() {
         "an infinite weight must also fall back to 1.0"
     );
 }
+
+#[test]
+fn stats_percentile_list_rejects_out_of_range_and_non_numeric() {
+    // `to_record` casts each token `as u8` (SATURATING) while the output label keeps the
+    // original string, so out-of-range and non-numeric tokens produced nonsense with exit 0:
+    //   150 -> rank exceeds total weight, emitting the pre-filled default as "150: 0"
+    //   nan -> saturating cast to 0, emitting p0 under a "nan" label
+    //   -5  -> likewise
+    //   0   -> p0 is not a percentile
+    // Only `fast_float2::parse().is_ok()` was checked, which accepts every one of them.
+    let wrk = Workdir::new("stats_percentile_list_range");
+    let mut rows = vec![svec!["n"]];
+    for i in 1..=100 {
+        rows.push(vec![i.to_string()]);
+    }
+    wrk.create("pct.csv", rows);
+
+    for bad in ["150", "nan", "inf", "-5", "0", "101", "5,,10", "5,abc"] {
+        let mut cmd = wrk.command("stats");
+        cmd.arg("--force")
+            .arg("--percentiles")
+            .args(["--percentile-list", bad])
+            .arg("pct.csv");
+        wrk.assert_err(&mut cmd);
+    }
+
+    // in-range values keep working, including the boundaries and `deciles`/`quintiles`, which
+    // are expanded BEFORE validation
+    for good in ["1", "100", "5,10,95", "deciles", "quintiles", "50.0"] {
+        let mut cmd = wrk.command("stats");
+        cmd.arg("--force")
+            .arg("--percentiles")
+            .args(["--percentile-list", good])
+            .arg("pct.csv");
+        wrk.assert_success(&mut cmd);
+    }
+}


### PR DESCRIPTION
Batch C of the `src/cmd/stats.rs` review — the "wrong results" cluster. Follows Batch A (#4438), Batch B (#4439), the date-coercion fix (#4441) and F3 (#4442). Branched off `master` and independent of both open PRs.

Seven commits, one per finding. **Every finding was reproduced against a real fixture before being fixed, and every test was verified to fail against the pre-fix source** with the intended assertion.

## What was wrong

| # | Symptom (reproduced) | Fix |
|---|---|---|
| **R13** | `qsv stats -E --cache-threshold -105 d.tsv` leaves `d.tsv.idx` behind; the same run on `d.csv` cleans up | cleanup used `with_extension("csv.idx")` (REPLACES the extension) while `util::idx_path` APPENDS `.idx` |
| **R14** | `--dates-whitelist "date,"` types a non-whitelisted `note` column as Date | `"".contains("")` is always true, so one empty token silently meant "all"; empties are now filtered |
| **F9** | one `NaN` weight blanks the column's weighted mean/sem/stddev/variance/cv **and** shifts the quantiles (40th pct 20→30) | non-finite now takes the documented 1.0 default; all three weighted sites agree |
| **R7a** | `--percentile-list 150` → `"150: 0"`, `nan` → `"nan: <p0>"`, `-5`/`0` likewise, all exit 0 | tokens must now be finite and in `1..=100` |
| **R7b** | `--percentile-list 99.9` on 1000 rows → `"99.9: 990"` — the p99 value under a p99.9 label | the label now reports the percentile actually computed |
| **R9** | `-007` → Integer `-7`; `+007` → Float `7.0` — padded codes silently numeric-ized | sign is stripped before the leading-zero check; the float-side helper no longer requires a dot |
| **R8** | date fences render `+12000-01-`, `-10000-01-`, `-4000-01-0` | split at the RFC3339 `'T'` instead of slicing a fixed 10 bytes |

## Notes on scope — three deliberate non-fixes

**R16 is dropped as a phantom.** The finding claims an invalid-UTF-8 header *silently* loses date inference. The silence is the whole claim and it is false — `qsv stats` cannot process such a file at all:

| scenario | result |
|---|---|
| invalid UTF-8 in **header** | **exit 1**, `io error: stream did not contain valid UTF-8` |
| same, plus `--select 1`, or with no date flags at all | exit 1 |
| invalid UTF-8 in **data** only | exit 0, date inference works fine |
| `--no-headers` | exit 0, but field names are synthetic `0`/`1`, so the invalid bytes never reach the whitelist match |

A lossy conversion there would be dead code whose only test could assert unreachable behavior.

**R8's second half is unreachable.** A timestamp beyond `DateTime::from_timestamp_millis`'s range would be silently reported as `1970-01-01`, but date parsing caps years at 9999, so the largest reachable fence is ~year 37000 (~1.1e15 ms) against chrono's limit of year 262143 (~8.2e15 ms). No overflow sentinel added.

**R7's fractional case was a product decision, not a bug fix.** `--percentile-list 99.9` was accepted and truncated while the label kept the fraction. Two existing tests pinned that (`stats_percentiles_floats`, `stats_percentiles_custom_list`), and one is named for the behavior — so rejecting fractional input outright would have deleted a deliberately-written test. The objection was always the *lying label*, not the input, so fractional stays accepted and the label now matches: `99.9` and `99` produce byte-identical output. Those two tests' expected **labels** change; their **values** do not, which is the proof that only the label was ever wrong. Implementing true fractional percentiles (so `99.9` computes ~999) would be a feature and is out of scope.

## Behavior changes worth flagging

- `--percentile-list` now **errors** (exit 2) on `150`, `nan`, `inf`, `-5`, `0` and empty tokens, which previously produced nonsense output with exit 0.
- Percentile labels are normalized to the percentile computed: `99.9` → `99`, `50.0` → `50`, `010` → `10`.
- `-007` / `+007` now type as **String** (padded code) rather than Integer/Float. Guarded against over-reach: `0.5`, `7.1`, `+7` and `-7` are asserted to stay Float.
- A `NaN`/`inf` weight now behaves as the documented `1.0` default instead of poisoning the column — verified byte-identical to a reference file with an explicit `1.0` in that cell, across moments *and* quantiles.

R9 changes type inference, so the full suite was run before its test was written, not after.

Full suite green (3729 integration + 978 unit), `-F lite` green (2232), clippy identical to master's pre-existing warnings.

Remaining after this: **F10** (epoch date excluded from date min/max — reproduced, but the `0` sentinel in `from_sample` conflates "epoch" with "no value", so it needs its own PR) and Batch D (R15, R17, R18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
