### PR TITLE
refactor(stats): Batch D of the stats.rs review — dead field, constant drift, capacity off-by-one

### DIFF
--- a/docs/contributor/STATS_TECHNICAL_GUIDE.md
+++ b/docs/contributor/STATS_TECHNICAL_GUIDE.md
@@ -377,7 +377,7 @@ struct Stats {
     is_ascii: bool,           // 1 byte
     max_precision: u16,       // 2 bytes
     nullcount: u64,           // 8 bytes
-    sum_stotlen: u64,         // 8 bytes
+    total_weight: f64,        // 8 bytes
     
     // CONFIGURATION
     which: WhichStats,        // Flags for what to compute

--- a/scripts/docs-drift-check.py
+++ b/scripts/docs-drift-check.py
@@ -9,8 +9,10 @@ flags any documentation file that contradicts them:
      `all_features`, and `qsvmcp` (source: Cargo.toml).
   2. Source-file line counts referenced in contributor docs as
      "~NNN lines" (source: wc -l on the named .rs file).
-  3. The MAX_STAT_COLUMNS constant referenced as "up to N (summary) statistics"
-     (source: src/cmd/stats.rs).
+  3. The documented stat-column total, referenced as "up to N (summary)
+     statistics", derived from the MAX_STAT_COLUMNS constant
+     (source: src/cmd/stats.rs). See STAT_COLUMN_* below - the constant and the
+     documented total are NOT the same number.
   4. The 🤯 "loads entire CSV into memory" command set duplicated between
      docs/PERFORMANCE.md (prose) and docs/PERFORMANCE_TLDR.md (bullets);
      both docs must list the same commands.
@@ -134,6 +136,32 @@ MAX_STAT_COLUMNS_RE = re.compile(
     r"^\s*(?:pub\s+)?const\s+MAX_STAT_COLUMNS\s*:\s*\w+\s*=\s*(\d+)\s*;",
     re.MULTILINE,
 )
+
+
+# MAX_STAT_COLUMNS and the number the docs quote are two DIFFERENT quantities,
+# and conflating them is a live trap - they were equal only while the constant
+# was wrong (it read 48; `stats --everything` emits 49 columns).
+#
+#   MAX_STAT_COLUMNS is the width of the WIDEST SINGLE stats record. It
+#   INCLUDES the two leading `field`/`type` identifier columns, and it counts
+#   only one of `median` / `q2_median`, which are mutually exclusive: `median`
+#   is emitted under --median alone, `q2_median` replaces it under --quartiles
+#   or --everything.
+#
+#   The docs quote the UNION of stat names across all flag combinations,
+#   explicitly "beyond the `field`/`type` identifiers" - so they exclude both
+#   identifiers and include BOTH members of that mutually exclusive pair.
+#
+# Hence: documented_total = MAX_STAT_COLUMNS - IDENTIFIER_COLUMNS + MEDIAN_PAIR_EXTRA
+# Today: 49 - 2 + 1 = 48. Verified against the binary:
+#   `stats --everything` -> 49 columns (no `median`, has `q2_median`)
+#   union with `stats --median`, minus field/type -> 48 stat names.
+IDENTIFIER_COLUMNS = 2  # `field`, `type` - always emitted, never counted as stats
+MEDIAN_PAIR_EXTRA = 1  # `median` XOR `q2_median`: the union has both, a record has one
+
+
+def documented_stat_total(max_stat_columns: int) -> int:
+    return max_stat_columns - IDENTIFIER_COLUMNS + MEDIAN_PAIR_EXTRA
 
 
 def get_max_stat_columns() -> int:
@@ -380,7 +408,8 @@ STAT_COLUMN_CHECKS: list[tuple[str, re.Pattern[str]]] = [
 
 
 def check_stat_columns(report: Report) -> None:
-    truth = get_max_stat_columns()
+    max_stat_columns = get_max_stat_columns()
+    truth = documented_stat_total(max_stat_columns)
     for doc_rel, pattern in STAT_COLUMN_CHECKS:
         doc = REPO_ROOT / doc_rel
         if not doc.exists():
@@ -406,7 +435,11 @@ def check_stat_columns(report: Report) -> None:
                 line=lineno,
                 category="stat-columns",
                 message=(
-                    f"MAX_STAT_COLUMNS is {truth}; doc still says {n}"
+                    f"documented stat total should be {truth} "
+                    f"(MAX_STAT_COLUMNS is {max_stat_columns}, minus "
+                    f"{IDENTIFIER_COLUMNS} identifier columns, plus "
+                    f"{MEDIAN_PAIR_EXTRA} for median/q2_median); "
+                    f"doc says {n}"
                 ),
             )
 

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -3738,7 +3738,6 @@ struct Stats {
 
     // Hot counters - all 8-byte aligned, accessed frequently
     nullcount:    u64, // 8 bytes - frequently updated counter
-    sum_stotlen:  u64, // 8 bytes - frequently updated counter
     total_weight: f64, // 8 bytes - frequently updated for weighted stats
 
     // Configuration flags (accessed once during initialization, cold after init)
@@ -4381,7 +4380,6 @@ impl Stats {
             zpn_has_value: false,
             max_precision: 0,
             nullcount: 0,
-            sum_stotlen: 0,
             total_weight: 0.0,
             which,
             sum,
@@ -5711,7 +5709,6 @@ impl Commute for Stats {
         self.max_precision = self.max_precision.max(other.max_precision);
         self.which.merge(other.which);
         self.nullcount += other.nullcount;
-        self.sum_stotlen = self.sum_stotlen.saturating_add(other.sum_stotlen);
         self.sum.merge(other.sum);
         self.modes.merge(other.modes);
         self.unsorted_stats.merge(other.unsorted_stats);

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -851,8 +851,14 @@ const MS_IN_DAY_INT: i64 = 86_400_000;
 // 5 decimal places give us sub-second precision
 const DAY_DECIMAL_PLACES: u32 = 5;
 
-// maximum number of output columns
-const MAX_STAT_COLUMNS: usize = 48;
+// maximum number of output columns, i.e. the width of `stats_headers()` under
+// --everything: 29 always-on + mad + 9 quartile + 2 cardinality + 6 mode +
+// percentiles + zero_padded_numeric. Used only as a capacity hint, so a
+// mismatch costs a reallocation rather than correctness. `stats_headers()`
+// debug_asserts that it never emits MORE than this; the other direction (a
+// constant left too large) is deliberately not asserted, because --everything
+// is not a fixed width - `--quantile-method approx` drops `mad` and yields 48.
+const MAX_STAT_COLUMNS: usize = 49;
 
 // HyperLogLog precision parameter for `--cardinality-method approx`. lg_k=12
 // gives ~1.5% relative standard error and ~5KB per column at the dense Hll8
@@ -3080,6 +3086,19 @@ impl Args {
         if self.flag_zero_padded_numeric || everything {
             fields.push("zero_padded_numeric");
         }
+
+        // MAX_STAT_COLUMNS is the capacity hint for `fields` here and for the
+        // per-column StringRecord in `to_record()`. Adding a stats column without
+        // bumping it silently costs a reallocation on every --everything row, so
+        // pin the undercount direction here: any debug-build run of
+        // `stats --everything` checks it. An over-large constant is NOT caught -
+        // it cannot be, since --everything's width varies (48 under
+        // `--quantile-method approx`, which turns `mad` off).
+        debug_assert!(
+            fields.len() <= MAX_STAT_COLUMNS,
+            "stats_headers() emitted {} columns, exceeding MAX_STAT_COLUMNS ({MAX_STAT_COLUMNS})",
+            fields.len()
+        );
 
         csv::StringRecord::from(fields)
     }

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -6292,7 +6292,7 @@ impl TypedMinMax {
                         #[allow(clippy::cast_precision_loss)]
                         util::round_num(
                             (*max - *min) as f64 / MS_IN_DAY,
-                            u32::max(round_places, 5),
+                            u32::max(round_places, DAY_DECIMAL_PLACES),
                         ),
                         sort_order.to_string(),
                         util::round_num(sortiness, round_places),


### PR DESCRIPTION
Batch D of the `src/cmd/stats.rs` review. Three independent, low-risk commits — no behavior change in any of them — plus a CI
drift-check fix the third one exposed. Branched off `master` (`adfceaa50`), independent of the five open stats PRs
(#4441–#4445), mergeable in any order.

### `6139c4fe2` — R18: remove the dead `Stats.sum_stotlen` field

Declared, zero-initialized, and merged (`0 + 0`), but never incremented and never read. The real
string-length sum is `TypedSum.stotlen`, which is what `to_record()` renders as
`sum_length`/`avg_length`.

Beyond dead weight it was actively misleading: its declaration carried a "frequently updated
counter" comment and it sat in the cache-line-1 group the surrounding layout comments reason
about, so anyone chasing a `stotlen` bug would plausibly edit the wrong field.

`Stats` is module-private and is not serialized outside `stats.rs` — its `Serialize`/`Deserialize`
derives are unused crate-wide — so unlike `StatsData` it has no cross-command surface. Confirmed
by a repo-wide grep. `docs/contributor/STATS_TECHNICAL_GUIDE.md`, which mirrors the struct's
hot-field layout, is updated in the same commit.

### `fabd99da6` — R15: date range rounding uses `DAY_DECIMAL_PLACES`, not a hardcoded `5`

`TypedMinMax::show`'s `TDateTime | TDate` arm rounded the day range with
`u32::max(round_places, 5)` while all 12 sibling day-rounding sites use
`u32::max(round_places, DAY_DECIMAL_PLACES)`. The constant is currently `5`, so output is
byte-identical today.

Worth fixing because the drift is silent: bumping `DAY_DECIMAL_PLACES` for finer sub-second
precision would change the sem/stddev/iqr/mad day renderings but leave the `range` column at the
old precision — an internally inconsistent stats row, with no compile-time signal that one site
was missed.

The 13-site `round_days()` helper the review floated is deliberately **not** done here: it is a
pure refactor of correct code and does not belong in a fix commit.

### `ef20c4ea1` — U13: `MAX_STAT_COLUMNS` was 48; `--everything` emits 49

29 always-on columns, plus `mad`, 9 quartile, 2 cardinality, 6 mode, `percentiles` and
`zero_padded_numeric`. The constant is only ever a capacity hint — for the `fields` Vec in
`stats_headers()` and the per-column `StringRecord` in `to_record()` — so the undercount cost a
reallocation rather than wrong output. `to_record()` runs once per column, so the saving is one
Vec growth per column; this is a correctness-of-the-constant fix, not a measurable speedup.

`stats_headers()` now `debug_assert!`s that it never emits *more* than `MAX_STAT_COLUMNS`, which
turns every debug-build `stats --everything` in the suite into the check — rather than adding a
test that hand-copies the column list into a third place.

The opposite direction (a constant left too large) is deliberately **not** asserted: `--everything`
is not a fixed width, so there is no equality to assert against. `--everything --quantile-method
approx` emits 48, because `which_stats()` turns `mad` off for the approximate quantile engine.
Both the constant's comment and the assertion site record this.

### `5e4fed363` — CI: `docs-drift-check` conflated two different stat counts

Bumping `MAX_STAT_COLUMNS` to 49 made the repo's `docs-drift-check` demand that four docs change
"up to 48 summary statistics" to 49. **That would have made four user-facing docs state a false
number** — the docs were already correct. The rule compared the documented total directly against
the constant, and those two numbers were equal only *because* the constant was wrong.

- `MAX_STAT_COLUMNS` is the width of the **widest single** stats record. It **includes** the two
  `field`/`type` identifier columns, and counts only one of `median` / `q2_median`, which are
  mutually exclusive — `median` is emitted under `--median` alone, `q2_median` replaces it under
  `--quartiles`/`--everything`.
- The docs quote the **union** of stat names across all flag combinations, explicitly "beyond the
  `field`/`type` identifiers" — excluding both identifiers and including *both* members of that
  pair.

So `documented_total = MAX_STAT_COLUMNS - 2 identifiers + 1 for the median pair` = `49 - 2 + 1` =
**48**, which is what the docs already say. Verified against the binary: `stats --everything`
emits 49 columns with `q2_median` and no `median`; unioned with `stats --median`, minus
`field`/`type`, that is 48 distinct stat names. `STATS_DEFINITIONS.md`'s own breakdown agrees
independently (27 streaming + 21 non-streaming = 48).

**No doc is changed.** The derivation is now a named, commented expression rather than an implicit
identity, and the failure message prints the arithmetic so the next reader is not tempted to "fix"
the docs instead. Confirmed the rule still catches genuine drift in both directions: bumping the
constant to 50 flags all four docs (expecting 49), and editing `README.md` to say 49 flags
`README.md` alone (expecting 48).

## On tests

R15 and R18 carry no regression test, on purpose. R15's constant equals the literal it replaced
and R18's field is unreachable by construction, so any test would pass identically before and
after — a test that cannot fail against the pre-fix source is decoration. A clean build is the
proof for R18.

U13's guard **was** verified to fail pre-fix: with the constant put back to 48,
`qsv stats --everything` panics with
`stats_headers() emitted 49 columns, exceeding MAX_STAT_COLUMNS (48)`.

## Verification

- `cargo test -F all_features`: **978 unit + 3722 integration passed, 0 failed**.
- `cargo clippy -F all_features`: identical to master's baseline (compared by stashing the diff).
- `cargo +nightly fmt` clean.

Not run: `-F lite`, since nothing here touches `config.rs` or `util.rs`.

## Not in this batch

**R17** (full pre-pass over unindexed files just to count rows) was scoped and deliberately split
out. Two constraints surfaced that the original finding did not mention:

1. The same `record_count` feeds the dataset fingerprint string and `current_stats_args.record_count`
   (the cached args JSON). `compute()`'s `records_read` counts records the CSV reader yielded;
   `count_rows()` may instead use `polars_count_input`, and the codebase already notes polars
   "sometimes returns a zero count even if the file is not empty". These are not known-identical
   today — a difference of one would invalidate every previously written stats cache. That is the
   class #4439 closed, so it does not belong in a series with two cleanups.
2. `expected_rows` reaches `stats::Unsorted::with_capacity()` and `Vec::with_capacity()` — real
   upfront allocations, not lazily-growing hints. A filesize/avg-record-size estimate that
   overshoots allocates those bytes for real.

R17 will get its own branch once both are settled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

