### PR TITLE
fix(apply): negative currencytonum — pin the #4478 regression, fix sub-dollar sign handling (#4483)

### DIFF
--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -546,6 +546,20 @@ fn fract_3digits_regex() -> &'static Regex {
     RE.get_or_init(|| Regex::new(r"\.\d\d\d$").unwrap())
 }
 
+// Render a currency's integer "coins" value (i.e. hundredths) as a decimal string.
+// The sign is stripped before zero-padding on purpose: padding the *signed* rendering
+// lets the sign consume a pad column, so -23 stays "-23" instead of widening to "-023"
+// and the slice below yields "-.23" rather than "-0.23".
+fn coins_to_decimal(coins: &impl std::fmt::Display) -> String {
+    let raw = coins.to_string();
+    let (sign, digits) = raw
+        .strip_prefix('-')
+        .map_or(("", raw.as_str()), |digits| ("-", digits));
+    let padded = format!("{digits:0>3}");
+    let decpoint = padded.len() - 2;
+    format!("{sign}{}.{}", &padded[..decpoint], &padded[decpoint..])
+}
+
 // valid subcommands
 #[derive(PartialEq)]
 enum ApplySubCmd {
@@ -1620,21 +1634,8 @@ fn apply_operations(
                 if let Ok(currency_val) = Currency::from_str(&cell_val) {
                     if formatstr == "strict" {
                         // Process ISO currency values
-                        let currency_coins = currency_val.value();
-                        let coins = format!("{currency_coins:03}");
-
                         if currency_val.is_iso_currency() {
-                            if coins == "000" {
-                                *cell = "0.00".to_string();
-                            } else {
-                                let coinlen = coins.len();
-                                if coinlen > 2 {
-                                    let decpoint = coinlen - 2;
-                                    let coin_num = &coins[..decpoint];
-                                    let coin_frac = &coins[decpoint..];
-                                    *cell = format!("{coin_num}.{coin_frac}");
-                                }
-                            }
+                            *cell = coins_to_decimal(currency_val.value());
                         }
                     } else {
                         // For non-strict mode, extract numeric parts from currency strings
@@ -1653,20 +1654,7 @@ fn apply_operations(
                             };
 
                             if let Ok(extracted_currency) = Currency::from_str(&numparts_val) {
-                                let currency_coins = extracted_currency.value();
-                                let coins = format!("{currency_coins:03}");
-
-                                if coins == "000" {
-                                    *cell = "0.00".to_string();
-                                } else {
-                                    let coinlen = coins.len();
-                                    if coinlen > 2 {
-                                        let decpoint = coinlen - 2;
-                                        let coin_num = &coins[..decpoint];
-                                        let coin_frac = &coins[decpoint..];
-                                        *cell = format!("{coin_num}.{coin_frac}");
-                                    }
-                                }
+                                *cell = coins_to_decimal(extracted_currency.value());
                             }
                         }
                     }

--- a/tests/test_apply.rs
+++ b/tests/test_apply.rs
@@ -2150,6 +2150,9 @@ fn apply_ops_currencytonum() {
             svec!["-1.234"],
             svec!["-12.345"],
             svec!["-0.999"],
+            // negative sub-dollar amounts - https://github.com/dathere/qsv/issues/4483
+            svec!["-0.23"],
+            svec!["-0.05"],
         ],
     );
     let mut cmd = wrk.command("apply");
@@ -2203,6 +2206,8 @@ fn apply_ops_currencytonum() {
         svec!["-1.23"],
         svec!["-12.35"],
         svec!["-1.00"],
+        svec!["-0.23"],
+        svec!["-0.05"],
     ];
     assert_eq!(got, expected);
 }
@@ -2261,6 +2266,9 @@ fn apply_ops_currencytonum_strict() {
             svec!["$-1.234"],
             svec!["$-12.345"],
             svec!["$-0.999"],
+            // negative sub-dollar amounts - https://github.com/dathere/qsv/issues/4483
+            svec!["$-0.23"],
+            svec!["$-0.05"],
         ],
     );
     let mut cmd = wrk.command("apply");
@@ -2316,6 +2324,8 @@ fn apply_ops_currencytonum_strict() {
         svec!["-1.23"],
         svec!["-12.35"],
         svec!["-1.00"],
+        svec!["-0.23"],
+        svec!["-0.05"],
     ];
     assert_eq!(got, expected);
 }

--- a/tests/test_apply.rs
+++ b/tests/test_apply.rs
@@ -2146,6 +2146,10 @@ fn apply_ops_currencytonum() {
             svec!["$10.8723"],
             svec!["$10.77777"],
             svec!["$10.777"],
+            // negative amounts with three decimal places - https://github.com/dathere/qsv/issues/4478
+            svec!["-1.234"],
+            svec!["-12.345"],
+            svec!["-0.999"],
         ],
     );
     let mut cmd = wrk.command("apply");
@@ -2196,6 +2200,9 @@ fn apply_ops_currencytonum() {
         svec!["10.87"],
         svec!["10.78"],
         svec!["10.78"],
+        svec!["-1.23"],
+        svec!["-12.35"],
+        svec!["-1.00"],
     ];
     assert_eq!(got, expected);
 }
@@ -2250,6 +2257,10 @@ fn apply_ops_currencytonum_strict() {
             svec!["$10.8723"],
             svec!["$10.77777"],
             svec!["$10.777"],
+            // negative amounts with three decimal places - https://github.com/dathere/qsv/issues/4478
+            svec!["$-1.234"],
+            svec!["$-12.345"],
+            svec!["$-0.999"],
         ],
     );
     let mut cmd = wrk.command("apply");
@@ -2302,6 +2313,9 @@ fn apply_ops_currencytonum_strict() {
         svec!["10.87"],
         svec!["10.78"],
         svec!["10.78"],
+        svec!["-1.23"],
+        svec!["-12.35"],
+        svec!["-1.00"],
     ];
     assert_eq!(got, expected);
 }


### PR DESCRIPTION
Two related commits, both about negative amounts in `apply operations currencytonum`.

### 1. Pin the #4478 regression (test-only)

The `qsv_currency` 0.7 -> 0.8 bump fixed negative amounts with three decimal places silently returning `0.00`, but nothing in the suite covered the case. Adds `-1.234` / `-12.345` / `-0.999` to `apply_ops_currencytonum` and the `$`-prefixed equivalents to `apply_ops_currencytonum_strict` -- bare values are pass-through in strict mode because `is_iso_currency()` gates that branch, so they would have been tautological there.

### 2. Fix #4483 -- sub-dollar negatives lost their leading zero

Found while writing the above. Both branches rendered the integer "coins" value with `format!("{coins:03}")`, but the width counts the sign, so `-23` stayed `"-23"` instead of widening to `"-023"`. `decpoint` then landed at 1 and the numerator slice collapsed to a bare `"-"`:

```
          before   after
$-0.23     -.23    -0.23
$-0.05     -.05    -0.05
$-0.99     -.99    -0.99
```

Positive values were never affected -- `0.23` works precisely because `"023"` has three real digits to slice. Anything with magnitude >= 1.00 was already correct. `numtocurrency` was never affected; it formats via `Display`.

The fix strips the sign before zero-padding and re-attaches it afterwards, in a new `coins_to_decimal` helper that also collapses the two near-identical slicing blocks. The `coins == "000"` special case and the `coinlen > 2` guard drop out: padding guarantees at least three digits, and `0` already formats as `0.00`.

### Verification

- `cargo t apply_ -F all_features` -- 90 passed, 0 failed.
- `cargo clippy -F all_features` -- no new warnings.
- Manually confirmed unchanged behavior on the paths the removed special-cases covered: `$ 0.00` / `USD 0` -> `0.00`, bare `0` in strict mode still passes through as `0`, `¥10,000,000.00` -> `10000000.00`, and `$-0.004` -> `0.00` (not `-0.00`).