### PR TITLE
fix(moarstats): read special-format inputs through Config, not raw paths (#4460)

### DIFF
--- a/src/cmd/moarstats.rs
+++ b/src/cmd/moarstats.rs
@@ -754,9 +754,14 @@ fn join_datasets_internal(
             .collect();
         drop(joined_rdr);
 
-        let mut additional_rdr = csv::ReaderBuilder::new()
-            .has_headers(true)
-            .from_path(Path::new(additional_input))
+        // Read through `Config`, not a raw `from_path`: a special-format secondary
+        // (.gz/.zip/.parquet/...) is only decompressed on Config's read path, so a raw
+        // open would parse the compressed container and fail with "invalid utf-8 near
+        // byte index 0". Config also picks up the inner file's real delimiter (e.g. a
+        // .tsv inside a .zip). The `qsv join` subprocess above already handles these.
+        let additional_input_owned = additional_input.to_string();
+        let mut additional_rdr = Config::new(Some(&additional_input_owned))
+            .reader()
             .map_err(|e| {
                 CliError::Other(format!(
                     "Failed to open secondary input to validate header ({additional_input}): {e}"
@@ -4164,13 +4169,32 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         input_path
     };
 
+    // A special-format input (.gz/.zip/.parquet/.jsonl/...) is only decompressed when it is
+    // read through `Config`. Several passes below hand a path straight to
+    // `csv::ReaderBuilder::from_path` (and to Configs built inside worker threads), which
+    // would parse the COMPRESSED CONTAINER as CSV - erroring with "invalid utf-8 near byte
+    // index 0", or worse, silently yielding empty headers where the error is swallowed.
+    //
+    // Bind ONE Config and resolve through it. `resolved_path()` caches in that Config's
+    // `Arc<OnceLock>`, so every call returns the SAME converted temp; two throwaway
+    // `Config::new(..).resolved_path()` calls would each convert to a temp of their own.
+    // For an ordinary input this is just `path` unchanged and nothing is converted.
+    let actual_input_path_str = actual_input_path
+        .to_str()
+        .ok_or_else(|| CliError::Other("Invalid input path".to_string()))?
+        .to_string();
+    let read_conf = Config::new(Some(&actual_input_path_str));
+    let resolved_input = read_conf.resolved_path()?;
+    // The path to READ DATA from. `actual_input_path` is deliberately left alone: the
+    // `qsv stats` subprocess below must still receive the ORIGINAL path, both because
+    // `stats` does its own conversion and because the stats cache is keyed on it.
+    let read_input_path: &Path = resolved_input.as_deref().unwrap_or(actual_input_path);
+
     // Auto-create index if --advanced or --bivariate is set and index doesn't exist
     if args.flag_advanced || args.flag_bivariate {
-        let actual_input_path_str = actual_input_path
-            .to_str()
-            .ok_or_else(|| CliError::Other("Invalid input path".to_string()))?
-            .to_string();
-        let rconfig = Config::new(Some(&actual_input_path_str));
+        // index the RESOLVED path - an index beside the compressed source is useless,
+        // since the data actually read is the converted temp
+        let rconfig = read_conf.clone();
         let indexed_result = rconfig.indexed()?;
 
         if indexed_result.is_none() && !rconfig.is_stdin() {
@@ -4184,7 +4208,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                  to enable parallel processing..."
             );
 
-            match util::create_index_for_file(actual_input_path, &rconfig) {
+            match util::create_index_for_file(read_input_path, &rconfig) {
                 Ok(()) => {
                     log::info!("Index created successfully for statistics computation.");
                 },
@@ -5098,7 +5122,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let (outlier_fields, outlier_names, kga_fields, kga_names) = {
         let mut csv_rdr = ReaderBuilder::new()
             .has_headers(true)
-            .from_path(actual_input_path)?;
+            .from_path(read_input_path)?;
         let csv_headers = csv_rdr.headers()?.clone();
         // First occurrence wins for duplicate header names, matching the prior
         // `csv_headers.iter().position(|h| h == field_name)` (first-match) semantics
@@ -5141,7 +5165,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             outlier_names,
             kga_fields,
             kga_names,
-            actual_input_path,
+            read_input_path,
             args.flag_jobs,
             args.flag_epsilon,
         )?
@@ -5149,7 +5173,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
     // Compute Shannon Entropy for all fields
     let entropy_stats = if new_column_indices.contains_key("shannon_entropy") {
-        compute_all_entropy(actual_input_path)?
+        compute_all_entropy(read_input_path)?
     } else {
         HashMap::new()
     };
@@ -5164,11 +5188,8 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
         // Get record count to check for all-unique fields (cardinality == rowcount)
         let record_count: Option<u64> = {
-            let actual_input_path_str = actual_input_path
-                .to_str()
-                .ok_or_else(|| CliError::Other("Invalid input path".to_string()))?
-                .to_string();
-            let rconfig = Config::new(Some(&actual_input_path_str));
+            // the resolved Config, so the count is of the DATA, not the compressed container
+            let rconfig = read_conf.clone();
             if let Ok(Some(idx)) = rconfig.indexed() {
                 Some(idx.count())
             } else if !rconfig.is_stdin() {
@@ -5198,7 +5219,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         let read_csv_headers = || -> CliResult<StringRecord> {
             let mut csv_rdr = ReaderBuilder::new()
                 .has_headers(true)
-                .from_path(actual_input_path)?;
+                .from_path(read_input_path)?;
             Ok(csv_rdr.headers()?.clone())
         };
 
@@ -5213,7 +5234,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             // than silently dropping bivariate pairs (lines below `continue`
             // on a header miss) and emitting "primary-only" join-corrupt
             // output.
-            util::sync_subprocess_output(actual_input_path)?;
+            util::sync_subprocess_output(read_input_path)?;
             let missing_cols = |hdrs: &StringRecord| -> Vec<String> {
                 let header_set: std::collections::HashSet<&str> = hdrs.iter().collect();
                 stats_field_names
@@ -5229,7 +5250,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                     "Joined CSV header missing columns {missing:?} present in the stats output; \
                      re-syncing joined CSV and re-reading its header once"
                 );
-                util::sync_subprocess_output(actual_input_path)?;
+                util::sync_subprocess_output(read_input_path)?;
                 headers = read_csv_headers()?;
                 missing = missing_cols(&headers);
                 if !missing.is_empty() {
@@ -5525,7 +5546,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             // earlier revision opened input_path twice.
             let primary_headers: Vec<String> = csv::ReaderBuilder::new()
                 .has_headers(true)
-                .from_path(input_path)
+                .from_path(read_input_path)
                 .ok()
                 .and_then(|mut r| r.headers().ok().cloned())
                 .map(|h| h.iter().map(std::string::ToString::to_string).collect())
@@ -5676,10 +5697,10 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                 .unwrap_or_default();
             let mut pairable_secondary_only: Vec<(String, String, usize)> = Vec::new();
             for add_path in &additional_inputs_for_guard {
-                let Ok(mut add_rdr) = csv::ReaderBuilder::new()
-                    .has_headers(true)
-                    .from_path(add_path)
-                else {
+                // via `Config` so a special-format secondary is decompressed first; a raw
+                // open would fail here and be SWALLOWED by the `else { continue }`,
+                // silently dropping that input's pairable columns from the guard.
+                let Ok(mut add_rdr) = Config::new(Some(add_path)).reader() else {
                     continue;
                 };
                 let Ok(add_hdrs) = add_rdr.headers() else {
@@ -5735,11 +5756,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             HashMap::new()
         } else {
             // Setup progress bar if requested and not reading from stdin
-            let actual_input_path_str = actual_input_path
-                .to_str()
-                .ok_or_else(|| CliError::Other("Invalid input path".to_string()))?
-                .to_string();
-            let rconfig_bivariate = Config::new(Some(&actual_input_path_str));
+            let rconfig_bivariate = read_conf.clone();
             let show_progress = (args.flag_progressbar || util::get_envvar_flag("QSV_PROGRESSBAR"))
                 && !rconfig_bivariate.is_stdin();
             let progress = if show_progress {
@@ -5789,7 +5806,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             let result = compute_all_bivariatestats(
                 field_pairs,
                 &field_names,
-                actual_input_path,
+                read_input_path,
                 progress.as_ref(),
                 cardinality_threshold,
                 stats_config,

--- a/tests/test_moarstats.rs
+++ b/tests/test_moarstats.rs
@@ -6780,3 +6780,105 @@ fn moarstats_pct_thresholds_collapsing_to_one_percentile_errors() {
         .args(["--pct-thresholds", "33.3,33.6"]);
     wrk.assert_err(&mut cmd);
 }
+
+// issue #4460: a special-format input (.gz/.zip/.parquet/...) is only decompressed when it
+// is read through `Config`. Several moarstats passes handed the ORIGINAL path straight to
+// `csv::ReaderBuilder::from_path`, so a `.zip` was parsed as the compressed container:
+// `csv error: ... invalid utf-8: invalid UTF-8 in field 0 near byte index 0`. Where the
+// error was swallowed (`.ok()` / `else { continue }`) it silently yielded empty headers
+// instead. The input is now resolved once through a bound `Config` and every data read uses
+// that resolved path.
+//
+// The two inputs deliberately produce DIFFERENT sidecar names - `boston311-100.csv.zip`
+// yields `boston311-100.csv.stats.csv` while `boston311-100.csv` yields
+// `boston311-100.stats.csv` - so both runs can share one Workdir without clobbering each
+// other's baseline stats.
+#[test]
+fn moarstats_from_zip_matches_uncompressed() {
+    let wrk = Workdir::new("moarstats_from_zip_matches_uncompressed");
+    let zip_file = wrk.load_test_file("boston311-100.csv.zip");
+    let csv_file = wrk.load_test_file("boston311-100.csv");
+
+    for input in [&zip_file, &csv_file] {
+        let mut cmd = wrk.command("moarstats");
+        cmd.arg(input);
+        wrk.assert_success(&mut cmd);
+    }
+
+    let from_zip = wrk.read_to_string("boston311-100.csv.stats.csv").unwrap();
+    let from_csv = wrk.read_to_string("boston311-100.stats.csv").unwrap();
+
+    assert!(
+        from_zip.lines().count() > 1,
+        "moarstats over a .zip input produced no data rows"
+    );
+    assert_eq!(
+        from_zip, from_csv,
+        "moarstats over a .zip input must equal moarstats over the same data uncompressed"
+    );
+}
+
+// issue #4460, the --bivariate branch: it reaches sites the bare command does not - the
+// auto-created index (which must be built beside the RESOLVED temp, not the .zip), the
+// record-count probe, and the primary-header read whose error was swallowed into an empty
+// header vector.
+#[test]
+fn moarstats_bivariate_from_zip_matches_uncompressed() {
+    let wrk = Workdir::new("moarstats_bivariate_from_zip_matches_uncompressed");
+    let zip_file = wrk.load_test_file("boston311-100.csv.zip");
+    let csv_file = wrk.load_test_file("boston311-100.csv");
+
+    for input in [&zip_file, &csv_file] {
+        let mut cmd = wrk.command("moarstats");
+        cmd.arg("--bivariate").arg(input);
+        wrk.assert_success(&mut cmd);
+    }
+
+    let from_zip = wrk
+        .read_to_string("boston311-100.csv.stats.bivariate.csv")
+        .unwrap();
+    let from_csv = wrk
+        .read_to_string("boston311-100.stats.bivariate.csv")
+        .unwrap();
+
+    // real field pairs, not just a header - an empty-header read would produce none
+    assert!(
+        from_zip.lines().count() > 1,
+        "bivariate stats over a .zip input produced no field pairs"
+    );
+    assert_eq!(
+        from_zip, from_csv,
+        "bivariate stats for a .zip input must equal the same data uncompressed"
+    );
+}
+
+// issue #4460, the --join-inputs branch: the `qsv join` subprocess handles a compressed
+// secondary fine, but moarstats then re-opened that secondary RAW to validate the joined
+// header and died with "Failed to read secondary header: ... invalid utf-8".
+#[test]
+fn moarstats_join_inputs_from_zip_secondary() {
+    use std::io::Write;
+
+    let wrk = Workdir::new("moarstats_join_inputs_from_zip_secondary");
+
+    wrk.create_from_string("a.csv", "id,x\n1,10\n2,20\n3,30\n4,40\n5,50\n");
+    let secondary = "id,y\n1,7\n2,8\n3,9\n4,11\n5,13\n";
+    wrk.create_from_string("b.csv", secondary);
+
+    let zip_path = wrk.path("b.zip");
+    let zf = std::fs::File::create(&zip_path).unwrap();
+    let mut zw = zip::ZipWriter::new(zf);
+    zw.start_file("b.csv", zip::write::SimpleFileOptions::default())
+        .unwrap();
+    zw.write_all(secondary.as_bytes()).unwrap();
+    zw.finish().unwrap();
+
+    // a compressed secondary must be accepted exactly like the plain one
+    for secondary_input in ["b.csv", "b.zip"] {
+        let mut cmd = wrk.command("moarstats");
+        cmd.args(["--join-inputs", secondary_input])
+            .args(["--join-keys", "id,id"])
+            .arg("a.csv");
+        wrk.assert_success(&mut cmd);
+    }
+}


### PR DESCRIPTION
Fixes #4460.

## The bug

```console
$ qsv moarstats f.zip
Ran stats command to generate baseline stats... (elapsed: 0.19s)
csv error: CSV parse error: record 0 (line 1, field: 0, byte: 0): invalid utf-8: invalid UTF-8 in field 0 near byte index 0
```

A special-format input (`.gz`/`.zip`/`.parquet`/`.jsonl`/…) is only decompressed when read through
`Config`'s read entry points. Several `moarstats` passes handed the **original** path straight to
`csv::ReaderBuilder::from_path`, parsing the compressed container as CSV. The baseline `stats`
subprocess succeeds (it converts internally), which is why the failure surfaces only afterwards.

**Where the error was swallowed, the outcome was worse than a hard failure.** The primary-header
read used `.ok()…unwrap_or_default()` and the `--join-inputs` guard used `let Ok(..) else
{ continue }` — so a compressed input silently produced **empty headers** and quietly dropped that
input's pairable columns.

Four affected paths, all reproduced and all now fixed:

| invocation | before |
|---|---|
| `qsv moarstats f.zip` | exit 1, invalid utf-8 |
| `qsv moarstats --advanced f.zip` | exit 1 |
| `qsv moarstats --bivariate f.zip` | exit 1 |
| `qsv moarstats --join-inputs b.zip --join-keys id,id a.csv` | exit 1, "Failed to read secondary header" |

## The fix

Resolve the input **once** through a bound `Config` (`read_conf`) and use `read_input_path` for
every data read.

Binding the `Config` matters rather than calling `Config::new(..).resolved_path()` ad hoc:
`resolved_path()` caches in that Config's `Arc<OnceLock>`, so repeat calls return the **same** temp.
Two throwaway Configs would each convert to a temp of their own — the #4446 divergence,
reintroduced inside a single function.

`actual_input_path` is deliberately **not** repointed: the `qsv stats` subprocess must still receive
the original path, both because `stats` converts it itself and because the stats cache is keyed on
it.

Sites were enumerated **by variable**, not just by `actual_input_path` — the primary-header read
keys on `input_path` and the join guard on `add_path`, and both were affected. The two
secondary-input header reads now use `Config::reader()` directly instead of resolving a path and
re-opening: they're header-only reads, and `Config` also picks up the inner file's real delimiter
(e.g. a `.tsv` inside a `.zip`).

### Two things that fall out

- **The #4446 defect class in `moarstats` goes away.** `compute_outliers_and_kga` and
  `compute_all_bivariatestats` build a `Config` per worker from their `input_path` parameter. Handed
  the resolved temp, every worker sees an ordinary CSV and they all agree on one path. Verified that
  `input_path_string` in both derives solely from that parameter.
- **`--advanced`/`--bivariate` now index the resolved temp.** An index beside the compressed source
  could never be used by the reader. That temp is process-lifetime, so such a run re-indexes each
  time — the same trade `frequency` makes.

## Tests

Three tests, one per distinct code path (bare, `--bivariate`, `--join-inputs`), asserting **output
equality against the same data uncompressed** — including 352 rows of real bivariate field pairs, so
an empty-header regression would be caught.

All three **fail against the reverted `src/`**; the other 92 `moarstats` tests pass either way. Full
suite green (988 unit + 3743 integration), clippy clean, `cargo +nightly fmt`.

The two inputs deliberately produce different sidecar names (`boston311-100.csv.stats.csv` vs
`boston311-100.stats.csv`) so both runs share one `Workdir` without clobbering each other's baseline.

## Out of scope — filed separately as #4463

`QSV_AUTOINDEX_SIZE=1 qsv stats --infer-dates f.zip` fails independently of this change:
`--infer-dates` routes through `sniff`, which resolves its **own** temp and autoindexes it, setting
the process-global `AUTO_INDEXED`; `stats` then resolves a second temp whose sibling `.idx` doesn't
exist. Since `moarstats`' default `--stats-options` includes `--infer-dates`, that bug also breaks
`moarstats` on compressed input **when `QSV_AUTOINDEX_SIZE` is set** — but the defect and its fix
belong in `stats`/`Config`, not here.

Worth flagging: #4459's PR body described that `AUTO_INDEXED` hazard as latent-but-unreachable,
reasoning that no multi-input command calls `indexed()`. That reasoning was incomplete — the real
trigger is one command resolving one input through two `Config`s in a single process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
