### PR TITLE
fix: warn on failed stale cache refresh

### DIFF
--- a/src/diskcache.rs
+++ b/src/diskcache.rs
@@ -2957,11 +2957,22 @@ mod rich {
                         .map(|(k, v)| format!("{k}={v}"))
                         .collect(),
                 };
-                // Best-effort: on refresh failure, fall back to the stale copy.
-                if get_resource(&refresh_opts).is_ok()
-                    && let Some(refreshed) = load_entry_by_name(root, name)?
-                {
-                    entry = refreshed;
+                // Best-effort: on refresh failure, fall back to the stale copy but make
+                // the degraded result visible to callers instead of silently succeeding.
+                match get_resource(&refresh_opts) {
+                    Ok(_) => {
+                        if let Some(refreshed) = load_entry_by_name(root, name)? {
+                            entry = refreshed;
+                        }
+                    },
+                    Err(err) => {
+                        wwarn!(
+                            "get: refresh of stale cache entry '{}' from '{}' failed: {err}; \
+                             using cached copy",
+                            name,
+                            refresh_opts.source
+                        );
+                    },
                 }
             }
         }

--- a/tests/test_get.rs
+++ b/tests/test_get.rs
@@ -416,6 +416,34 @@ fn get_local_file_and_dc_read() {
     assert_eq!(got, "4");
 }
 
+#[test]
+fn get_dc_failed_refresh_warns_and_uses_stale_copy() {
+    let wrk = Workdir::new("get_dc_failed_refresh_warns_and_uses_stale_copy");
+    wrk.create_from_string("states_src.csv", STATES_CSV);
+    let cache_dir = wrk.path("qsvcache");
+
+    // A zero TTL makes the entry stale on every dc: resolution. Remove the
+    // source after seeding so the refresh fails while the cached copy remains.
+    let mut get = wrk.command("get");
+    get.env("QSV_CACHE_DIR", &cache_dir)
+        .args(["--name", "states.csv", "--ttl", "0"])
+        .arg("states_src.csv");
+    wrk.assert_success(&mut get);
+    std::fs::remove_file(wrk.path("states_src.csv")).unwrap();
+
+    let mut count = wrk.command("count");
+    count.env("QSV_CACHE_DIR", &cache_dir).arg("dc:states.csv");
+    let (got, stderr): (String, String) = wrk.stdout_and_stderr_on_success(&mut count);
+    assert_eq!(
+        got, "4",
+        "failed refresh should keep serving the stale copy"
+    );
+    assert!(
+        stderr.contains("using cached copy"),
+        "failed refresh should explain the stale fallback on stderr; got:\n{stderr}"
+    );
+}
+
 // issue #3988: local compressed sources are STREAMED into the content-addressed
 // blob store (bounded memory) and stored DECOMPRESSED, so `dc:` reads see plain
 // CSV with a correct record_count. Exercises `ingest_local`'s streaming-decode


### PR DESCRIPTION
Fixes #4511.

Preserves the stale-cache fallback while surfacing the refresh error through qsv's warning path. Adds a regression test that removes the original local source and verifies both the cached result and stderr warning.

Tests:
- `cargo +1.98.0 test --locked --no-default-features --features feature_capable,get_cloud --test tests test_get` (51 passed)
- `cargo +1.98.0 clippy --locked --no-default-features --features feature_capable,get_cloud --test tests -- -W clippy::perf`
- `cargo +nightly-2026-08-14 fmt -- --check`

AI use: OpenAI Codex GPT-5.6 Luna produced the initial patch and regression test; GPT-5.6 Sol reviewed the change and validation.