### PR TITLE
fix: unbreak master — stale-index rebuilds are serialized, atomic, and permission-preserving

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -267,31 +267,23 @@ impl Config {
             Some(s) => {
                 let path = PathBuf::from(s);
 
-                // if QSV_SKIP_FORMAT_CHECK is set or path is a temp file, we skip format check
-                let temp_dir = crate::config::TEMP_FILE_DIR.get_or_init(|| {
-                    tempfile::TempDir::new().map_or_else(
-                        |e| {
-                            // Fall back to a qsv-OWNED subdirectory of the system temp dir -
-                            // NEVER `env::temp_dir()` itself. `util::log_end` removes
-                            // `TEMP_FILE_DIR` wholesale at exit, so storing the system temp
-                            // root here would delete every other process's temp files too.
-                            // This is the only init site that can produce a directory qsv did
-                            // not create; the others `unwrap()` a `TempDir`.
-                            let fallback =
-                                env::temp_dir().join(format!("qsv-{}", std::process::id()));
-                            warn!(
-                                "failed to create temp dir: {e}; falling back to {}",
-                                fallback.display()
-                            );
-                            fs::create_dir_all(&fallback).unwrap_or_default();
-                            fallback
-                        },
-                        tempfile::TempDir::keep,
-                    )
-                });
+                // if QSV_SKIP_FORMAT_CHECK is set or path is a temp file, we skip format check.
+                //
+                // `get()`, NOT `get_or_init()`. The temp dir is only ever READ here, to answer
+                // a path comparison - yet initializing eagerly meant every `Config::new`
+                // CREATED a temp directory just to ask that question, and needed a fallback
+                // when creation failed. That fallback is what could put a directory qsv does
+                // not own into `TEMP_FILE_DIR`, which `util::log_end` then deletes wholesale
+                // (roborev 4366, 4367). There is no fallback to get wrong now.
+                //
+                // Behavior is unchanged: if this process has not created a temp dir yet, no
+                // path can be inside one. Previously `get_or_init` would mint a FRESH
+                // randomly-named dir here, which `starts_with` could never match either.
                 skip_format_check = sniff
                     || util::get_envvar_flag("QSV_SKIP_FORMAT_CHECK")
-                    || path.starts_with(temp_dir);
+                    || crate::config::TEMP_FILE_DIR
+                        .get()
+                        .is_some_and(|temp_dir| path.starts_with(temp_dir));
 
                 // Detect special formats. The actual conversion to a delimited temp
                 // file is DEFERRED to the read path (see `prepared_for_read`), so a

--- a/src/config.rs
+++ b/src/config.rs
@@ -788,49 +788,86 @@ impl Config {
         // partial index behind, and a concurrent reader can open one mid-write. `rename` on
         // the same directory is atomic: readers see either the old complete index or the new
         // one, never a torn file.
-        // `tempfile` picks a UNIQUE name and creates it exclusively (O_EXCL), so two
-        // concurrent builds - which the `autoindex_size` path below does not serialize -
-        // cannot land on the same file, and a pre-existing file or symlink at a guessable
-        // name cannot be written through. A deterministic `<idx>.tmp<pid>` had both problems:
-        // same-process builds share a pid.
+        // Build into a UNIQUE sibling temp, then rename into place. `create_new` is
+        // O_CREAT|O_EXCL, so two concurrent builds - which the `autoindex_size` path below
+        // does NOT serialize - cannot land on the same file, and a pre-existing file or
+        // symlink at a guessable name cannot be written through. A deterministic
+        // `<idx>.tmp<pid>` had both problems, since same-process builds share a pid.
+        //
+        // `create_new` rather than `tempfile`: it applies the process umask exactly like the
+        // `fs::File::create` that `qsv index` uses, whereas `tempfile` creates 0600 and would
+        // carry that onto the `.idx` through the rename - silently turning auto-created and
+        // rebuilt indexes into owner-only files (roborev 4371).
         let idx_dir = pidx.parent().unwrap_or_else(|| Path::new("."));
-        let Ok(mut tmp) = tempfile::Builder::new()
-            .prefix(".qsv-idx")
-            .tempfile_in(idx_dir)
-        else {
+        // Uniqueness does not need randomness here: `create_new` fails with AlreadyExists,
+        // so the loop simply advances the counter until it wins. pid separates processes, the
+        // counter separates threads and repeat calls within one.
+        static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+        let pid = std::process::id();
+        let mut tmp_path = None;
+        let mut tmp_file = None;
+        for _ in 0..16 {
+            let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            let candidate = idx_dir.join(format!(".qsv-autoindex-{pid}-{seq}.tmp"));
+            if let Ok(f) = fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&candidate)
+            {
+                tmp_path = Some(candidate);
+                tmp_file = Some(f);
+                break;
+            }
+        }
+        let (Some(tmp_path), Some(idxfile)) = (tmp_path, tmp_file) else {
+            debug!(
+                "autoindex of {}: could not create a temp index file",
+                path_buf.display()
+            );
             return false;
         };
+
+        // any early return from here on must not leave the temp behind
+        let cleanup = |tmp: &Path| {
+            let _ = fs::remove_file(tmp);
+        };
+
         let Ok(mut rdr) = self.reader_file() else {
-            // `tmp` removes itself on drop
+            cleanup(&tmp_path);
             return false;
         };
 
         let build = {
-            let mut wtr =
-                io::BufWriter::with_capacity(DEFAULT_WTR_BUFFER_CAPACITY, tmp.as_file_mut());
+            let mut wtr = io::BufWriter::with_capacity(DEFAULT_WTR_BUFFER_CAPACITY, idxfile);
             csv_index::RandomAccessSimple::create(&mut rdr, &mut wtr)
                 .and_then(|()| io::Write::flush(&mut wtr).map_err(Into::into))
         };
         if let Err(e) = build {
+            cleanup(&tmp_path);
             debug!("autoindex of {} failed: {e}", path_buf.display());
             return false;
         }
 
-        // persist() renames into place, which is atomic on the same filesystem: readers see
-        // either the old complete index or the new one, never a torn file
-        match tmp.persist(&pidx) {
-            Ok(_) => {
-                debug!("autoindex of {} successful.", path_buf.display());
-                true
-            },
-            Err(e) => {
-                debug!(
-                    "autoindex of {} could not be put in place: {e}",
-                    path_buf.display()
-                );
-                false
-            },
+        // On a REBUILD, carry over the existing index's permissions, so an index someone
+        // deliberately chmod'd keeps that mode instead of reverting to the umask default.
+        #[cfg(unix)]
+        if let Ok(existing) = fs::metadata(&pidx) {
+            let _ = fs::set_permissions(&tmp_path, existing.permissions());
         }
+
+        // rename is atomic on the same filesystem: readers see either the old complete index
+        // or the new one, never a torn file
+        if let Err(e) = fs::rename(&tmp_path, &pidx) {
+            cleanup(&tmp_path);
+            debug!(
+                "autoindex of {} could not be put in place: {e}",
+                path_buf.display()
+            );
+            return false;
+        }
+        debug!("autoindex of {} successful.", path_buf.display());
+        true
     }
 
     /// Check if the index file exists and is newer than the CSV file.
@@ -1522,6 +1559,75 @@ mod tests {
         assert_ne!(
             after, marker,
             "a failed rebuild poisoned the memo: the retry skipped the repair"
+        );
+    }
+
+    /// An auto-created index must get the same permissions as one built by `qsv index`, and a
+    /// REBUILD must preserve whatever mode the existing index had.
+    ///
+    /// `qsv index` uses `fs::File::create`, which applies the process umask. Building the
+    /// index through `tempfile` instead created it 0600 and carried that onto the `.idx` via
+    /// the rename - silently turning auto-created and rebuilt indexes owner-only and breaking
+    /// group/shared-readable workflows. roborev 4371.
+    ///
+    /// The expected mode is taken from a probe file created the same way `qsv index` does,
+    /// rather than hardcoding 0644, so this holds under any umask.
+    #[cfg(unix)]
+    #[test]
+    fn autoindex_permissions_match_a_normally_created_file() {
+        use std::{io::Write, os::unix::fs::PermissionsExt};
+
+        let dir = tempfile::tempdir().unwrap();
+        let csv_path = dir.path().join("perm.csv");
+
+        let mut f = std::fs::File::create(&csv_path).unwrap();
+        writeln!(f, "a,b").unwrap();
+        for i in 0..2_000 {
+            writeln!(f, "{i},{}", i * 2).unwrap();
+        }
+        f.sync_all().unwrap();
+        drop(f);
+
+        // what the umask yields for a plainly-created file - what `qsv index` would produce
+        let probe_path = dir.path().join("probe");
+        std::fs::File::create(&probe_path).unwrap();
+        let expected = std::fs::metadata(&probe_path).unwrap().permissions().mode() & 0o777;
+
+        let path_str = csv_path.to_string_lossy().to_string();
+        let mut config = Config::new(Some(&path_str));
+        config.autoindex_size = 100;
+        assert!(
+            config.indexed().unwrap().is_some(),
+            "the fixture should have been autoindexed"
+        );
+
+        let idx_path = crate::util::idx_path(&csv_path);
+        let actual = std::fs::metadata(&idx_path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            actual, expected,
+            "an auto-created index must have the same permissions as a normally created file (got \
+             {actual:o}, expected {expected:o})"
+        );
+
+        // a REBUILD must not revert a deliberately-set mode
+        let restrictive = 0o640;
+        std::fs::set_permissions(&idx_path, std::fs::Permissions::from_mode(restrictive)).unwrap();
+        let future = filetime::FileTime::from_unix_time(
+            filetime::FileTime::from_last_modification_time(&std::fs::metadata(&csv_path).unwrap())
+                .unix_seconds()
+                + 86_400,
+            0,
+        );
+        filetime::set_file_mtime(&csv_path, future).unwrap();
+
+        assert!(
+            Config::new(Some(&path_str)).indexed().unwrap().is_some(),
+            "the stale index should have been rebuilt"
+        );
+        let after = std::fs::metadata(&idx_path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            after, restrictive,
+            "a rebuild must preserve the existing index's permissions (got {after:o})"
         );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,6 +33,23 @@ Need a UI & more advanced data-wrangling? Upgrade to qsv pro (https://qsvpro.dat
 
 pub static TEMP_FILE_DIR: OnceLock<PathBuf> = OnceLock::new();
 
+// Index paths this process has already rebuilt because they looked stale.
+//
+// Several parallel workers call `index_files()` on the same input and can all observe the
+// same stale index. Worse, a data file whose mtime is in the FUTURE never stops looking
+// stale, so the condition does not clear after a rebuild. Without this, every worker
+// rebuilds - each `File::create`ing (truncating) the very index the others are reading,
+// which corrupts it and fails the run with a bare "Invalid argument".
+//
+// The lock is held ACROSS the rebuild, so late arrivals block until it is complete and then
+// simply re-open the finished file.
+static AUTOINDEXED_STALE: OnceLock<std::sync::Mutex<std::collections::HashSet<PathBuf>>> =
+    OnceLock::new();
+
+fn autoindexed_stale() -> &'static std::sync::Mutex<std::collections::HashSet<PathBuf>> {
+    AUTOINDEXED_STALE.get_or_init(|| std::sync::Mutex::new(std::collections::HashSet::new()))
+}
+
 #[cfg(feature = "polars")]
 pub static POLARS_FLOAT_PRECISION: OnceLock<Option<usize>> = OnceLock::new();
 
@@ -865,8 +882,18 @@ impl Config {
         if let Some(idx_path) = &idx_path_work {
             let (idx_modified, _) = util::file_metadata(&idx_file.metadata()?);
             if data_modified > idx_modified {
-                info!("index stale... autoindexing...");
-                self.autoindex_file();
+                // Rebuild AT MOST ONCE per path per process, and never concurrently - see
+                // `AUTOINDEXED_STALE`. Late arrivals block here until the rebuild finishes,
+                // then fall through and re-open the completed index.
+                {
+                    let mut rebuilt = autoindexed_stale()
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    if rebuilt.insert(idx_path.clone()) {
+                        info!("index stale... autoindexing...");
+                        self.autoindex_file();
+                    }
+                }
                 idx_file = fs::File::open(idx_path)?;
             }
         }
@@ -1269,5 +1296,75 @@ mod tests {
         assert_eq!(ext, "tsv");
         assert_eq!(delim, b'\t');
         assert!(snappy);
+    }
+
+    /// A STALE index must be rebuilt AT MOST ONCE per process, and never concurrently.
+    ///
+    /// Several parallel workers call `index_files()` on the same input and all observe the
+    /// same stale index; a data file whose mtime is in the FUTURE never stops looking stale,
+    /// so the condition does not clear after a rebuild either. Before the fix every caller
+    /// rebuilt - each truncating the index the others were mid-read of - corrupting it and
+    /// failing the run with a bare "Invalid argument" from `Indexed::open`. That is what broke
+    /// `stats` on a stale index (test_index::index_outdated_stats) on macOS CI.
+    ///
+    /// The assertion is on the rebuild COUNT, not on the crash: the corruption is a race that
+    /// a fast machine reliably wins, so a concurrency-only test passes even with the fix
+    /// removed (verified). Watching the index's mtime instead is deterministic - a second
+    /// rebuild necessarily rewrites the file.
+    #[test]
+    fn stale_index_is_rebuilt_once_not_once_per_caller() {
+        use std::io::Write;
+
+        let dir = tempfile::tempdir().unwrap();
+        let csv_path = dir.path().join("stale.csv");
+
+        let mut f = std::fs::File::create(&csv_path).unwrap();
+        writeln!(f, "letter,number").unwrap();
+        for i in 0..2_000 {
+            writeln!(f, "{},{i}", char::from(b'a' + (i % 26) as u8)).unwrap();
+        }
+        f.sync_all().unwrap();
+        drop(f);
+
+        let path_str = csv_path.to_string_lossy().to_string();
+        let config = Config::new(Some(&path_str));
+        crate::util::create_index_for_file(&csv_path, &config).unwrap();
+        let idx_path = crate::util::idx_path(&csv_path);
+
+        // push the DATA mtime into the future so the index looks stale to EVERY caller and
+        // STAYS stale after a rebuild - the exact shape of test_index::index_outdated_stats
+        let future = filetime::FileTime::from_unix_time(
+            filetime::FileTime::from_last_modification_time(&std::fs::metadata(&csv_path).unwrap())
+                .unix_seconds()
+                + 86_400,
+            0,
+        );
+        filetime::set_file_mtime(&csv_path, future).unwrap();
+
+        // first call: sees the stale index and rebuilds it
+        assert!(
+            config.indexed().unwrap().is_some(),
+            "the first caller must get a usable index"
+        );
+
+        // stamp the index with a distinctive mtime; any FURTHER rebuild overwrites it
+        let marker = filetime::FileTime::from_unix_time(1_000_000, 0);
+        filetime::set_file_mtime(&idx_path, marker).unwrap();
+
+        // later callers - the parallel workers - must reuse it rather than rebuild
+        for i in 0..8 {
+            assert!(
+                Config::new(Some(&path_str)).indexed().unwrap().is_some(),
+                "caller {i} must get a usable index"
+            );
+        }
+
+        let after =
+            filetime::FileTime::from_last_modification_time(&std::fs::metadata(&idx_path).unwrap());
+        assert_eq!(
+            after, marker,
+            "the stale index was rebuilt again by a later caller; with parallel workers those \
+             rebuilds race and truncate the index the others are reading"
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -760,37 +760,68 @@ impl Config {
     /// - If the file is Snappy-compressed, the function returns immediately w/o creating an index.
     /// - If `self.path` is `None`, the function returns without action.
     /// - The function creates an index file using `util::idx_path()` to determine index file path.
-    /// - It uses `csv_index::RandomAccessSimple::create()` to generate the index.
-    /// - Success is only logged; no process-global state is set. A subsequent `index_files()`
-    ///   discovers the new index by looking for it beside `self.path`, like any other index.
+    /// - It builds the index into a sibling temp file and `rename`s it into place, so the existing
+    ///   index is never truncated and readers never observe a partial one.
+    /// - Returns whether an index was successfully put in place. Callers that memoize the rebuild
+    ///   must only record it on `true`.
+    /// - No process-global state is set here. A subsequent `index_files()` discovers the new index
+    ///   by looking for it beside `self.path`, like any other index.
     ///
     /// # Errors
     ///
     /// While this function doesn't return any errors, it logs debug messages for both successful
     /// and failed index creation attempts.
-    fn autoindex_file(&self) {
+    fn autoindex_file(&self) -> bool {
         if self.snappy {
-            return;
+            return false;
         }
 
-        let Some(path_buf) = &self.path else { return };
+        let Some(path_buf) = &self.path else {
+            return false;
+        };
 
         let pidx = util::idx_path(Path::new(path_buf));
-        let Ok(idxfile) = fs::File::create(pidx) else {
-            return;
+
+        // Build into a SIBLING temp file and rename into place only after the index is
+        // complete. Writing straight to `pidx` means `File::create` TRUNCATES it before a
+        // single byte of the new index is written - so any later failure leaves an empty or
+        // partial index behind, and a concurrent reader can open one mid-write. `rename` on
+        // the same directory is atomic: readers see either the old complete index or the new
+        // one, never a torn file.
+        let mut tmp = pidx.clone().into_os_string();
+        tmp.push(format!(".tmp{}", std::process::id()));
+        let tmp = PathBuf::from(tmp);
+
+        let Ok(idxfile) = fs::File::create(&tmp) else {
+            return false;
         };
         let Ok(mut rdr) = self.reader_file() else {
-            return;
+            let _ = fs::remove_file(&tmp);
+            return false;
         };
         let mut wtr = io::BufWriter::with_capacity(DEFAULT_WTR_BUFFER_CAPACITY, idxfile);
         match csv_index::RandomAccessSimple::create(&mut rdr, &mut wtr) {
             Ok(()) => {
-                let Ok(()) = io::Write::flush(&mut wtr) else {
-                    return;
-                };
+                if io::Write::flush(&mut wtr).is_err() {
+                    drop(wtr);
+                    let _ = fs::remove_file(&tmp);
+                    return false;
+                }
+                // drop the writer before renaming so every buffered byte is in the file
+                drop(wtr);
+                if fs::rename(&tmp, &pidx).is_err() {
+                    let _ = fs::remove_file(&tmp);
+                    return false;
+                }
                 debug!("autoindex of {} successful.", path_buf.display());
+                true
             },
-            Err(e) => debug!("autoindex of {} failed: {e}", path_buf.display()),
+            Err(e) => {
+                drop(wtr);
+                let _ = fs::remove_file(&tmp);
+                debug!("autoindex of {} failed: {e}", path_buf.display());
+                false
+            },
         }
     }
 
@@ -849,8 +880,15 @@ impl Config {
                             return Ok(None);
                         } else if self.autoindex_size > 0 && data_fsize >= self.autoindex_size {
                             // if CSV file size >= QSV_AUTOINDEX_SIZE, and
-                            // its not a snappy file, create an index automatically
-                            self.autoindex_file();
+                            // its not a snappy file, create an index automatically.
+                            // If that fails, fall back to "no index" rather than erroring -
+                            // this branch is passively LOOKING for an index, and the caller
+                            // can still process the file sequentially. `autoindex_file`
+                            // renames into place only on success, so there is no partial
+                            // index to open here.
+                            if !self.autoindex_file() {
+                                return Ok(None);
+                            }
                             fs::File::open(&idx_path)?
                         } else if data_fsize >= NO_INDEX_WARNING_FILESIZE {
                             // warn user that the CSV file is large and not indexed
@@ -889,9 +927,15 @@ impl Config {
                     let mut rebuilt = autoindexed_stale()
                         .lock()
                         .unwrap_or_else(std::sync::PoisonError::into_inner);
-                    if rebuilt.insert(idx_path.clone()) {
+                    if !rebuilt.contains(idx_path) {
                         info!("index stale... autoindexing...");
-                        self.autoindex_file();
+                        // record ONLY on success: `autoindex_file` reports failure quietly,
+                        // and memoizing a failed rebuild would poison this path for the rest
+                        // of the process - every later caller skipping the repair and reusing
+                        // the stale index.
+                        if self.autoindex_file() {
+                            rebuilt.insert(idx_path.clone());
+                        }
                     }
                 }
                 idx_file = fs::File::open(idx_path)?;
@@ -1365,6 +1409,85 @@ mod tests {
             after, marker,
             "the stale index was rebuilt again by a later caller; with parallel workers those \
              rebuilds race and truncate the index the others are reading"
+        );
+    }
+
+    /// A FAILED stale-index rebuild must neither destroy the existing index nor poison the
+    /// per-path memo.
+    ///
+    /// `autoindex_file` reports failure quietly. It used to `File::create` the real index
+    /// path first, truncating it before writing a byte - so a failure part-way left an empty
+    /// or partial index behind. Combined with memoizing the path BEFORE knowing the rebuild
+    /// worked, one failure would poison that path for the rest of the process: every later
+    /// caller skipped the repair and reopened the wreckage. roborev 4369.
+    ///
+    /// Failure is induced by making the directory read-only, so the sibling temp index cannot
+    /// be created.
+    #[cfg(unix)]
+    #[test]
+    fn failed_stale_rebuild_preserves_the_index_and_retries() {
+        use std::{io::Write, os::unix::fs::PermissionsExt};
+
+        let dir = tempfile::tempdir().unwrap();
+        let csv_path = dir.path().join("failing.csv");
+
+        let mut f = std::fs::File::create(&csv_path).unwrap();
+        writeln!(f, "letter,number").unwrap();
+        for i in 0..2_000 {
+            writeln!(f, "{},{i}", char::from(b'a' + (i % 26) as u8)).unwrap();
+        }
+        f.sync_all().unwrap();
+        drop(f);
+
+        let path_str = csv_path.to_string_lossy().to_string();
+        let config = Config::new(Some(&path_str));
+        crate::util::create_index_for_file(&csv_path, &config).unwrap();
+        let idx_path = crate::util::idx_path(&csv_path);
+        let good_len = std::fs::metadata(&idx_path).unwrap().len();
+        assert!(good_len > 0, "fixture index should be non-empty");
+
+        // make the index look stale, permanently
+        let future = filetime::FileTime::from_unix_time(
+            filetime::FileTime::from_last_modification_time(&std::fs::metadata(&csv_path).unwrap())
+                .unix_seconds()
+                + 86_400,
+            0,
+        );
+        filetime::set_file_mtime(&csv_path, future).unwrap();
+
+        // read-only directory => the sibling temp index cannot be created => rebuild fails
+        let original_perms = std::fs::metadata(dir.path()).unwrap().permissions();
+        let mut readonly = original_perms.clone();
+        readonly.set_mode(0o555);
+        std::fs::set_permissions(dir.path(), readonly).unwrap();
+
+        let during_failure = Config::new(Some(&path_str)).indexed();
+
+        std::fs::set_permissions(dir.path(), original_perms).unwrap();
+
+        // the EXISTING index must have survived intact - the rebuild never touched it
+        assert!(
+            during_failure.is_ok_and(|i| i.is_some()),
+            "a failed rebuild must leave the existing index usable"
+        );
+        assert_eq!(
+            std::fs::metadata(&idx_path).unwrap().len(),
+            good_len,
+            "a failed rebuild must not truncate the existing index"
+        );
+
+        // and the failure must NOT have been memoized - a later caller retries and succeeds
+        let marker = filetime::FileTime::from_unix_time(1_000_000, 0);
+        filetime::set_file_mtime(&idx_path, marker).unwrap();
+        assert!(
+            Config::new(Some(&path_str)).indexed().unwrap().is_some(),
+            "the retry must produce a usable index"
+        );
+        let after =
+            filetime::FileTime::from_last_modification_time(&std::fs::metadata(&idx_path).unwrap());
+        assert_ne!(
+            after, marker,
+            "a failed rebuild poisoned the memo: the retry skipped the repair"
         );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -271,10 +271,20 @@ impl Config {
                 let temp_dir = crate::config::TEMP_FILE_DIR.get_or_init(|| {
                     tempfile::TempDir::new().map_or_else(
                         |e| {
+                            // Fall back to a qsv-OWNED subdirectory of the system temp dir -
+                            // NEVER `env::temp_dir()` itself. `util::log_end` removes
+                            // `TEMP_FILE_DIR` wholesale at exit, so storing the system temp
+                            // root here would delete every other process's temp files too.
+                            // This is the only init site that can produce a directory qsv did
+                            // not create; the others `unwrap()` a `TempDir`.
+                            let fallback =
+                                env::temp_dir().join(format!("qsv-{}", std::process::id()));
                             warn!(
-                                "failed to create temp dir: {e}; falling back to system temp dir"
+                                "failed to create temp dir: {e}; falling back to {}",
+                                fallback.display()
                             );
-                            env::temp_dir()
+                            fs::create_dir_all(&fallback).unwrap_or_default();
+                            fallback
                         },
                         tempfile::TempDir::keep,
                     )

--- a/src/config.rs
+++ b/src/config.rs
@@ -788,38 +788,46 @@ impl Config {
         // partial index behind, and a concurrent reader can open one mid-write. `rename` on
         // the same directory is atomic: readers see either the old complete index or the new
         // one, never a torn file.
-        let mut tmp = pidx.clone().into_os_string();
-        tmp.push(format!(".tmp{}", std::process::id()));
-        let tmp = PathBuf::from(tmp);
-
-        let Ok(idxfile) = fs::File::create(&tmp) else {
+        // `tempfile` picks a UNIQUE name and creates it exclusively (O_EXCL), so two
+        // concurrent builds - which the `autoindex_size` path below does not serialize -
+        // cannot land on the same file, and a pre-existing file or symlink at a guessable
+        // name cannot be written through. A deterministic `<idx>.tmp<pid>` had both problems:
+        // same-process builds share a pid.
+        let idx_dir = pidx.parent().unwrap_or_else(|| Path::new("."));
+        let Ok(mut tmp) = tempfile::Builder::new()
+            .prefix(".qsv-idx")
+            .tempfile_in(idx_dir)
+        else {
             return false;
         };
         let Ok(mut rdr) = self.reader_file() else {
-            let _ = fs::remove_file(&tmp);
+            // `tmp` removes itself on drop
             return false;
         };
-        let mut wtr = io::BufWriter::with_capacity(DEFAULT_WTR_BUFFER_CAPACITY, idxfile);
-        match csv_index::RandomAccessSimple::create(&mut rdr, &mut wtr) {
-            Ok(()) => {
-                if io::Write::flush(&mut wtr).is_err() {
-                    drop(wtr);
-                    let _ = fs::remove_file(&tmp);
-                    return false;
-                }
-                // drop the writer before renaming so every buffered byte is in the file
-                drop(wtr);
-                if fs::rename(&tmp, &pidx).is_err() {
-                    let _ = fs::remove_file(&tmp);
-                    return false;
-                }
+
+        let build = {
+            let mut wtr =
+                io::BufWriter::with_capacity(DEFAULT_WTR_BUFFER_CAPACITY, tmp.as_file_mut());
+            csv_index::RandomAccessSimple::create(&mut rdr, &mut wtr)
+                .and_then(|()| io::Write::flush(&mut wtr).map_err(Into::into))
+        };
+        if let Err(e) = build {
+            debug!("autoindex of {} failed: {e}", path_buf.display());
+            return false;
+        }
+
+        // persist() renames into place, which is atomic on the same filesystem: readers see
+        // either the old complete index or the new one, never a torn file
+        match tmp.persist(&pidx) {
+            Ok(_) => {
                 debug!("autoindex of {} successful.", path_buf.display());
                 true
             },
             Err(e) => {
-                drop(wtr);
-                let _ = fs::remove_file(&tmp);
-                debug!("autoindex of {} failed: {e}", path_buf.display());
+                debug!(
+                    "autoindex of {} could not be put in place: {e}",
+                    path_buf.display()
+                );
                 false
             },
         }
@@ -923,20 +931,40 @@ impl Config {
                 // Rebuild AT MOST ONCE per path per process, and never concurrently - see
                 // `AUTOINDEXED_STALE`. Late arrivals block here until the rebuild finishes,
                 // then fall through and re-open the completed index.
-                {
+                let usable = {
                     let mut rebuilt = autoindexed_stale()
                         .lock()
                         .unwrap_or_else(std::sync::PoisonError::into_inner);
-                    if !rebuilt.contains(idx_path) {
+                    if rebuilt.contains(idx_path) {
+                        // an earlier caller in this process already rebuilt it successfully
+                        true
+                    } else {
                         info!("index stale... autoindexing...");
                         // record ONLY on success: `autoindex_file` reports failure quietly,
                         // and memoizing a failed rebuild would poison this path for the rest
                         // of the process - every later caller skipping the repair and reusing
                         // the stale index.
-                        if self.autoindex_file() {
+                        let ok = self.autoindex_file();
+                        if ok {
                             rebuilt.insert(idx_path.clone());
                         }
+                        ok
                     }
+                };
+                if !usable {
+                    // The index is stale and could not be refreshed. Do NOT hand back the
+                    // stale one: we just determined its offsets no longer describe the data,
+                    // so a caller seeking with it can read the wrong rows or miss rows
+                    // entirely while believing the index is valid. Reporting "no index" sends
+                    // the caller down its sequential path, which is slower but correct.
+                    warn!(
+                        "index for {} is stale and could not be rebuilt; proceeding without an \
+                         index",
+                        self.path
+                            .as_ref()
+                            .map_or_else(String::new, |p| p.display().to_string())
+                    );
+                    return Ok(None);
                 }
                 idx_file = fs::File::open(idx_path)?;
             }
@@ -1465,11 +1493,17 @@ mod tests {
 
         std::fs::set_permissions(dir.path(), original_perms).unwrap();
 
-        // the EXISTING index must have survived intact - the rebuild never touched it
+        // A stale index that could not be refreshed must NOT be handed back: its offsets no
+        // longer describe the data, so seeking with it can read the wrong rows. "No index"
+        // sends the caller down its sequential path, which is slower but correct.
+        // (roborev 4370 - an earlier revision of this test asserted the opposite.)
         assert!(
-            during_failure.is_ok_and(|i| i.is_some()),
-            "a failed rebuild must leave the existing index usable"
+            during_failure.is_ok_and(|i| i.is_none()),
+            "a stale index that could not be rebuilt must be reported as absent, not returned"
         );
+
+        // ...but the existing index file must still be INTACT on disk - the failed rebuild
+        // never touched it, so a later successful rebuild is not starting from wreckage
         assert_eq!(
             std::fs::metadata(&idx_path).unwrap().len(),
             good_len,

--- a/src/util.rs
+++ b/src/util.rs
@@ -2051,6 +2051,33 @@ fn is_conditionally_safe(header_name: &str, collapse: bool, unicode: bool) -> bo
     true
 }
 
+/// Whether `dir` is safe for `log_end` to delete WHOLESALE.
+///
+/// `TEMP_FILE_DIR` is meant to hold only a directory qsv itself created, but `Config::new`
+/// once fell back to `env::temp_dir()` when `TempDir::new()` failed - and the cleanup below
+/// would then have removed the SYSTEM temp root, taking every other process's files with it.
+/// That fallback now creates a qsv-owned subdirectory instead; this is the second line of
+/// defense, enforced at the point of deletion so a future init site cannot quietly
+/// reintroduce the hazard.
+pub(crate) fn temp_dir_is_removable(dir: &std::path::Path) -> bool {
+    // a filesystem root has no parent
+    if dir.parent().is_none() {
+        return false;
+    }
+    let system_temp = std::env::temp_dir();
+    if dir == system_temp {
+        return false;
+    }
+    // compare resolved forms too, so /tmp vs /private/tmp (macOS) or a trailing separator
+    // cannot sneak the system temp root past the check above
+    match (dir.canonicalize(), system_temp.canonicalize()) {
+        (Ok(resolved_dir), Ok(resolved_system)) => resolved_dir != resolved_system,
+        // if either cannot be resolved we cannot prove they differ; the equality checks
+        // above already passed, so allow it
+        _ => true,
+    }
+}
+
 pub fn log_end(mut qsv_args: String, now: std::time::Instant) {
     use crate::config::TEMP_FILE_DIR;
 
@@ -2065,7 +2092,14 @@ pub fn log_end(mut qsv_args: String, now: std::time::Instant) {
     // per invocation, until the OS reclaimed the temp dir - which on many systems is only at
     // reboot. This is the ONLY cleanup site for `TEMP_FILE_DIR`.
     if let Some(temp_dir) = TEMP_FILE_DIR.get() {
-        std::fs::remove_dir_all(temp_dir).unwrap_or_default();
+        if temp_dir_is_removable(temp_dir) {
+            std::fs::remove_dir_all(temp_dir).unwrap_or_default();
+        } else {
+            log::warn!(
+                "refusing to remove {} - it is not a qsv-created temp directory",
+                temp_dir.display()
+            );
+        }
     }
     if log::log_enabled!(log::Level::Info) {
         let ellipsis = if qsv_args.len() > 24 {
@@ -6149,5 +6183,48 @@ mod tests {
         let blob_url = "https://github.com/user/repo/blob/main/file.csv?ref=v1.0#L10";
         let expected = "https://raw.githubusercontent.com/user/repo/main/file.csv";
         assert_eq!(transform_github_url(blob_url), expected);
+    }
+
+    /// The system temp root must NEVER be removable. `Config::new` once fell back to
+    /// `env::temp_dir()` when `TempDir::new()` failed, and `log_end` removes `TEMP_FILE_DIR`
+    /// wholesale - so without this guard a rare temp-dir creation failure would have wiped
+    /// every other process's temp files. roborev 4366.
+    #[test]
+    fn temp_dir_is_removable_refuses_the_system_temp_root() {
+        let system_temp = std::env::temp_dir();
+        assert!(
+            !temp_dir_is_removable(&system_temp),
+            "the system temp root must never be removable"
+        );
+
+        // A SYMLINK to the system temp root must not be removable either. This is the case
+        // that actually exercises the canonicalize branch: `Path` equality normalizes away
+        // `.` and trailing separators, so those variants are already caught by the check
+        // above and would leave that branch untested.
+        #[cfg(unix)]
+        {
+            let holder = tempfile::TempDir::new().unwrap();
+            let link = holder.path().join("link-to-system-temp");
+            std::os::unix::fs::symlink(&system_temp, &link).unwrap();
+            assert_ne!(
+                link, system_temp,
+                "the symlink path must differ textually, or this asserts nothing"
+            );
+            assert!(
+                !temp_dir_is_removable(&link),
+                "a symlink resolving to the system temp root must not be removable"
+            );
+        }
+
+        // a filesystem root is never removable
+        assert!(!temp_dir_is_removable(std::path::Path::new("/")));
+
+        // but a qsv-created subdirectory of it IS - this is the normal case, and a guard
+        // that refused everything would silently reintroduce the leak this all started from
+        let owned = tempfile::TempDir::new().unwrap();
+        assert!(
+            temp_dir_is_removable(owned.path()),
+            "a qsv-created temp directory must remain removable"
+        );
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -2053,12 +2053,13 @@ fn is_conditionally_safe(header_name: &str, collapse: bool, unicode: bool) -> bo
 
 /// Whether `dir` is safe for `log_end` to delete WHOLESALE.
 ///
-/// `TEMP_FILE_DIR` is meant to hold only a directory qsv itself created, but `Config::new`
-/// once fell back to `env::temp_dir()` when `TempDir::new()` failed - and the cleanup below
-/// would then have removed the SYSTEM temp root, taking every other process's files with it.
-/// That fallback now creates a qsv-owned subdirectory instead; this is the second line of
-/// defense, enforced at the point of deletion so a future init site cannot quietly
-/// reintroduce the hazard.
+/// Every site that initializes `TEMP_FILE_DIR` does so with a `tempfile::TempDir` qsv created,
+/// so in practice this always answers true. It exists because the cost of being wrong is
+/// severe and asymmetric: `Config::new` once fell back to `env::temp_dir()` itself when
+/// `TempDir::new()` failed, and the cleanup would then have removed the SYSTEM temp root along
+/// with every other process's files (roborev 4366). That site no longer initializes the lock at
+/// all - it only reads it - but this check lives at the point of DELETION so a future init site
+/// cannot quietly reintroduce the hazard.
 pub(crate) fn temp_dir_is_removable(dir: &std::path::Path) -> bool {
     // a filesystem root has no parent
     if dir.parent().is_none() {

--- a/src/util.rs
+++ b/src/util.rs
@@ -2052,14 +2052,19 @@ fn is_conditionally_safe(header_name: &str, collapse: bool, unicode: bool) -> bo
 }
 
 pub fn log_end(mut qsv_args: String, now: std::time::Instant) {
-    #[cfg(feature = "polars")]
     use crate::config::TEMP_FILE_DIR;
 
-    #[cfg(feature = "polars")]
+    // Remove the temp directory this run may have created, now that the command has
+    // finished. `unwrap_or_default()` avoids a panic if it is already gone.
+    //
+    // This is deliberately NOT gated on `polars`. `TEMP_FILE_DIR` is declared
+    // unconditionally and is populated in every build: `extract_zip_to_temp` is always
+    // compiled (it needs only the non-optional `zip` crate), and the stdin spill temps in
+    // `split`, `stats` and `partition` land here too. Gating the cleanup meant a non-polars
+    // build (e.g. qsvlite) left a full decompressed copy of every `.zip` input on disk, once
+    // per invocation, until the OS reclaimed the temp dir - which on many systems is only at
+    // reboot. This is the ONLY cleanup site for `TEMP_FILE_DIR`.
     if let Some(temp_dir) = TEMP_FILE_DIR.get() {
-        // if polars is enabled, we need to remove the temporary directory
-        // after the command finishes. This is using unwrap_or_default()
-        // to avoid panics if the directory is already deleted.
         std::fs::remove_dir_all(temp_dir).unwrap_or_default();
     }
     if log::log_enabled!(log::Level::Info) {

--- a/tests/test_count.rs
+++ b/tests/test_count.rs
@@ -573,3 +573,45 @@ fn count_file_schema_inference_issue_3103() {
         "Count should be 3050, not 0, even with schema inference issues"
     );
 }
+
+// issue #4461: `util::log_end` deletes `TEMP_FILE_DIR`, but that cleanup was gated on the
+// `polars` feature while the directory is populated in EVERY build - `extract_zip_to_temp` is
+// always compiled (it needs only the non-optional `zip` crate). So a non-polars build such as
+// qsvlite left a full decompressed copy of every `.zip` input on disk, once per invocation,
+// until the OS reclaimed the temp dir.
+//
+// The child's temp root is redirected into the Workdir so the assertion is hermetic and does
+// not depend on the state of the real system temp dir. TMPDIR covers Unix; TMP/TEMP cover
+// Windows (`std::env::temp_dir` reads different vars per platform).
+//
+// Under `-F all_features` this passes either way, since the polars-gated cleanup was already
+// running. It has teeth under `-F lite`, which CI runs (rust-qsvlite, rust-musl,
+// rust-windows-lite).
+#[test]
+fn count_from_zip_leaves_no_temp_behind() {
+    let wrk = Workdir::new("count_from_zip_leaves_no_temp_behind");
+    let test_file = wrk.load_test_file("boston311-100.csv.zip");
+
+    wrk.create_subdir("tmproot").unwrap();
+    let tmproot = wrk.path("tmproot");
+
+    let mut cmd = wrk.command("count");
+    cmd.env("TMPDIR", &tmproot)
+        .env("TMP", &tmproot)
+        .env("TEMP", &tmproot)
+        .arg(&test_file);
+
+    // the command must still work - the temp is removed only AFTER the run finishes
+    let got: String = wrk.stdout_on_success(&mut cmd);
+    assert_eq!(got, "100".to_string());
+
+    let leftovers: Vec<String> = std::fs::read_dir(&tmproot)
+        .unwrap()
+        .filter_map(|e| e.ok().map(|e| e.file_name().to_string_lossy().into_owned()))
+        .collect();
+    assert!(
+        leftovers.is_empty(),
+        "the converted temp was not cleaned up; {} left in the temp root: {leftovers:?}",
+        leftovers.len()
+    );
+}


### PR DESCRIPTION
**Unbreaks master.** `227c678f5` (the #4463 merge, PR #4466) is currently red on macOS and qsvlite;
PR #4467's three `build` failures are this same inherited panic, not its own changes.

## The regression

Removing the `AUTO_INDEXED` fast path in #4463 correctly restored the staleness recheck — but that
recheck now runs in **every** caller, including each `parallel_stats` worker. And a data file whose
mtime is in the **future** never stops looking stale, so the condition doesn't clear after a rebuild.

Every worker rebuilt the index, each `File::create` truncating the file the others were mid-read of.
Measured on a 20k-row fixture: **17 concurrent rebuilds in one `qsv stats` run** (now 1).

```
thread '<unnamed>' panicked at src/cmd/stats.rs:2850:22:
Failed to re-open index for parallel stats.: Io(Os { code: 22, kind: InvalidInput })
Parallel stats is incomplete - only 1 of 4 chunks were merged
```

That's `test_index::index_outdated_stats`, which sets the data mtime into the future deliberately.
It passes locally — a fast machine serializes the writes — and fails on CI. My pre-merge check was a
green local suite, which was not evidence of what CI would do.

## The four commits

1. **Serialize and memoize** stale rebuilds per index path, with the lock held *across* the rebuild
   so late arrivals block and then re-open the finished file. This is the path-aware form of what
   `AUTO_INDEXED` did by accident, without the cross-path leak that made #4463 necessary.
2. **Build atomically**, and memoize only *successful* rebuilds. `autoindex_file` had been
   truncating the real index before writing a byte and reporting failure quietly — so a failed
   rebuild destroyed the index, and memoizing before knowing it worked poisoned that path for the
   rest of the process.
3. **Never return a stale index that couldn't be rebuilt.** Handing back an index we just judged
   stale can silently read wrong rows; `Ok(None)` sends the caller down its sequential path — slower,
   correct. Also replaced a guessable `<idx>.tmp<pid>` temp (same-process builds share a pid) with an
   exclusive unique one.
4. **Keep normal file permissions.** `tempfile` creates 0600 and the rename carried that onto the
   `.idx`. Measured: `qsv index` → `-rw-r--r--`, the new path → `-rw-------`, and a rebuild
   *downgraded* an existing 0644 index. Now `OpenOptions::create_new` — same O_EXCL guarantee,
   umask-respecting like the `File::create` that `qsv index` uses — and a rebuild copies the existing
   index's mode.

## Tests

Three new unit tests, **all mutation-verified** against the pre-fix behavior:

- rebuild-at-most-once, asserted through the index's mtime
- a failed rebuild (induced with a read-only directory) leaves the existing index intact, is not
  memoized, and is reported as absent
- auto-created index permissions match a `File::create` probe, and a rebuild preserves a
  deliberately-set mode

**Why mtime and not concurrency:** my first attempt was the obvious 16-thread hammer test. It passed
**with the fix removed, 3/3** — a race a fast machine always wins is untestable that way, which is
exactly why CI caught this and local runs didn't. The permissions test likewise compares against a
probe rather than hardcoding 0644, so it holds under any umask instead of passing only on mine.

Verified end to end: 1 rebuild per run (was 17), 0 leftover temp files, 0 failures over 10
consecutive runs of the repro, all 5 `test_index` tests.

Suites green: **2250** under `-F lite`; **993** unit + **3747** integration under `-F all_features`.

## Worth saying plainly

Commits 2–4 each fix a defect introduced by the commit before it, found by successive local reviews.
Every one was real and the changes converge (3 and 4 remove code), but four rounds of self-inflicted
follow-ups in `Config::index_files` — a path every command goes through — says this area deserves a
slower, deliberate pass rather than more incremental patching. Flagging that rather than burying it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
