### PR TITLE
ci: exercise MCP feature in Linux tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -64,7 +64,7 @@ jobs:
       # this, `viz_static` appeared in no test workflow at all and those tests were never even
       # checked — which is how their fixtures silently rotted (issues #4221 / #4343).
       # Actually RUNNING them needs a browser; that is the rust-viz-static.yml workflow.
-      run: cargo test --verbose --locked --features=apply,fetch,foreach,geocode,luau,python,feature_capable,lens,magika,color,viz_static
+      run: cargo test --verbose --locked --features=apply,fetch,foreach,geocode,luau,python,feature_capable,lens,magika,color,viz_static,mcp
     # Windows gives the main thread 1 MB of stack and debug frames are not collapsed, so a
     # stack-usage regression in `viz smart` breaks every Windows debug test run (issue #4328).
     # Encode that constraint on every PR by running the debug binary under a 1 MB rlimit here.


### PR DESCRIPTION
Fixes #4493.

Add the `mcp` marker feature to the main Linux test job so the 14 feature-gated MCP skill parser tests are compiled and run in CI.

Validation:
- workflow YAML parses successfully
- `cargo metadata --locked --no-deps --offline`
- `git diff --check`
- the issue author verified the exact feature set locally: 14 MCP parser tests pass

AI assistance: OpenAI GPT-5.6 Luna Max prepared the one-line workflow change; GPT-5.6 Sol independently reviewed the issue, contribution rules, duplicate status, diff, and validation.