### PR TITLE
deps: bump qsv_currency from 0.7 to 0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4050,6 +4050,17 @@ dependencies = [
  "iso_country",
  "proc-macro2",
  "quote",
+]
+
+[[package]]
+name = "iso_currency"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64ce7657a0b2e5b242df91e377c928a83a54628b946939d3aa81f57efef99a9"
+dependencies = [
+ "iso_country",
+ "proc-macro2",
+ "quote",
  "strum 0.27.2",
 ]
 
@@ -6932,7 +6943,7 @@ dependencies = [
  "iana-time-zone",
  "indexmap 2.14.0",
  "indicatif",
- "iso_currency",
+ "iso_currency 0.5.3",
  "itertools 0.15.0",
  "itoa",
  "jaq-core",
@@ -7055,12 +7066,12 @@ dependencies = [
 
 [[package]]
 name = "qsv_currency"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee20db00fad0bc38941997c53efd2dcb586bc8de05f070156d56b13079ce6d5"
+checksum = "8437239eab8971bed0416bef2fd7d208e826278fed7d162d2cfc65ca3880b651"
 dependencies = [
  "ahash 0.8.12",
- "iso_currency",
+ "iso_currency 0.7.0",
  "num",
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -367,7 +367,7 @@ yaml_serde = { version = "0.10", optional = true }
 qsv-dateparser = "0.15"
 qsv_docopt = "1.10"
 qsv-stats = "0.55"
-qsv_currency = "0.7"
+qsv_currency = "0.8"
 qsv-tabwriter = "2"
 qsv_vader_sentiment_analysis = { version = "0.2", optional = true }
 rand = "0.10"


### PR DESCRIPTION
Fixes #4478.

`qsv_currency` 0.7.0 rounded over-precise parses through `f64`, and `.round() as u64`
**saturates to zero** for negative values. Combined with the `fract_3digits` padding in
`apply.rs` (which turns `-1.234` into `-1.2340`), every negative amount with three decimal
places came out of `apply operations currencytonum` as `0.00` — silently, with no error.

Fixed upstream in dathere/qsv_currency#5 by redoing that branch in `BigInt` (half away from
zero, no `f64` in the path), released as 0.8.0.

## Verified against a locally built binary

```
$ printf 'amt\n-1.234\n1.234\n-12.345\n-0.999\n-1.23\n' > cur.csv
$ qsv apply operations currencytonum amt cur.csv
```

| input | 0.7.0 | 0.8.0 |
|---|---|---|
| `-1.234` | `0.00` | `-1.23` |
| `-12.345` | `0.00` | `-12.35` |
| `-0.999` | `0.00` | `-1.00` |
| `1.234` | `1.23` | `1.23` |
| `-1.23` | `-1.23` | `-1.23` |

A second fix in the same release also affects qsv: `{:e}` used an `'x'` placeholder when
swapping `,` and `.`, corrupting any symbol containing an `x` — so `numtocurrency --formatstr
euro` into a symbol like `Mex$` produced `Me,$`.

## Notes

- **No code changes needed.** qsv uses `from_str`, `value()`, `symbol()`, `is_iso_currency()`,
  `convert()` and the `{}` / `{:e}` formatters. 0.8.0 is breaking only in removing
  `scalar / Currency`, which qsv never used.
- **The `fract_3digits` padding in `apply.rs` stays.** qsv_currency still reads a 3-digit streak
  after a delimiter as a thousands separator; that heuristic is deliberate and unchanged, so the
  workaround is still doing real work.
- MSRV is unaffected — qsv_currency 0.8.0 declares 1.98.0 and qsv is already at `1.98`.

## Follow-up, not addressed here

This bump puts **two copies of `iso_currency` in the tree**: qsv pins `iso_currency = "0.5"`
directly (0.5.3) while qsv_currency 0.8 pulls 0.7.0. Nothing breaks — qsv only crosses that
boundary via `is_iso_currency() -> bool`, never passing `iso_currency` types — but the comment
above that pin says it is taken directly *because* it is already a transitive dependency of
qsv_currency, and that is no longer true. Unifying on 0.7 is a separate change with its own
two-major API risk, so I left it out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
