### PR TITLE
fix: remove the AUTO_INDEXED global fast path from Config::index_files (#4463)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -778,9 +778,10 @@ impl Config {
     /// Check if the index file exists and is newer than the CSV file.
     /// If so, return the CSV file handle and the index file handle. If not, return None.
     /// Unless the CSV's file size >= `QSV_AUTOINDEX_SIZE`, then we'll create an index
-    /// automatically. Stale indices (CSV newer than index) are rebuilt automatically, but only
-    /// on the `(Some(path), None)` branch that resolves the index path internally; the
-    /// `auto_indexed` and explicit-`(path, idx_path)` branches skip the staleness recheck.
+    /// automatically. Stale indices (CSV newer than index) are rebuilt automatically on the
+    /// `(Some(path), None)` branch that resolves the index path internally; only the
+    /// explicit-`(path, idx_path)` branch skips the staleness recheck, since the caller
+    /// supplied both paths and is trusted.
     pub fn index_files(&self) -> io::Result<Option<(csv::Reader<fs::File>, fs::File)>> {
         if self.special_format != SpecialFormat::Unknown {
             return self.prepared_for_read()?.index_files();

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,10 +2,7 @@ use std::{
     env, fs,
     io::{self, Read},
     path::{Path, PathBuf},
-    sync::{
-        Arc, OnceLock,
-        atomic::{AtomicBool, Ordering},
-    },
+    sync::{Arc, OnceLock},
 };
 
 use csv_nose::{SampleSize, Sniffer};
@@ -29,9 +26,6 @@ const DEFAULT_SNIFFER_SAMPLE: usize = 100;
 
 // file size at which we warn user that a large file has not been indexed
 const NO_INDEX_WARNING_FILESIZE: u64 = 100 * (1 << 20); // 100MB
-
-// so we don't have to keep checking if the index has been created
-static AUTO_INDEXED: AtomicBool = AtomicBool::new(false);
 
 pub static SPONSOR_MESSAGE: &str = r"sponsored by datHere - Data Infrastructure Engineering (https://qsv.datHere.com)
 Need a UI & more advanced data-wrangling? Upgrade to qsv pro (https://qsvpro.datHere.com)
@@ -748,7 +742,8 @@ impl Config {
     /// - If `self.path` is `None`, the function returns without action.
     /// - The function creates an index file using `util::idx_path()` to determine index file path.
     /// - It uses `csv_index::RandomAccessSimple::create()` to generate the index.
-    /// - If index creation is successful, it sets the `AUTO_INDEXED` atomic flag to `true`.
+    /// - Success is only logged; no process-global state is set. A subsequent `index_files()`
+    ///   discovers the new index by looking for it beside `self.path`, like any other index.
     ///
     /// # Errors
     ///
@@ -775,7 +770,6 @@ impl Config {
                     return;
                 };
                 debug!("autoindex of {} successful.", path_buf.display());
-                AUTO_INDEXED.store(true, Ordering::Relaxed);
             },
             Err(e) => debug!("autoindex of {} failed: {e}", path_buf.display()),
         }
@@ -792,77 +786,75 @@ impl Config {
             return self.prepared_for_read()?.index_files();
         }
         // Track the data file's mtime and the resolved index path *only* on the
-        // path that may need a staleness recheck. For the auto_indexed and
-        // explicit-(path, idx_path) branches, staleness is not re-checked, so
-        // these stay at their default values.
+        // path that may need a staleness recheck. For the explicit-(path, idx_path)
+        // branch, staleness is not re-checked, so these stay at their default values.
         let mut data_modified = 0_u64;
         let data_fsize;
         let mut idx_path_work: Option<PathBuf> = None;
 
-        // the auto_indexed flag is set when an index is created automatically with
-        // autoindex_file(). We use this flag to avoid checking if the index exists every
-        // time this function is called. If the index was already auto-indexed, we can just
-        // use it & return immediately.
-        let auto_indexed = AUTO_INDEXED.load(Ordering::Relaxed);
+        // NOTE: there was once an `AUTO_INDEXED` global fast path here, skipping the
+        // existence check whenever ANY file had been autoindexed in this process. It was
+        // unsound: the flag carried no path, so it also fired for a DIFFERENT input, whose
+        // sibling `.idx` then did not exist - and its `fs::File::open` was unconditional, so
+        // the result was a hard ENOENT instead of a graceful "no index" (issue #4463).
+        //
+        // It bit whenever one command resolved one input through two `Config`s - each
+        // converting a special-format input to its OWN temp - which is exactly what
+        // `stats --infer-dates` does via `sniff`. The branch below already handles both
+        // "index present" and "index absent" correctly, and unlike the fast path it performs
+        // the staleness recheck. It costs two `metadata()` calls per `indexed()`, which
+        // happens at setup and once per parallel worker - never per record.
+        let (csv_file, mut idx_file) = match (&self.path, &self.idx_path) {
+            (&None, &None) => return Ok(None),
+            (&None, &Some(_)) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "Cannot use <stdin> with indexes",
+                ));
+            },
+            // When the caller supplies both paths explicitly, trust them and skip
+            // the staleness recheck below (idx_path_work stays None).
+            (Some(p), Some(ip)) => (fs::File::open(p)?, fs::File::open(ip)?),
+            (Some(p), &None) => {
+                // We generally don't want to report an error here, since we're
+                // passively trying to find an index.
 
-        let (csv_file, mut idx_file) = if auto_indexed {
-            (
-                fs::File::open(self.path.clone().unwrap())?,
-                fs::File::open(util::idx_path(&self.path.clone().unwrap()))?,
-            )
-        } else {
-            match (&self.path, &self.idx_path) {
-                (&None, &None) => return Ok(None),
-                (&None, &Some(_)) => {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "Cannot use <stdin> with indexes",
-                    ));
-                },
-                // When the caller supplies both paths explicitly, trust them and skip
-                // the staleness recheck below (idx_path_work stays None).
-                (Some(p), Some(ip)) => (fs::File::open(p)?, fs::File::open(ip)?),
-                (Some(p), &None) => {
-                    // We generally don't want to report an error here, since we're
-                    // passively trying to find an index.
+                (data_modified, data_fsize) = util::file_metadata(&p.metadata()?);
+                let idx_path = util::idx_path(p);
+                let idx_file = match fs::File::open(&idx_path) {
+                    Err(_) => {
+                        // the index file doesn't exist
+                        if self.snappy {
+                            // cannot index snappy compressed files
+                            return Ok(None);
+                        } else if self.autoindex_size > 0 && data_fsize >= self.autoindex_size {
+                            // if CSV file size >= QSV_AUTOINDEX_SIZE, and
+                            // its not a snappy file, create an index automatically
+                            self.autoindex_file();
+                            fs::File::open(&idx_path)?
+                        } else if data_fsize >= NO_INDEX_WARNING_FILESIZE {
+                            // warn user that the CSV file is large and not indexed
+                            use indicatif::HumanBytes;
 
-                    (data_modified, data_fsize) = util::file_metadata(&p.metadata()?);
-                    let idx_path = util::idx_path(p);
-                    let idx_file = match fs::File::open(&idx_path) {
-                        Err(_) => {
-                            // the index file doesn't exist
-                            if self.snappy {
-                                // cannot index snappy compressed files
-                                return Ok(None);
-                            } else if self.autoindex_size > 0 && data_fsize >= self.autoindex_size {
-                                // if CSV file size >= QSV_AUTOINDEX_SIZE, and
-                                // its not a snappy file, create an index automatically
-                                self.autoindex_file();
-                                fs::File::open(&idx_path)?
-                            } else if data_fsize >= NO_INDEX_WARNING_FILESIZE {
-                                // warn user that the CSV file is large and not indexed
-                                use indicatif::HumanBytes;
-
-                                warn!(
-                                    "The {} CSV file is larger than the {} \
-                                     NO_INDEX_WARNING_FILESIZE threshold. Consider creating an \
-                                     index file as it will make qsv commands much faster.",
-                                    HumanBytes(data_fsize),
-                                    HumanBytes(NO_INDEX_WARNING_FILESIZE)
-                                );
-                                return Ok(None);
-                            } else {
-                                // CSV not greater than QSV_AUTOINDEX_SIZE, and not greater than
-                                // NO_INDEX_WARNING_FILESIZE, so we don't create an index
-                                return Ok(None);
-                            }
-                        },
-                        Ok(f) => f,
-                    };
-                    idx_path_work = Some(idx_path);
-                    (fs::File::open(p)?, idx_file)
-                },
-            }
+                            warn!(
+                                "The {} CSV file is larger than the {} NO_INDEX_WARNING_FILESIZE \
+                                 threshold. Consider creating an index file as it will make qsv \
+                                 commands much faster.",
+                                HumanBytes(data_fsize),
+                                HumanBytes(NO_INDEX_WARNING_FILESIZE)
+                            );
+                            return Ok(None);
+                        } else {
+                            // CSV not greater than QSV_AUTOINDEX_SIZE, and not greater than
+                            // NO_INDEX_WARNING_FILESIZE, so we don't create an index
+                            return Ok(None);
+                        }
+                    },
+                    Ok(f) => f,
+                };
+                idx_path_work = Some(idx_path);
+                (fs::File::open(p)?, idx_file)
+            },
         };
         // If the CSV data was last modified after the index file was last
         // modified, recreate the stale index automatically. Only checked when

--- a/tests/test_stats.rs
+++ b/tests/test_stats.rs
@@ -9083,3 +9083,77 @@ fn stats_trailing_blank_line_denominator() {
         );
     }
 }
+
+// issue #4463: `Config::index_files` had an `AUTO_INDEXED` global fast path that skipped the
+// index-existence check whenever ANY file had been autoindexed in this process. The flag
+// carried no path, so it also fired for a DIFFERENT input whose sibling `.idx` did not exist -
+// and its `fs::File::open` was unconditional, so the result was a hard ENOENT rather than a
+// graceful "no index".
+//
+// `stats --infer-dates` is the reachable trigger: with the default `--dates-whitelist sniff`
+// it calls `sniff`, which builds its OWN Config. For a special-format input that Config
+// resolves its own converted temp and autoindexes it, setting the flag; `stats` then resolves
+// a SECOND temp whose sibling `.idx` does not exist, and the run died with
+// "io error: No such file or directory (os error 2)" at exit 1.
+//
+// `--jobs 1` on both sides: `stats` keeps its #4445 guard, so the .zip stays sequential while
+// an ordinary CSV autoindexes and goes parallel, and merging chunk variances is not bit-identical
+// to a single pass. That last-ulp difference is a pre-existing property of the parallel path,
+// not what this test is about.
+#[test]
+fn stats_infer_dates_autoindex_does_not_leak_across_configs() {
+    use std::io::Write;
+
+    let wrk = Workdir::new("stats_infer_dates_autoindex_leak");
+
+    let mut plain = String::from("id,d,val\n");
+    for i in 0..400 {
+        plain.push_str(&format!(
+            "{i},2020-{:02}-{:02},{}\n",
+            (i % 12) + 1,
+            (i % 28) + 1,
+            (i * 7) % 500 + 1
+        ));
+    }
+    wrk.create_from_string("s.csv", &plain);
+
+    let zip_path = wrk.path("s.zip");
+    let zf = std::fs::File::create(&zip_path).unwrap();
+    let mut zw = zip::ZipWriter::new(zf);
+    zw.start_file("s.csv", zip::write::SimpleFileOptions::default())
+        .unwrap();
+    zw.write_all(plain.as_bytes()).unwrap();
+    zw.finish().unwrap();
+
+    // QSV_AUTOINDEX_SIZE=1 makes sniff's own Config autoindex its temp, which is what set the
+    // global flag. Without it the bug does not fire at all.
+    let stats_of = |input: &str, out: &str| -> String {
+        let mut cmd = wrk.command("stats");
+        cmd.env("QSV_AUTOINDEX_SIZE", "1")
+            .arg("--infer-dates")
+            .args(["--jobs", "1"])
+            .args(["--output", wrk.path(out).to_str().unwrap()])
+            .arg(input);
+        wrk.assert_success(&mut cmd);
+        std::fs::read_to_string(wrk.path(out)).unwrap()
+    };
+
+    let zip_stats = stats_of("s.zip", "zip.csv");
+    assert!(
+        zip_stats.lines().count() > 1,
+        "stats over a .zip produced no data rows"
+    );
+
+    // the date column must actually be inferred, otherwise the sniff pass this test depends on
+    // is not doing anything
+    assert!(
+        zip_stats.lines().any(|l| l.starts_with("d,Date,")),
+        "expected the `d` column to be inferred as Date; got:\n{zip_stats}"
+    );
+
+    let plain_stats = stats_of("s.csv", "plain.csv");
+    assert_eq!(
+        zip_stats, plain_stats,
+        "stats --infer-dates for a .zip input must equal the same data uncompressed"
+    );
+}


### PR DESCRIPTION
Fixes #4463.

## The bug

```console
$ QSV_AUTOINDEX_SIZE=1 qsv stats --infer-dates f.zip
io error: No such file or directory (os error 2)      # exit 1
```

`Config::index_files` had a fast path keyed on a process-global `AUTO_INDEXED: AtomicBool`, set
whenever **any** file was autoindexed. The flag carried no path, so it also fired for a *different*
input — and its `fs::File::open(idx_path(self.path))` was unconditional, so a missing sibling index
became a hard ENOENT instead of a graceful `Ok(None)` and a sequential read.

**The reachable trigger is one command resolving one input through two `Config`s.** Each converts a
special-format input to its own temp (separate `Arc<OnceLock>`s), so an index built beside the first
is invisible beside the second. `stats --infer-dates` does exactly that: with the default
`--dates-whitelist sniff` it calls `sniff`, which builds its own `Config`, resolves its own temp, and
autoindexes it:

```
Resolving dates-whitelist 'sniff' for f.zip
autoindex of /var/.../.tmp6UEwwe/.tmp2KRsJs.csv successful.
sniff: no Date/DateTime columns found
io error: No such file or directory (os error 2)
```

`--infer-dates` was the **only** trigger among the whole default flag set (bisected). And because
`moarstats` passes `--infer-dates` in its default `--stats-options` and shells out to `stats`, this
took `moarstats` down on compressed input too — so it partly undercut #4464.

## The fix

The fast path is **deleted outright** rather than made path-aware. The normal `(Some(p), None)`
branch already handles both "index present" and "index absent", and — unlike the fast path — it
performs the staleness recheck, so removing it also *restores* that check for autoindexed files.
`AUTO_INDEXED` had exactly two uses and is now gone, so no global state remains to leak across paths.

Cost was measured, not assumed: the fast path saved two `metadata()` calls per `indexed()`, which
happens at setup and once per parallel worker — never per record. `util::file_metadata` compares
whole seconds, so a file and its freshly-written index don't spuriously compare stale.

**The `config.rs` diff looks larger than it is:** `git diff --ignore-all-space` reduces it to
**21/-29**. The rest is re-indentation from unwrapping `if auto_indexed { .. } else { match .. }`
into a plain match.

## Tests

`stats_infer_dates_autoindex_does_not_leak_across_configs`, verified to fail against the reverted
`src/`.

Two deliberate choices in it:

- **`--jobs 1` on both sides.** `stats` keeps its #4445 guard, so a `.zip` stays sequential while an
  ordinary CSV autoindexes and goes parallel — and merging chunk variances isn't bit-identical to a
  single pass. That last-ulp `variance` difference is a pre-existing property of the parallel path,
  not something this change introduces. At `--jobs 1` the two match exactly.
- **Asserts the `d` column is actually inferred as `Date`.** A fixture where `sniff` finds nothing
  wouldn't exercise the pass this test is about.

Full suite green (988 unit + 3746 integration), all index/autoindex tests pass, `-F lite` and
`-F datapusher_plus` compile.

The second commit is doc-only: the `index_files()` doc comment still listed `auto_indexed` as a
branch that skips the staleness recheck. `src/`, `tests/` and `docs/` were swept for other stale
references — the only remaining mentions are two deliberate historical notes.

## Note on scope

This does **not** touch `stats`' own `is_special_format()` guards from #4445, so a compressed input
still processes sequentially in `stats`. Re-parallelizing it is #4462.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
