### PR TITLE
fix: share the resolved Config with parallel workers (#4446)

### DIFF
--- a/src/cmd/pragmastat.rs
+++ b/src/cmd/pragmastat.rs
@@ -1060,21 +1060,18 @@ fn collect_numeric_values_parallel(
     let pool = ThreadPool::new(njobs);
     let (send, recv) = crossbeam_channel::bounded(nchunks);
 
-    let input_path_string = rconfig
-        .path
-        .as_ref()
-        .unwrap()
-        .to_str()
-        .unwrap_or("")
-        .to_string();
     let selected_vec = selected.to_vec();
     let col_types_vec = col_types.clone();
-    let delimiter = Delimiter(rconfig.get_delimiter());
-    let no_headers = rconfig.no_headers;
 
     for chunk_idx in 0..nchunks {
         let send = send.clone();
-        let input_path_string = input_path_string.clone();
+        // CLONE the already-resolved `rconfig`; never rebuild a Config from the input
+        // path here. A special-format input (.gz/.zip/.parquet/...) is read through a
+        // converted temp file, and each freshly-built Config resolves its OWN temp - so
+        // a worker would look for the index beside a different temp than the one the
+        // parent indexed. Cloning shares the `Arc<OnceLock>` holding that temp path (and
+        // with it the temp's real delimiter). See `frequency::parallel_ftables`.
+        let rconfig_chunk = rconfig.clone();
         let selected = selected_vec.clone();
         let col_types = col_types_vec.clone();
         let num_cols = selected.len();
@@ -1085,9 +1082,6 @@ fn collect_numeric_values_parallel(
         };
 
         pool.execute(move || {
-            let rconfig_chunk = Config::new(Some(&input_path_string))
-                .delimiter(Some(delimiter))
-                .no_headers_flag(no_headers);
             let Ok(Some(mut idx)) = rconfig_chunk.indexed() else {
                 let _ = send.send(Err(CliError::Other(
                     "Failed to open index for parallel reading".to_string(),

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -226,10 +226,10 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         .dfa_size_limit(args.flag_dfa_size_limit * (1 << 20))
         .build()?;
 
-    let rconfig = Config::new(args.arg_input.as_ref())
-        .delimiter(args.flag_delimiter)
-        .no_headers_flag(args.flag_no_headers)
-        .select(args.flag_select.clone());
+    // BIND the Config here and hand it to both routes. For special-format inputs
+    // (.gz/.zip/.parquet/...) it lazily resolves a converted temp file, and the parallel
+    // workers must share that same temp - and the index built beside it.
+    let rconfig = args.rconfig();
 
     // Route to parallel or sequential search
     // based on index availability, number of jobs, and --preview-match option
@@ -620,23 +620,24 @@ impl Args {
         let pool = ThreadPool::new(njobs);
         let (send, recv) = crossbeam_channel::bounded::<CliResult<ChunkOutput>>(nchunks);
 
-        // Share Args across workers via Arc to avoid a per-worker clone
-        // of SelectColumns and other inner allocations.
-        let args = Arc::new(self.clone());
-
         // Spawn search jobs
         for chunk_index in 0..nchunks {
-            let (send, args, sel, pattern, lowest_match) = (
+            // CLONE the already-resolved `rconfig`; never rebuild `self.rconfig()` here.
+            // A special-format input (.gz/.zip/.parquet/...) is read through a converted
+            // temp file, and each freshly-built Config resolves its OWN temp - so a worker
+            // would look for the index beside a different temp than the one the parent
+            // indexed. Cloning shares the `Arc<OnceLock>` holding that temp path.
+            // See `frequency::parallel_ftables` for the same invariant.
+            let (send, rconf, sel, pattern, lowest_match) = (
                 send.clone(),
-                Arc::clone(&args),
+                rconfig.clone(),
                 sel.clone(),
                 Arc::clone(&pattern),
                 Arc::clone(&lowest_match_chunk),
             );
             pool.execute(move || {
                 let result: CliResult<ChunkOutput> = (|| {
-                    let mut idx = args
-                        .rconfig()
+                    let mut idx = rconf
                         .indexed()?
                         .ok_or_else(|| CliError::Other("CSV index unavailable".to_string()))?;
                     idx.seek((chunk_index * chunk_size) as u64)?;

--- a/src/cmd/searchset.rs
+++ b/src/cmd/searchset.rs
@@ -238,10 +238,10 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         .build()?;
     debug!("Successfully compiled regex set!");
 
-    let rconfig = Config::new(args.arg_input.as_ref())
-        .delimiter(args.flag_delimiter)
-        .no_headers_flag(args.flag_no_headers)
-        .select(args.flag_select.clone());
+    // BIND the Config here and hand it to both routes. For special-format inputs
+    // (.gz/.zip/.parquet/...) it lazily resolves a converted temp file, and the parallel
+    // workers must share that same temp - and the index built beside it.
+    let rconfig = args.rconfig();
 
     // Route to parallel or sequential search
     // based on index availability and number of jobs
@@ -489,23 +489,24 @@ impl Args {
         let pool = ThreadPool::new(njobs);
         let (send, recv) = crossbeam_channel::bounded::<CliResult<ChunkOutput>>(nchunks);
 
-        // Share Args across workers via Arc to avoid a per-worker clone
-        // of SelectColumns and other inner allocations.
-        let args = Arc::new(self.clone());
-
         // Spawn search jobs
         for chunk_index in 0..nchunks {
-            let (send, args, sel, pattern, lowest_match) = (
+            // CLONE the already-resolved `rconfig`; never rebuild `self.rconfig()` here.
+            // A special-format input (.gz/.zip/.parquet/...) is read through a converted
+            // temp file, and each freshly-built Config resolves its OWN temp - so a worker
+            // would look for the index beside a different temp than the one the parent
+            // indexed. Cloning shares the `Arc<OnceLock>` holding that temp path.
+            // See `frequency::parallel_ftables` for the same invariant.
+            let (send, rconf, sel, pattern, lowest_match) = (
                 send.clone(),
-                Arc::clone(&args),
+                rconfig.clone(),
                 sel.clone(),
                 Arc::clone(&pattern),
                 Arc::clone(&lowest_match_chunk),
             );
             pool.execute(move || {
                 let result: CliResult<ChunkOutput> = (|| {
-                    let mut idx = args
-                        .rconfig()
+                    let mut idx = rconf
                         .indexed()?
                         .ok_or_else(|| CliError::Other("CSV index unavailable".to_string()))?;
                     idx.seek((chunk_index * chunk_size) as u64)?;

--- a/src/cmd/split.rs
+++ b/src/cmd/split.rs
@@ -214,9 +214,14 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     if let Some(kb_size) = args.flag_kb_size {
         args.split_by_kb_size(kb_size)
     } else {
-        // we're splitting by rowcount or by number of chunks
-        match args.rconfig().indexed()? {
-            Some(idx) => args.parallel_split(&idx),
+        // we're splitting by rowcount or by number of chunks.
+        // BIND the Config rather than using a temporary: for special-format inputs
+        // (.gz/.zip/.parquet/...) it lazily resolves a converted temp file, and
+        // `parallel_split`'s workers must share that same temp - and the index built
+        // beside it - rather than each resolving one of their own.
+        let rconfig = args.rconfig();
+        match rconfig.indexed()? {
+            Some(idx) => args.parallel_split(&idx, &rconfig),
             None => args.sequential_split(),
         }
     }
@@ -404,7 +409,13 @@ impl Args {
         Ok(())
     }
 
-    fn parallel_split(&self, idx: &Indexed<fs::File, fs::File>) -> CliResult<()> {
+    // `rconfig` must be the SAME (already-resolved) Config that produced `idx`.
+    // For special-format inputs (e.g. `.zip`) each `Config` lazily resolves to its
+    // own temp path; sharing this one means every worker re-opens the index next to
+    // the same temp - and decompresses the input once, not once per chunk. Rebuilding
+    // `self.rconfig()` inside a worker resolves a different temp with no sibling
+    // `.idx`. See `frequency::parallel_ftables` for the same invariant.
+    fn parallel_split(&self, idx: &Indexed<fs::File, fs::File>, rconfig: &Config) -> CliResult<()> {
         let chunk_size;
         let idx_count = idx.count();
 
@@ -429,12 +440,13 @@ impl Args {
         (0..nchunks)
             .into_par_iter()
             .try_for_each(|i| -> CliResult<()> {
-                let conf = self.rconfig();
+                // Only the Config is shared - each worker still opens its OWN
+                // Indexed handle here, because each seeks to a different offset.
                 // safety: indexed() returned Some at the call site; the index is
                 // guaranteed to exist because parallel_split is only entered when
                 // the caller observed a valid index. A failed re-open here is a
                 // genuine I/O error and should propagate.
-                let mut idx = conf.indexed()?.ok_or_else(|| {
+                let mut idx = rconfig.indexed()?.ok_or_else(|| {
                     crate::CliError::Other("indexed CSV vanished during parallel split".to_string())
                 })?;
                 let headers = idx.byte_headers()?;

--- a/tests/test_pragmastat.rs
+++ b/tests/test_pragmastat.rs
@@ -1632,3 +1632,73 @@ fn pragmastat_subsample_cache_incompatible() {
 
     wrk.assert_err(&mut cmd);
 }
+
+// issue #4446: `collect_numeric_values_parallel` rebuilt a Config per worker from the input
+// PATH STRING (`Config::new(Some(&input_path_string))`). For a special-format input
+// (.gz/.zip/.parquet/...) each Config resolves its OWN converted temp file, so with an
+// autoindex in play every worker looked for the index beside a different temp and the run
+// died with "Failed to open index for parallel reading". Workers now clone the
+// already-resolved Config the function was handed all along.
+//
+// The fixture must have >= 10_000 rows: the parallel path is gated on that row count, so the
+// 100-row boston311 fixture never reaches it. A .zip rather than .gz on purpose - zip support
+// is non-optional in every build, so this also runs under `-F lite`.
+#[test]
+fn pragmastat_from_zip_parallel_autoindexed() {
+    use std::io::Write;
+
+    let wrk = Workdir::new("pragmastat_from_zip_parallel_autoindexed");
+
+    let mut plain = String::from("a,b\n");
+    for i in 0..12_000 {
+        plain.push_str(&format!("{i},{}\n", i % 97));
+    }
+    wrk.create_from_string("pg.csv", &plain);
+
+    let zip_path = wrk.path("pg.zip");
+    let zf = std::fs::File::create(&zip_path).unwrap();
+    let mut zw = zip::ZipWriter::new(zf);
+    zw.start_file("pg.csv", zip::write::SimpleFileOptions::default())
+        .unwrap();
+    zw.write_all(plain.as_bytes()).unwrap();
+    zw.finish().unwrap();
+
+    // --standalone writes to stdout; without it pragmastat appends to a stats sidecar keyed
+    // to the input path, so the .zip and .csv runs would write to DIFFERENT files and this
+    // comparison would have nothing to compare.
+    let pragmastat_of = |input: &str| -> Vec<Vec<String>> {
+        let mut cmd = wrk.command("pragmastat");
+        cmd.env("QSV_AUTOINDEX_SIZE", "1")
+            .env("QSV_STATSCACHE_MODE", "none")
+            .arg("--standalone")
+            .args(["--jobs", "4"])
+            .arg(input);
+        wrk.read_stdout_on_success(&mut cmd)
+    };
+
+    let from_zip = pragmastat_of(zip_path.to_str().unwrap());
+    let from_csv = pragmastat_of(wrk.path("pg.csv").to_str().unwrap());
+
+    assert!(
+        from_zip.len() > 1,
+        "pragmastat over a .zip input produced no data rows"
+    );
+    assert_eq!(
+        from_zip.len(),
+        from_csv.len(),
+        "pragmastat over a .zip input must cover the same columns as the uncompressed input"
+    );
+
+    // Compare only field/n/center/spread/center_lower/center_upper. spread_lower and
+    // spread_upper (the last two) are order statistics of a RANDOM disjoint pairing under a
+    // time-seeded RNG - they legitimately differ between two runs of the same input, so
+    // asserting on them would make this test flaky. See pragmastat_onesample_basic.
+    const DETERMINISTIC_COLS: usize = 6;
+    for (zip_row, csv_row) in from_zip.iter().zip(from_csv.iter()) {
+        assert_eq!(
+            &zip_row[..DETERMINISTIC_COLS],
+            &csv_row[..DETERMINISTIC_COLS],
+            "pragmastat for a .zip input must equal the same data uncompressed"
+        );
+    }
+}

--- a/tests/test_search.rs
+++ b/tests/test_search.rs
@@ -945,3 +945,42 @@ fn search_no_headers_envvar_issue_3437() {
     let expected = vec![svec!["@", "bar"], svec!["@", "bar"], svec!["@", "bar"]];
     assert_eq!(got, expected);
 }
+
+// issue #4446: with an autoindex on a special-format input, `parallel_search`'s workers
+// rebuilt `args.rconfig()` and resolved a DIFFERENT converted temp file than the one the
+// parent indexed, so `indexed()` hit an absent sibling `.idx` and the run failed with
+// "io error: No such file or directory" after emitting only the header. Workers now clone
+// the already-resolved Config that `parallel_search` was handed all along.
+//
+// QSV_AUTOINDEX_SIZE=1 forces the autoindex; --jobs 4 is required because the parallel path
+// is gated on njobs > 1. --preview-match is deliberately NOT set: it disables parallelism.
+#[test]
+fn search_from_zip_parallel_autoindexed() {
+    let wrk = Workdir::new("search_from_zip_parallel_autoindexed");
+    let zip_file = wrk.load_test_file("boston311-100.csv.zip");
+    let csv_file = wrk.load_test_file("boston311-100.csv");
+
+    let search_in = |input: &str| -> String {
+        let mut cmd = wrk.command("search");
+        cmd.env("QSV_AUTOINDEX_SIZE", "1")
+            .args(["--jobs", "4"])
+            .args(["--select", "neighborhood"])
+            .arg("(?i)roxbury")
+            .arg(input);
+        wrk.stdout_on_success::<String>(&mut cmd)
+    };
+
+    let from_zip = search_in(&zip_file);
+    let from_csv = search_in(&csv_file);
+
+    // matched rows, not just the header - a fix that silently produced nothing would
+    // otherwise satisfy the equality check below
+    assert!(
+        from_zip.lines().count() > 1,
+        "search over a .zip input returned no matching rows"
+    );
+    assert_eq!(
+        from_zip, from_csv,
+        "search over a .zip input must equal search over the same data uncompressed"
+    );
+}

--- a/tests/test_searchset.rs
+++ b/tests/test_searchset.rs
@@ -696,3 +696,43 @@ fn searchset_comment_lines() {
     ];
     assert_eq!(got, expected);
 }
+
+// issue #4446: with an autoindex on a special-format input, `parallel_search`'s workers
+// rebuilt `args.rconfig()` and resolved a DIFFERENT converted temp file than the one the
+// parent indexed, so `indexed()` hit an absent sibling `.idx` and the run failed with
+// "io error: No such file or directory" after emitting only the header. Workers now clone
+// the already-resolved Config that `parallel_search` was handed all along.
+//
+// QSV_AUTOINDEX_SIZE=1 forces the autoindex; --jobs 4 is required because the parallel path
+// is gated on njobs > 1.
+#[test]
+fn searchset_from_zip_parallel_autoindexed() {
+    let wrk = Workdir::new("searchset_from_zip_parallel_autoindexed");
+    let zip_file = wrk.load_test_file("boston311-100.csv.zip");
+    let csv_file = wrk.load_test_file("boston311-100.csv");
+    wrk.create_from_string("patterns.txt", "(?i)roxbury\n(?i)dorchester\n");
+
+    let searchset_in = |input: &str| -> String {
+        let mut cmd = wrk.command("searchset");
+        cmd.env("QSV_AUTOINDEX_SIZE", "1")
+            .args(["--jobs", "4"])
+            .args(["--select", "neighborhood"])
+            .arg("patterns.txt")
+            .arg(input);
+        wrk.stdout_on_success::<String>(&mut cmd)
+    };
+
+    let from_zip = searchset_in(&zip_file);
+    let from_csv = searchset_in(&csv_file);
+
+    // matched rows, not just the header - a fix that silently produced nothing would
+    // otherwise satisfy the equality check below
+    assert!(
+        from_zip.lines().count() > 1,
+        "searchset over a .zip input returned no matching rows"
+    );
+    assert_eq!(
+        from_zip, from_csv,
+        "searchset over a .zip input must equal searchset over the same data uncompressed"
+    );
+}

--- a/tests/test_split.rs
+++ b/tests/test_split.rs
@@ -1852,3 +1852,48 @@ fn split_filter_multiword_command_windows() {
     wrk.assert_success(&mut cmd);
     assert!(wrk.path("name with space.bak").exists());
 }
+
+// issue #4446: a special-format input (.gz/.zip/.parquet/...) is read through a CONVERTED
+// temp file, and every Config instance converts to its OWN temp path. When an autoindex is
+// created, `parallel_split`'s workers used to rebuild `self.rconfig()`, resolve a DIFFERENT
+// temp, and find no index beside it - failing with "io error: No such file or directory" and
+// writing zero chunk files. Workers now share the parent's already-resolved Config.
+//
+// QSV_AUTOINDEX_SIZE=1 forces the autoindex, and `--size 10` on the 100-row fixture yields
+// 10 chunks: `parallel_split` short-circuits to `sequential_split` when nchunks == 1, which
+// would exercise nothing.
+#[test]
+fn split_from_zip_parallel_autoindexed() {
+    let wrk = Workdir::new("split_from_zip_parallel_autoindexed");
+    let zip_file = wrk.load_test_file("boston311-100.csv.zip");
+    let csv_file = wrk.load_test_file("boston311-100.csv");
+
+    let split_into = |input: &str, outdir: &str| {
+        wrk.create_subdir(outdir).unwrap();
+        let mut cmd = wrk.command("split");
+        cmd.env("QSV_AUTOINDEX_SIZE", "1")
+            .args(["--size", "10"])
+            .arg(wrk.path(outdir))
+            .arg(input);
+        wrk.assert_success(&mut cmd);
+    };
+
+    split_into(&zip_file, "zipout");
+    split_into(&csv_file, "csvout");
+
+    // every chunk must exist and be byte-identical to the same split of the uncompressed
+    // input. Asserting only exit 0 would also pass if the fix silently went sequential.
+    for start in (0..100).step_by(10) {
+        let from_zip = wrk
+            .read_to_string(&format!("zipout/{start}.csv"))
+            .unwrap_or_else(|e| panic!("missing chunk zipout/{start}.csv: {e}"));
+        let from_csv = wrk
+            .read_to_string(&format!("csvout/{start}.csv"))
+            .unwrap_or_else(|e| panic!("missing chunk csvout/{start}.csv: {e}"));
+        assert_eq!(
+            from_zip, from_csv,
+            "chunk {start}.csv from a .zip input must equal the same chunk from the uncompressed \
+             input"
+        );
+    }
+}


### PR DESCRIPTION
Fixes #4446.

## The bug

A special-format input (`.gz`/`.zip`/`.parquet`/`.jsonl`/…) is read through a **converted temp
file**. `Config` caches that temp in `read_input: Arc<OnceLock<…>>`, so **clones share it but
freshly-constructed Configs each resolve their own**.

Commands whose parallel workers *rebuild* a Config therefore autoindexed temp **A** in the parent
and looked for that index beside temp **B** in every worker.

One detail the issue doesn't mention, and the reason this fails *loudly* rather than falling back:
`AUTO_INDEXED` is a **process-global**, so once the parent autoindexes, `Config::index_files` takes
its fast path and does an unconditional `fs::File::open(idx_path(temp_B))` → hard ENOENT.

| command (`QSV_AUTOINDEX_SIZE=1000`) | before | after |
|---|---|---|
| `qsv split -s 10000 out f.zip` | exit 1, **zero** chunk files | 5 chunk files |
| `qsv search -s cat "c1" f.zip` | exit 1, header only | 11001 rows |
| `qsv searchset pats.txt f.zip` | exit 1, header only | 22001 rows |
| `qsv pragmastat f.zip` | exit 1 | exit 0 |

**`pragmastat` is a fourth victim not named in the issue** — same defect, reached by rebuilding
`Config::new(Some(&input_path_string))` from a captured path string rather than `args.rconfig()`.
Found by sweeping every `.indexed()` call site, then reproducing.

## The fix

Issue option **(1): share the resolved `Config`**, the way `frequency`, `schema` and `replace`
already do. `search`, `searchset` and `pragmastat` were **already handed** that Config and simply
ignored it in the worker, so those are one-liners. `split` built a temporary Config at the call site
and never passed it, so `parallel_split` gains an `rconfig` parameter.

Only the `Config` is shared — each worker still opens its own `Indexed` handle, since each seeks to
a different offset.

Two things fall out beyond the crash fix:

- **The N× decompression is gone.** Every worker used to convert the whole input into a temp of its
  own; `split` additionally leaked the temp from the Config it dropped.
- **Cloning a `Config` is strictly cheaper than the `Config::new` it replaces**, which re-parsed env
  vars and re-ran special-format detection per worker. So the `Arc<Args>` that `search`/`searchset`
  shared purely as a Config factory is gone — noting it because the comment it carried claimed the
  opposite trade-off.

`search`/`searchset` `run()` also now call `args.rconfig()` instead of an inline, byte-identical
`Config::new(…)` chain; without that the method becomes dead code.

## Tests

One per command, each asserting **output equality against the same command on the uncompressed
CSV** — not merely exit 0, which a fix that quietly dropped to sequential would also satisfy.

Verified to **fail against the reverted `src/`** (4 failed; `frequency`'s existing zip test still
passed), so they are real regression guards rather than tests that pass either way.

`pragmastat` compares only its six deterministic columns — `spread_lower`/`spread_upper` are order
statistics of a random disjoint pairing under a time-seeded RNG and legitimately differ run to run.
Its fixture is built inline at 12k rows because that parallel path is gated on `>= 10_000`.

`.zip` fixtures throughout: zip support is non-optional, so these also run under `-F lite`.

Full suite green (3739 passed), clippy clean, `cargo +nightly fmt`, `-F lite` compiles.

## Deliberately out of scope

1. **`stats` re-parallelization.** Its two `is_special_format()` guards from #4445 could come out
   once `parallel_stats` shares its Config, but that is a perf change, not this crash — and that
   path also carries the memcheck fallback, the #4442 chunk-completeness check, and cache keying on
   the original path.
2. **`AUTO_INDEXED` is a process-global with no path association.** Still latent after this fix for
   multi-input commands (`join`, `cat`) where input A autoindexes and input B has no sibling `.idx`.
   Naming it so it isn't later mistaken for a regression from this PR.
3. **`qsv moarstats f.zip` reads the raw zip bytes** (`invalid utf-8 … near byte index 0`) — **with
   or without** an autoindex. A separate pre-existing bug; deserves its own issue.
4. **Non-polars builds never clean up zip temps** — `log_end` gates `remove_dir_all(TEMP_FILE_DIR)`
   on `#[cfg(feature = "polars")]`, but `extract_zip_to_temp` is always compiled. Also its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
