### PR TITLE
ci(wiki-lint): fail when MCP skill JSONs drift from generator output

### DIFF
--- a/.github/workflows/wiki-lint.yml
+++ b/.github/workflows/wiki-lint.yml
@@ -17,9 +17,14 @@
 # exactly the generator's inputs (src/cmd/**, src/main.rs, docs/help/**), so the
 # check rides along for free rather than paying for a second 10-minute build.
 #
+# The same reasoning covers .claude/skills/qsv/*.json, generated from those same USAGE
+# strings by `qsv --update-mcp-skills` -- a flag the released binaries lack, since
+# publish.yml omits the `mcp` feature, but which this job's `-F all_features` build has.
+# See issue #4491.
+#
 # Triggers:
 #   - Nightly cron
-#   - PRs touching src/cmd/, src/main.rs, or docs/help/
+#   - PRs touching src/cmd/, src/main.rs, docs/help/, or .claude/skills/qsv/
 #   - Manual workflow_dispatch
 #
 # Nightly failures open (or comment on) a sticky issue tagged `wiki-lint`.
@@ -34,6 +39,9 @@ on:
       - 'src/cmd/**'
       - 'src/main.rs'
       - 'docs/help/**'
+      # Hand-editing a skill JSON is the other half of the drift surface: without this
+      # path, a PR that only touches one would never run the staleness check below.
+      - '.claude/skills/qsv/**'
       # README.md is a generator INPUT, not just an output: `--generate-help-md`
       # reads the command table for each command's description blurb, so a
       # README-only edit rewrites docs/help/*.md and TableOfContents.md.
@@ -126,6 +134,33 @@ jobs:
             exit 1
           fi
           echo "docs/help/ is in sync with the USAGE strings and the README command table."
+
+      # .claude/skills/qsv/*.json is GENERATED from the same USAGE strings, and nothing
+      # verified it: a clean `git status` proves only that nobody regenerated locally.
+      # Two descriptions (qsv-geocode's <index-file>, qsv-moarstats' --pct-thresholds)
+      # had silently drifted until #4488/PR #4490 regenerated and turned them up, so MCP
+      # agents were reading stale docs. tests/test_mcp_skills.rs catches an EMPTY
+      # description but cannot see a stale one -- that needs fresh generator output.
+      #
+      # Must run AFTER the docs/help check: `--update-mcp-skills` also invokes the help
+      # generator (src/main.rs), whose output is known clean by this point. The skills
+      # generator is byte-stable across runs on an unchanged tree.
+      - name: Generated MCP skill JSONs are up to date
+        run: |
+          qsv --update-mcp-skills
+          # Porcelain for the same reason as above, plus two specific to this generator:
+          # a newly registered command emits an UNTRACKED qsv-<cmd>.json, and the
+          # stale-file sweep DELETES retired ones. `git diff` reports neither.
+          drift="$(git status --porcelain -- .claude/skills/qsv)"
+          if [ -n "$drift" ]; then
+            echo "::error::.claude/skills/qsv/ is stale. A USAGE string or README table row changed without regenerating the MCP skills."
+            echo "Run 'qsv --update-mcp-skills' and commit the result. Never hand-edit .claude/skills/qsv/*.json."
+            echo "--- drift ---"
+            echo "$drift"
+            git --no-pager diff -- .claude/skills/qsv | head -200
+            exit 1
+          fi
+          echo ".claude/skills/qsv/ is in sync with the USAGE strings and the README command table."
 
       - name: Run wiki lint
         env:

--- a/.github/workflows/wiki-lint.yml
+++ b/.github/workflows/wiki-lint.yml
@@ -24,7 +24,8 @@
 #
 # Triggers:
 #   - Nightly cron
-#   - PRs touching src/cmd/, src/main.rs, docs/help/, or .claude/skills/qsv/
+#   - PRs touching src/cmd/, src/main.rs, docs/help/, .claude/skills/qsv/, or the
+#     generator sources themselves
 #   - Manual workflow_dispatch
 #
 # Nightly failures open (or comment on) a sticky issue tagged `wiki-lint`.
@@ -42,6 +43,13 @@ on:
       # Hand-editing a skill JSON is the other half of the drift surface: without this
       # path, a PR that only touches one would never run the staleness check below.
       - '.claude/skills/qsv/**'
+      # The generators THEMSELVES are inputs: a parser change rewrites every generated
+      # file without touching a single USAGE string, so a PR that edits one of these and
+      # forgets to regenerate is exactly the drift these checks exist to catch.
+      # generators_common is shared by both generators.
+      - 'src/mcp_skills_gen.rs'
+      - 'src/help_markdown_gen.rs'
+      - 'src/generators_common.rs'
       # README.md is a generator INPUT, not just an output: `--generate-help-md`
       # reads the command table for each command's description blurb, so a
       # README-only edit rewrites docs/help/*.md and TableOfContents.md.


### PR DESCRIPTION
Closes #4491.

## Why here

The issue left two things to decide — where the check runs, and whether the generator is deterministic. Both are settled below.

`wiki-lint.yml` turns out to be a free host: it already builds `cargo build --locked --bin qsv -F all_features` and installs it, already triggers on the generator's inputs (`src/cmd/**`, `src/main.rs`, `README.md`), and already implements this exact regenerate-and-diff shape for `docs/help`, with a header comment making precisely this argument. `all_features → distrib_features → mcp`, so the flag works there — unlike the released binaries, whose feature list in `publish.yml` omits `mcp`.

For the same reason, `mcp-server-ci.yml` cannot host this despite looking like the natural home: it downloads a *released* qsv, which rejects `--update-mcp-skills` as unknown.

## Changes

- **New step**, after the `docs/help` check. `--update-mcp-skills` also invokes the help generator (`src/main.rs`), so it must run second; both generators were verified byte-stable across two runs on an unchanged tree.
- **`.claude/skills/qsv/**` added to the PR path trigger.** Hand-editing a skill JSON is the other half of the drift surface — without this, a PR touching only one would never run the check.
- **`git status --porcelain`, not `git diff --exit-code`** (which the issue suggested). A newly registered command emits an *untracked* `qsv-<cmd>.json`, and the generator's stale-file sweep *deletes* retired ones; `git diff` sees only tracked paths and would report neither. Same call the existing `docs/help` step already made.

## Verification

| Case | Result |
|---|---|
| Clean tree | passes |
| Staged hand-edit of `qsv-count.json` (models a committed hand-edit) | **fails**, prints the diff |
| USAGE edit in `src/cmd/count.rs` without regenerating (the #4488 scenario) | **fails** on the `--width` description |
| `qsv --update-mcp-skills` twice on a clean tree | byte-identical, all 55 JSONs |
| `qsv --generate-help-md` twice on a clean tree | tree stays clean (earns the ordering) |
| `actionlint` + YAML parse | clean |
| `git check-ignore .claude/skills/qsv/*` | nothing ignored — no CI-vs-local checkout skew |

Master is not currently drifted (PR #4490 regenerated it); that confirms determinism, it isn't an argument the guard is unneeded.

Two caveats stated plainly: the untracked-new-file and deleted-file branches of the porcelain rationale are **reasoned, not exercised** — both require rebuilding with a changed `commands` vec. And all measurements are aarch64.

## Separate finding, not addressed here

`mod tests` in `src/mcp_skills_gen.rs` has **14 parser unit tests that never run in CI**. The module is `#[cfg(feature = "mcp")]`, and no `cargo test` invocation in any of the 21 workflows enables `mcp` (verified transitively via `cargo metadata`). `rust-clippy.yml` compiles them under `-F all_features`, but they are never executed. Since `mcp = []` is dependency-free, adding it to `rust.yml`'s feature list would cost one module compile — worth its own issue.

Generated with Claude Code
