### PR TITLE
fix(stats): take record_count from the compute pass, not a separate pre-pass

### DIFF
--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -2134,27 +2134,38 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
             // we need to count the number of records in the file to calculate sparsity and
             // cardinality
-            let record_count: u64;
-
-            let (headers, stats) = match indexed_result {
+            //
+            // NOTE: the count obtained here is only a CAPACITY HINT for the per-column
+            // accumulators. The authoritative record_count - the one that seeds
+            // RECORD_COUNT and therefore every per-record denominator in to_record()
+            // (sparsity, uniqueness_ratio, the <ALL_UNIQUE> antimode sentinel) - is the
+            // count RETURNED by the compute pass, i.e. the number of records actually
+            // accumulated. Deriving it from a separate pre-pass was a live wrong-results
+            // bug: util::count_rows() may use polars, which counts blank lines that the
+            // csv reader skips, so a file ending in a blank line inflated the denominator
+            // and made the SAME file produce different stats depending only on whether an
+            // index existed. Taking the count from the pass itself makes the denominator
+            // self-consistent by construction, for any counter disagreement, not just
+            // blank lines.
+            let (headers, stats, record_count) = match indexed_result {
                 None => {
                     // without an index, we need to count the number of records in the file
                     // safety: we know util::count_rows() will not return an Err
-                    record_count = util::count_rows(&rconfig).unwrap();
-                    args.sequential_stats(&resolved_whitelist, record_count)
+                    let capacity_hint = util::count_rows(&rconfig).unwrap();
+                    args.sequential_stats(&resolved_whitelist, capacity_hint)
                 },
                 Some(idx) => {
                     // with an index, we get the rowcount instantaneously from the index
-                    record_count = idx.count();
+                    let idx_count = idx.count();
                     match args.flag_jobs {
                         Some(num_jobs) => {
                             if num_jobs == 1 {
-                                args.sequential_stats(&resolved_whitelist, record_count)
+                                args.sequential_stats(&resolved_whitelist, idx_count)
                             } else {
-                                args.parallel_stats(&resolved_whitelist, record_count)
+                                args.parallel_stats(&resolved_whitelist, idx_count)
                             }
                         },
-                        _ => args.parallel_stats(&resolved_whitelist, record_count),
+                        _ => args.parallel_stats(&resolved_whitelist, idx_count),
                     }
                 },
             }?;
@@ -2613,7 +2624,13 @@ impl Args {
     /// 2. **Headers**: Reads and processes the CSV headers, applying column selection
     /// 3. **Date Inference**: Initializes date inference flags based on the whitelist
     /// 4. **Computation**: Processes all records sequentially to compute statistics
-    /// 5. **Return**: Returns headers and computed statistics
+    /// 5. **Return**: Returns headers, computed statistics, and the number of records read
+    ///
+    /// `capacity_hint` is ONLY a preallocation hint for the per-column accumulators; it is
+    /// never a read limit and is deliberately NOT the value reported back. The returned
+    /// count comes from the compute pass itself, so the caller's record_count always
+    /// matches the records actually accumulated even when the hint was obtained from a
+    /// counter with different blank-line semantics (see the note in `run()`).
     ///
     /// # Performance Characteristics
     ///
@@ -2630,8 +2647,8 @@ impl Args {
     fn sequential_stats(
         &self,
         whitelist: &str,
-        record_count: u64,
-    ) -> CliResult<(csv::ByteRecord, Vec<Stats>)> {
+        capacity_hint: u64,
+    ) -> CliResult<(csv::ByteRecord, Vec<Stats>, u64)> {
         let mut rdr = self.rconfig().reader()?;
         let full_headers = rdr.byte_headers()?.clone();
 
@@ -2641,24 +2658,25 @@ impl Args {
 
         init_date_inference(self.flag_infer_dates, &headers, whitelist)?;
 
-        // record_count is only a capacity hint for the per-column accumulators;
+        // capacity_hint is only a capacity hint for the per-column accumulators;
         // the read limit stays usize::MAX so we always process the whole file.
+        // The count we RETURN comes from the pass itself, never from the hint.
         // With more than one job available, overlap CSV parsing with stats
         // accumulation via a two-thread pipeline - records are processed in
         // arrival order, so results are bit-identical to the single-threaded
         // path. --jobs 1 keeps everything on one thread.
-        let stats = if util::njobs(self.flag_jobs) > 1 {
-            self.compute_pipelined(&sel, rdr, record_count as usize, weight_col_idx)
+        let (stats, records_read) = if util::njobs(self.flag_jobs) > 1 {
+            self.compute_pipelined(&sel, rdr, capacity_hint as usize, weight_col_idx)
         } else {
             self.compute(
                 &sel,
                 &mut rdr,
                 usize::MAX,
-                record_count as usize,
+                capacity_hint as usize,
                 weight_col_idx,
             )
         };
-        Ok((headers, stats))
+        Ok((headers, stats, records_read as u64))
     }
 
     /// Computes statistics for CSV data using a multi-threaded parallel approach.
@@ -2719,7 +2737,7 @@ impl Args {
         &self,
         whitelist: &str,
         idx_count: u64,
-    ) -> CliResult<(csv::ByteRecord, Vec<Stats>)> {
+    ) -> CliResult<(csv::ByteRecord, Vec<Stats>, u64)> {
         // N.B. This method doesn't handle the case when the number of records
         // is zero correctly. So we use `sequential_stats` instead.
         if idx_count == 0 {
@@ -2846,7 +2864,10 @@ impl Args {
                 // Drop it deliberately instead of relying on an unchecked unwrap.
                 let _ = send.send((
                     i,
-                    args.compute(&sel, &mut idx, chunk_size, chunk_size, weight_idx),
+                    // .0 = the chunk's Stats; the per-chunk record count is not
+                    // needed here - the index count is authoritative for this path
+                    args.compute(&sel, &mut idx, chunk_size, chunk_size, weight_idx)
+                        .0,
                 ));
             });
         }
@@ -2862,7 +2883,9 @@ impl Args {
         // Workers start in chunk order, so results arrive roughly in order and
         // the out-of-order buffer stays small - collecting everything before
         // merging would hold all nchunks results resident simultaneously.
-        Ok((headers, merge_chunks_in_order(&recv, nchunks)?))
+        // idx_count is authoritative here: the chunks partition exactly that many
+        // records, so it already equals the number of records accumulated.
+        Ok((headers, merge_chunks_in_order(&recv, nchunks)?, idx_count))
     }
 
     /// Converts a vector of `Stats` objects into CSV records for output.
@@ -2949,7 +2972,9 @@ impl Args {
     ///
     /// # Returns
     ///
-    /// A vector of `Stats` objects, one for each selected column
+    /// A tuple of (a vector of `Stats` objects, one for each selected column; the number of
+    /// records actually read). The count is the authoritative record count for the
+    /// unindexed path - see the note in `run()`.
     ///
     /// # Process
     ///
@@ -2983,7 +3008,7 @@ impl Args {
         limit: usize,
         expected_rows: usize,
         weight_col_idx: Option<usize>,
-    ) -> Vec<Stats> {
+    ) -> (Vec<Stats>, usize) {
         let sel_len = sel.len();
         let mut stats = self.new_stats(sel_len, expected_rows);
 
@@ -3018,7 +3043,7 @@ impl Args {
                 prefer_dmy,
             );
         }
-        stats
+        (stats, records_read)
     }
 
     /// Processes one CSV record: extracts the optional weight and feeds every
@@ -3090,13 +3115,16 @@ impl Args {
     /// sortiness and t-digest state - is bit-identical to the single-threaded
     /// `compute`. Batches are recycled through a return channel, so
     /// steady-state processing does no per-record or per-batch allocation.
+    ///
+    /// Returns the accumulated `Stats` together with the number of records read,
+    /// counted on the consumer side so it matches `compute`'s count exactly.
     fn compute_pipelined(
         &self,
         sel: &Selection,
         rdr: csv::Reader<Box<dyn std::io::Read + Send + 'static>>,
         expected_rows: usize,
         weight_col_idx: Option<usize>,
-    ) -> Vec<Stats> {
+    ) -> (Vec<Stats>, usize) {
         const BATCH_SIZE: usize = 1024;
         // one being filled + one being drained + two in flight
         const NBATCHES: usize = 4;
@@ -3121,6 +3149,10 @@ impl Args {
                     .unwrap_unchecked();
             }
         }
+
+        // counted on the CONSUMER side: this sums exactly the rows fed to add_row,
+        // so the count cannot drift from what was actually accumulated.
+        let mut records_read = 0_usize;
 
         std::thread::scope(|s| {
             // reader thread: fills recycled batches in place
@@ -3149,6 +3181,7 @@ impl Args {
 
             // consumer (this thread): the same per-row hot loop as compute()
             for (batch, n) in &full_rx {
+                records_read += n;
                 for row in &batch[..n] {
                     Self::add_row(
                         &mut stats,
@@ -3164,7 +3197,7 @@ impl Args {
                 let _ = empty_tx.send(batch);
             }
         });
-        stats
+        (stats, records_read)
     }
 
     /// Processes headers and handles weight column exclusion if needed.

--- a/tests/test_stats.rs
+++ b/tests/test_stats.rs
@@ -8999,3 +8999,87 @@ fn stats_autoindex_is_skipped_for_special_format_inputs() {
         "autoindexing must still work for ordinary CSV inputs"
     );
 }
+
+// A blank line is counted by polars (util::count_rows) but SKIPPED by the csv reader that
+// actually feeds the compute pass. Seeding RECORD_COUNT from a separate pre-pass therefore
+// inflated every per-record denominator in to_record() - uniqueness_ratio, and the
+// cardinality == record_count test behind the <ALL_UNIQUE> antimode sentinel - so the SAME
+// file produced different statistics depending only on whether an index happened to exist.
+// The record count now comes from the compute pass itself, which makes the denominator
+// self-consistent by construction.
+//
+// The fixture ends in a blank line ("...\n\n"), which is ordinary real-world data.
+#[test]
+fn stats_trailing_blank_line_denominator() {
+    // the named stat for EVERY data row - the fixture's two columns are both affected
+    fn stats_of(out: &str, col: &str) -> Vec<String> {
+        let mut lines = out.lines();
+        let hdr: Vec<&str> = lines.next().unwrap().split(',').collect();
+        let idx = hdr
+            .iter()
+            .position(|h| *h == col)
+            .unwrap_or_else(|| panic!("no {col} column in stats output"));
+        lines
+            .map(|l| l.split(',').nth(idx).unwrap().to_string())
+            .collect()
+    }
+
+    let wrk = Workdir::new("stats_trailing_blank_line_denominator");
+    // every run gets its OWN fixture filename - stats sidecars are written next to the input
+    for name in ["blankline_par.csv", "blankline_j1.csv", "blankline_idx.csv"] {
+        wrk.create_from_string(name, "a,b\n1,2\n3,4\n\n");
+    }
+
+    let run = |input: &str, jobs: Option<&str>| -> String {
+        let mut cmd = wrk.command("stats");
+        cmd.arg("--everything").args(["--cache-threshold", "0"]);
+        if let Some(j) = jobs {
+            cmd.args(["--jobs", j]);
+        }
+        cmd.arg(input);
+        wrk.stdout_on_success::<String>(&mut cmd)
+    };
+
+    // the indexed path takes its count from the index, which is built by qsv's own csv
+    // reader - it has always been right, so it is the reference the other two must match.
+    let mut idx_cmd = wrk.command("index");
+    idx_cmd.arg("blankline_idx.csv");
+    wrk.assert_success(&mut idx_cmd);
+    let indexed = run("blankline_idx.csv", None);
+
+    // the two unindexed paths: pipelined (default --jobs) and single-threaded (--jobs 1).
+    // The pipelined one is the default, so a fix that only corrected compute() would leave
+    // the bug in place for nearly every real invocation.
+    let pipelined = run("blankline_par.csv", None);
+    let single = run("blankline_j1.csv", Some("1"));
+
+    for (label, out) in [
+        ("indexed", &indexed),
+        ("unindexed/pipelined", &pipelined),
+        ("unindexed/--jobs 1", &single),
+    ] {
+        // only 2 records are actually read, and every value in BOTH columns is distinct,
+        // so the ratio is 2/2 and the <ALL_UNIQUE> sentinel applies to each.
+        assert_eq!(
+            stats_of(out, "cardinality"),
+            ["2", "2"],
+            "{label}: the blank line must not be counted as a record"
+        );
+        assert_eq!(
+            stats_of(out, "uniqueness_ratio"),
+            ["1", "1"],
+            "{label}: uniqueness_ratio must be cardinality/records-actually-read (2/2), not 2/3 - \
+             a blank line inflating the denominator"
+        );
+        assert_eq!(
+            stats_of(out, "antimode"),
+            ["*ALL", "*ALL"],
+            "{label}: with every value unique, the <ALL_UNIQUE> antimode sentinel must apply"
+        );
+        assert_eq!(
+            stats_of(out, "antimode_count"),
+            ["0", "0"],
+            "{label}: antimode_count must be 0 under the <ALL_UNIQUE> sentinel"
+        );
+    }
+}


### PR DESCRIPTION
## The bug

`util::count_rows()` uses polars, which **counts blank lines**; the csv reader that feeds
`compute()` **skips** them. Seeding `RECORD_COUNT` from that separate pre-pass therefore
inflated every per-record denominator in `to_record()` — `uniqueness_ratio`, and the
`cardinality == record_count` test behind the `<ALL_UNIQUE>` antimode sentinel.

The trigger is **a file ending in a blank line** (`"...\n\n"`) — ordinary real-world data.

Same file, same binary, differing only by whether an index happened to exist:

```console
$ printf 'a,b\n1,2\n3,4\n\n' > blank.csv
```

| | cardinality | uniqueness_ratio | antimode | antimode_count |
|---|---|---|---|---|
| unindexed | 2 | **0.6667** | **1\|3** | **2** |
| indexed (correct) | 2 | 1 | `*ALL` | 0 |

Merely creating an index changed the statistical output.

## The fix

`compute()` and `compute_pipelined()` now return the number of records they actually
accumulated; `sequential_stats`/`parallel_stats` propagate it, and `run()` seeds
`RECORD_COUNT` from it. The denominator is now self-consistent **by construction** — immune
to any `count_rows` disagreement, not just blank lines.

`util::count_rows()` is retained purely as the capacity hint, and its `sequential_stats`
parameter is renamed `capacity_hint` because exactly that ambiguity was the bug.

Consequences worth stating explicitly:

- **Nothing about allocation behaviour changes** — the hint is still the exact count.
- **`util::ROW_COUNT`/`optimal_batch_size` are unaffected**, since the call remains.
- **Only the unindexed path changes.** The indexed path takes its count from the index,
  which is built by qsv's own csv reader and has always been right.
- **This is not a cache-invalidation event.** `record_count` and `hash` are explicitly
  zeroed before the stats-cache validity comparison (`stats.rs:1909`); `qsv_version` is
  what gates it.

## Note for reviewers: `compute_pipelined` is the default path

`sequential_stats` dispatches to `compute_pipelined` whenever `util::njobs() > 1`, which is
the default — a fix to `compute()` alone would have left the bug live for nearly every real
invocation. Its count is accumulated on the **consumer** side, summing exactly the rows fed
to `add_row`. The regression test asserts default-jobs, `--jobs 1` and indexed all agree.

## One deliberate output change

A file containing **only** blank lines after the header (`printf 'a,b\n\n\n'`) had
`record_count` 2; it is now 0, so it renders identically to a header-only file:

| column | before | after |
|---|---|---|
| `sparsity` | `0` | *(empty)* |
| `uniqueness_ratio` | `0` | *(empty)* |
| `antimode` | *(empty)* | `*ALL` |

Correct and intended — such a file contains zero records. No NaN/inf: a zero `record_count`
was already an exercised path (header-only files have always reached it). Verified on
header-only, truly-empty and blanks-only inputs.

## Testing

- New `stats_trailing_blank_line_denominator` — **verified to FAIL pre-fix** with the
  expected assertion (`left: ["0.6667", "0.6667"], right: ["1", "1"]`), on the pipelined path.
- Full suite green: **988 unit + 3736 integration, 0 failed**.
- `cargo check -F lite` clean; clippy clean (the one warning is pre-existing in `viz.rs`).
- 1M-row real-world file still reports `record_count = 1000000` exactly.

## Follow-ups filed

- **#4456** — `qsv count` is itself self-inconsistent on the same input (unindexed 3,
  indexed 2). Not addressed here; `stats` is now immune regardless of how it is resolved.
- **#4457** — the deferred perf half (skip the pre-pass entirely). Measured ceiling is only
  3-8% on the polars build; qsvlite (~30%) is the real beneficiary, and it needs an
  allocation-estimator decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)