### PR TITLE
fix: `count` is self-consistent on files with blank lines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6949,6 +6949,7 @@ dependencies = [
  "libc",
  "log",
  "magika",
+ "memchr",
  "memmap2",
  "mimalloc",
  "minijinja",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -253,6 +253,7 @@ jsonschema = { version = "0.49", features = [
 libc = "0.2"
 log = "0.4"
 magika = { version = "1.1", optional = true }
+memchr = "2"
 memmap2 = "0.9"
 mimalloc = { version = "0.1", default-features = false, features = ["extended"], optional = true }
 minijinja = { version = "2.23", features = [

--- a/src/cmd/count.rs
+++ b/src/cmd/count.rs
@@ -416,6 +416,41 @@ fn count_input(conf: &Config, count_delims_mode: CountDelimsMode) -> CliResult<(
     }
 }
 
+/// Returns true if the file at `path` may contain a literal blank line.
+///
+/// Polars materializes each blank line as an all-null row, while qsv's csv
+/// reader (and the index built with it) skip blank lines entirely (see issue
+/// #4456), so `polars_count_input` must not be used when a blank line may be
+/// present. A blank line requires the file to start with a line terminator or
+/// to contain two consecutive ones, so a fast SIMD byte scan can rule it out.
+/// A terminator pair inside a quoted multi-line field is a false positive,
+/// which only costs speed (we fall back to the regular csv reader), never
+/// correctness.
+#[cfg(feature = "polars")]
+fn may_contain_blank_lines(path: &std::path::Path) -> std::io::Result<bool> {
+    let file = std::fs::File::open(path)?;
+    if file.metadata()?.len() == 0 {
+        return Ok(false);
+    }
+    // safety: safe as we only read the mapped file
+    let mmap = unsafe { memmap2::MmapOptions::new().map(&file)? };
+    let bytes = &mmap[..];
+
+    if matches!(bytes.first(), Some(b'\n' | b'\r')) {
+        return Ok(true);
+    }
+    Ok(memchr::memchr2_iter(b'\n', b'\r', bytes).any(|i| {
+        match (bytes[i], bytes.get(i + 1)) {
+            // "\n\n" (LF blank line) or "\n\r" (start of a CRLF or bare-CR blank line)
+            (b'\n', Some(b'\n' | b'\r')) => true,
+            // "\r\r" (bare-CR blank line)
+            (b'\r', Some(b'\r')) => true,
+            // "\r\n" is a regular CRLF terminator; anything else starts a non-blank line
+            _ => false,
+        }
+    }))
+}
+
 /// Counts the number of records in a CSV file using Polars' optimized CSV reader
 ///
 /// # Arguments
@@ -496,6 +531,17 @@ pub fn polars_count_input(conf: &Config, low_memory: bool) -> CliResult<u64> {
     };
 
     let result = (|| -> CliResult<u64> {
+        // Polars counts literal blank lines as all-null rows; qsv's csv reader
+        // and the index skip them (issue #4456). If the input may contain one,
+        // use the regular csv reader so the count matches what every other
+        // command sees. On scan error, also fall back — polars would likely
+        // fail on such a file anyway.
+        if may_contain_blank_lines(&filepath).unwrap_or(true) {
+            info!("input may contain blank lines, using the regular csv reader count");
+            let (count_regular, _) = count_input(&fallback_conf, CountDelimsMode::NotRequired)?;
+            return Ok(count_regular);
+        }
+
         let mut comment_char = String::new();
         let comment_prefix = if let Some(c) = conf.comment {
             comment_char.push(c as char);

--- a/tests/test_count.rs
+++ b/tests/test_count.rs
@@ -615,3 +615,75 @@ fn count_from_zip_leaves_no_temp_behind() {
         leftovers.len()
     );
 }
+
+// issue #4456: polars materializes literal blank lines as all-null rows, while
+// qsv's csv reader (and the index) skip them — so `count` on a file with a
+// blank line disagreed with itself depending on whether an index existed.
+// These exercise the blank-line guard in `polars_count_input`, which falls
+// back to the regular csv reader whenever a blank line may be present.
+#[test]
+fn count_blank_line_trailing_unindexed_matches_indexed() {
+    let wrk = Workdir::new("count_blank_line_trailing_unindexed_matches_indexed");
+    wrk.create_from_string("in.csv", "a,b\n1,2\n3,4\n\n");
+
+    let mut cmd = wrk.command("count");
+    cmd.arg("in.csv");
+    let unindexed: String = wrk.stdout(&mut cmd);
+    assert_eq!(unindexed, "2");
+
+    let mut cmd = wrk.command("index");
+    cmd.arg("in.csv");
+    wrk.assert_success(&mut cmd);
+
+    let mut cmd = wrk.command("count");
+    cmd.arg("in.csv");
+    let indexed: String = wrk.stdout(&mut cmd);
+    assert_eq!(indexed, "2");
+}
+
+#[test]
+fn count_blank_line_middle() {
+    let wrk = Workdir::new("count_blank_line_middle");
+    wrk.create_from_string("in.csv", "a,b\n1,2\n\n3,4\n");
+
+    let mut cmd = wrk.command("count");
+    cmd.arg("in.csv");
+    let got: String = wrk.stdout(&mut cmd);
+    assert_eq!(got, "2");
+}
+
+#[test]
+fn count_multiple_trailing_blank_lines() {
+    let wrk = Workdir::new("count_multiple_trailing_blank_lines");
+    wrk.create_from_string("in.csv", "a,b\n1,2\n3,4\n\n\n\n");
+
+    let mut cmd = wrk.command("count");
+    cmd.arg("in.csv");
+    let got: String = wrk.stdout(&mut cmd);
+    assert_eq!(got, "2");
+}
+
+#[test]
+fn count_crlf_trailing_blank_line() {
+    let wrk = Workdir::new("count_crlf_trailing_blank_line");
+    wrk.create_from_string("in.csv", "a,b\r\n1,2\r\n3,4\r\n\r\n");
+
+    let mut cmd = wrk.command("count");
+    cmd.arg("in.csv");
+    let got: String = wrk.stdout(&mut cmd);
+    assert_eq!(got, "2");
+}
+
+// A "\n\n" inside a quoted multi-line field is a false positive for the
+// blank-line guard: it triggers the csv-reader fallback, which must still
+// return the correct count.
+#[test]
+fn count_quoted_double_newline_field() {
+    let wrk = Workdir::new("count_quoted_double_newline_field");
+    wrk.create_from_string("in.csv", "a,b\n\"x\n\ny\",2\n3,4\n");
+
+    let mut cmd = wrk.command("count");
+    cmd.arg("in.csv");
+    let got: String = wrk.stdout(&mut cmd);
+    assert_eq!(got, "2");
+}


### PR DESCRIPTION
Fixes #4456.

## Problem

`qsv count` disagreed with itself on any file containing a blank line:

```console
$ printf 'a,b\n1,2\n3,4\n\n' > blank.csv
$ qsv count blank.csv          # 3  (polars)
$ qsv index blank.csv && qsv count blank.csv   # 2  (index)
```

Polars materializes every literal blank line — trailing *or* mid-file — as an all-null row, while qsv's csv reader (and the index built with it) skip blank lines entirely. Polars 0.55 has **no skip-blank-lines option** in `CsvReadOptions`/`CsvParseOptions`, so this isn't fixable with a reader flag. Post-hoc SQL correction (`WHERE NOT all-null`) can't work either: a legit `,` line (two empty fields) also parses to all-nulls but *is* a record to the csv reader.

Because `util::count_rows` funnels through `polars_count_input`, the blast radius went well beyond `count` (full analysis in the issue comments). Confirmed behavioral breakage on the same fixture, all of it flipping to correct behavior the moment an index existed:

| Command | Unindexed (before) | Indexed |
|---|---|---|
| `slice --index -1` | **empty output — silent data loss** | `3,4` ✓ |
| `sample 0.5` | 2 rows (50% of phantom 3) | 1 row ✓ |
| `frequency` | misses uniqueness | `id,<ALL_UNIQUE>` ✓ |

## Fix

A conservative guard at the single choke point: before invoking polars, `polars_count_input` runs a fast SIMD byte scan (`memchr2_iter`) for the only patterns that can constitute a blank line — a leading line terminator, `\n\n`, `\n\r`, or `\r\r`. On a hit it falls back to the regular csv-reader count via the existing `fallback_conf` machinery (which already handles the stdin-temp path).

- A terminator pair inside a quoted multi-line field is a **false positive that only costs speed, never correctness** (covered by a test).
- No hit → blank lines are impossible → the polars count is exact, and the scan pre-warmed the page cache for it. Measured on a 145 MB / 5M-row file, the scan is a small fraction of the count's cost.
- Fixing here repairs `count` and all 13 `count_rows` consumers at once, and the `ROW_COUNT` OnceLock then caches a correct value.

`memchr` becomes a direct dependency; it was already compiled into every build transitively via the csv crate. The guard is `polars`-gated; qsvlite is unaffected (it was never inconsistent).

## Not addressed here

Every polars-backed command (`sqlp`, `joinp`, …) still *processes* the phantom null row — a broader engine-semantics divergence noted in the issue that may deserve its own issue, plus a possible upstream `skip_blank_lines` feature request to polars (pandas parity).

## Testing

- 5 new regression tests in `tests/test_count.rs`: trailing blank (unindexed == indexed), mid-file blank, multiple trailing blanks, CRLF trailing blank, quoted-`\n\n` false-positive path.
- Full `cargo test -F all_features`: **3756 passed, 0 failed**. Clippy clean for the change. `qsvlite` compiles.
- Manually verified: all repro cases return 2 (incl. stdin and CRLF); `frequency`/`slice`/`sample` now match their indexed behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
