### PR TITLE
get/dc: harden and enrich the stale-refresh warning

### DIFF
--- a/src/diskcache.rs
+++ b/src/diskcache.rs
@@ -2939,9 +2939,15 @@ mod rich {
     /// auth failures and, when it fired, still be guessing — so the hint states the fact
     /// (the var is unset) and lets the reader decide whether it applies.
     ///
+    /// Takes the token the REFRESH actually used rather than re-reading the environment, so the
+    /// hint cannot disagree with the attempt it is explaining. Re-reading would: `var_os` sees a
+    /// non-Unicode value that `var` (used for the refresh) rejects, so the refresh would go out
+    /// unauthenticated while the hint stayed silent. An empty value is likewise treated as
+    /// absent — it authenticates nothing, so the hint still applies.
+    ///
     /// `ckan://` is matched case-sensitively to mirror `resolve_uri_prefix`.
-    fn ckan_auth_hint(source_uri: &str) -> &'static str {
-        if source_uri.starts_with("ckan://") && std::env::var_os("QSV_CKAN_TOKEN").is_none() {
+    fn ckan_auth_hint(source_uri: &str, token: Option<&str>) -> &'static str {
+        if source_uri.starts_with("ckan://") && token.is_none_or(str::is_empty) {
             " (if this is a private CKAN resource, note that QSV_CKAN_TOKEN is not set)"
         } else {
             ""
@@ -3005,9 +3011,15 @@ mod rich {
                     Err(err) => {
                         // Deliberately NOT `wwarn!`. Every other `wwarn!` call site is in a
                         // command or in `main`; this one is in a shared path reached by every
-                        // command that reads a `dc:` handle, so a closed or full stderr must
-                        // DROP the warning rather than panic on the macro's
-                        // `writeln!(..).unwrap()`. The log record always survives.
+                        // command that reads a `dc:` handle, and the macro ends in
+                        // `writeln!(..).unwrap()`. A write that FAILS here — EBADF from a
+                        // closed fd (`2>&-`), ENOSPC from a full device — must drop the
+                        // warning, not panic a command that was otherwise about to succeed.
+                        //
+                        // This does NOT cover a closed stderr PIPE: `util::reset_sigpipe`
+                        // restores SIG_DFL at startup, so that case kills the process before
+                        // any `Result` comes back, and no error handling here can change it.
+                        // The log record always survives.
                         use std::io::Write as _;
 
                         let msg = format!(
@@ -3016,7 +3028,10 @@ mod rich {
                             name,
                             fmt_age(age),
                             refresh_opts.source,
-                            ckan_auth_hint(&refresh_opts.source)
+                            ckan_auth_hint(
+                                &refresh_opts.source,
+                                refresh_opts.ckan_token.as_deref()
+                            )
                         );
                         log::warn!("{msg}");
                         let _ = writeln!(std::io::stderr(), "{msg}");
@@ -3282,15 +3297,26 @@ mod rich {
             assert_eq!(fmt_age(2_419_200), "last fetched 28d ago");
         }
 
-        // A non-`ckan://` source short-circuits before consulting the environment, so this
-        // branch is deterministic no matter what QSV_CKAN_TOKEN is set to in the process
-        // running the test suite.
+        // The hint takes the refresh's own token rather than reading the environment, so every
+        // case here is deterministic regardless of the ambient QSV_CKAN_TOKEN.
         #[test]
-        fn ckan_auth_hint_is_empty_for_non_ckan_sources() {
-            assert_eq!(ckan_auth_hint("https://example.com/data.csv"), "");
-            assert_eq!(ckan_auth_hint("/local/data.csv"), "");
+        fn ckan_auth_hint_fires_only_for_ckan_without_a_usable_token() {
+            const HINT: &str =
+                " (if this is a private CKAN resource, note that QSV_CKAN_TOKEN is not set)";
+
+            // non-CKAN sources never hint, with or without a token
+            assert_eq!(ckan_auth_hint("https://example.com/data.csv", None), "");
+            assert_eq!(ckan_auth_hint("/local/data.csv", None), "");
             // matched case-sensitively, mirroring `resolve_uri_prefix`
-            assert_eq!(ckan_auth_hint("CKAN://some-id"), "");
+            assert_eq!(ckan_auth_hint("CKAN://some-id", None), "");
+
+            // a ckan:// source with no usable token hints; an empty token authenticates
+            // nothing, so it counts as absent
+            assert_eq!(ckan_auth_hint("ckan://some-id", None), HINT);
+            assert_eq!(ckan_auth_hint("ckan://some-id", Some("")), HINT);
+
+            // a real token means auth was attempted, so the hint would be misleading
+            assert_eq!(ckan_auth_hint("ckan://some-id", Some("tok")), "");
         }
 
         // The `--random` reservoir path parses the CSV from the start, so a quoted

--- a/src/diskcache.rs
+++ b/src/diskcache.rs
@@ -2911,6 +2911,43 @@ mod rich {
         Ok(resolved.csv_path)
     }
 
+    /// Render a cache entry's age as a compact, human-scale string ("30d", "6h").
+    /// Used only in the stale-refresh warning, where precision beyond one unit is noise —
+    /// the number exists to answer "do I care?", not to be arithmetic.
+    fn fmt_age(secs: i64) -> String {
+        const MINUTE: i64 = 60;
+        const HOUR: i64 = 60 * MINUTE;
+        const DAY: i64 = 24 * HOUR;
+
+        match secs {
+            s if s >= DAY => format!("last fetched {}d ago", s / DAY),
+            s if s >= HOUR => format!("last fetched {}h ago", s / HOUR),
+            s if s >= MINUTE => format!("last fetched {}m ago", s / MINUTE),
+            s => format!("last fetched {s}s ago"),
+        }
+    }
+
+    /// A hint for the silent `ckan://` refresh failure that is otherwise undiagnosable: the
+    /// CKAN API URL is persisted on the entry, but the TOKEN never is — it is read from
+    /// `QSV_CKAN_TOKEN` at refresh time — so a private resource stops refreshing in any shell
+    /// without that var set.
+    ///
+    /// Worded CONDITIONALLY on purpose. The refresh error is not a reliable auth signal: CKAN
+    /// may answer an unauthorized private resource with 404 rather than 401/403 (to avoid
+    /// confirming the resource exists), and a public resource can fail here for reasons that
+    /// have nothing to do with auth. Gating on a status code would therefore both miss real
+    /// auth failures and, when it fired, still be guessing — so the hint states the fact
+    /// (the var is unset) and lets the reader decide whether it applies.
+    ///
+    /// `ckan://` is matched case-sensitively to mirror `resolve_uri_prefix`.
+    fn ckan_auth_hint(source_uri: &str) -> &'static str {
+        if source_uri.starts_with("ckan://") && std::env::var_os("QSV_CKAN_TOKEN").is_none() {
+            " (if this is a private CKAN resource, note that QSV_CKAN_TOKEN is not set)"
+        } else {
+            ""
+        }
+    }
+
     /// The un-memoized body of `resolve_dc_path`: refresh-if-stale, then materialize the CSV
     /// and its sibling `.idx`. Call this ONCE per handle per run — see `DC_RESOLVED`.
     fn resolve_dc_uncached(cache_dir: &str, root: &Path, name: &str) -> CliResult<ResolvedDc> {
@@ -2966,12 +3003,23 @@ mod rich {
                         }
                     },
                     Err(err) => {
-                        wwarn!(
-                            "get: refresh of stale cache entry '{}' from '{}' failed: {err}; \
-                             using cached copy",
+                        // Deliberately NOT `wwarn!`. Every other `wwarn!` call site is in a
+                        // command or in `main`; this one is in a shared path reached by every
+                        // command that reads a `dc:` handle, so a closed or full stderr must
+                        // DROP the warning rather than panic on the macro's
+                        // `writeln!(..).unwrap()`. The log record always survives.
+                        use std::io::Write as _;
+
+                        let msg = format!(
+                            "get: refresh of stale cache entry '{}' ({}) from '{}' failed: {err}; \
+                             using cached copy{}",
                             name,
-                            refresh_opts.source
+                            fmt_age(age),
+                            refresh_opts.source,
+                            ckan_auth_hint(&refresh_opts.source)
                         );
+                        log::warn!("{msg}");
+                        let _ = writeln!(std::io::stderr(), "{msg}");
                     },
                 }
             }
@@ -3217,7 +3265,33 @@ mod rich {
     mod tests {
         use std::io::Cursor;
 
-        use super::emit_preview_reservoir;
+        use super::{ckan_auth_hint, emit_preview_reservoir, fmt_age};
+
+        // The stale-refresh warning reports ONE unit, the largest that fits, so the unit
+        // boundaries are the whole contract.
+        #[test]
+        fn fmt_age_picks_the_largest_fitting_unit() {
+            assert_eq!(fmt_age(0), "last fetched 0s ago");
+            assert_eq!(fmt_age(59), "last fetched 59s ago");
+            assert_eq!(fmt_age(60), "last fetched 1m ago");
+            assert_eq!(fmt_age(3_599), "last fetched 59m ago");
+            assert_eq!(fmt_age(3_600), "last fetched 1h ago");
+            assert_eq!(fmt_age(86_399), "last fetched 23h ago");
+            assert_eq!(fmt_age(86_400), "last fetched 1d ago");
+            // the `qsv get` default TTL
+            assert_eq!(fmt_age(2_419_200), "last fetched 28d ago");
+        }
+
+        // A non-`ckan://` source short-circuits before consulting the environment, so this
+        // branch is deterministic no matter what QSV_CKAN_TOKEN is set to in the process
+        // running the test suite.
+        #[test]
+        fn ckan_auth_hint_is_empty_for_non_ckan_sources() {
+            assert_eq!(ckan_auth_hint("https://example.com/data.csv"), "");
+            assert_eq!(ckan_auth_hint("/local/data.csv"), "");
+            // matched case-sensitively, mirroring `resolve_uri_prefix`
+            assert_eq!(ckan_auth_hint("CKAN://some-id"), "");
+        }
 
         // The `--random` reservoir path parses the CSV from the start, so a quoted
         // field containing an embedded newline must survive as ONE intact record

--- a/tests/test_get.rs
+++ b/tests/test_get.rs
@@ -442,6 +442,22 @@ fn get_dc_failed_refresh_warns_and_uses_stale_copy() {
         stderr.contains("using cached copy"),
         "failed refresh should explain the stale fallback on stderr; got:\n{stderr}"
     );
+    // the warning must identify WHICH entry went stale — a run resolving several `dc:`
+    // handles emits one line per handle, and an unnamed line is not actionable
+    assert!(
+        stderr.contains("'states.csv'"),
+        "the warning should name the stale entry; got:\n{stderr}"
+    );
+    // ... and HOW stale it is, which is the number that decides whether to care
+    assert!(
+        stderr.contains("last fetched "),
+        "the warning should report the entry's age; got:\n{stderr}"
+    );
+    // a local source is not `ckan://`, so the CKAN token hint must stay out of it
+    assert!(
+        !stderr.contains("QSV_CKAN_TOKEN"),
+        "the CKAN token hint must not fire for a non-CKAN source; got:\n{stderr}"
+    );
 }
 
 // issue #3988: local compressed sources are STREAMED into the content-addressed


### PR DESCRIPTION
Follow-up to #4512 (thanks @mameikagou), which fixed the silent stale-copy fallback
reported in #4511. The core fix is unchanged — this adds three refinements on top.

### 1. Don't use `wwarn!` in this particular spot

`wwarn!` is the right macro almost everywhere, and it was the natural choice here. But all
57 other call sites are in `cmd/*` or `main*.rs`, whereas this one is in a shared path
reached by every command that reads a `dc:` handle (39+ of them, via `Config::new`). The
macro does `writeln!(..).unwrap()`, so a closed or full stderr turns a warning into a panic.

`log::warn!` plus a guarded write keeps the log record unconditionally and drops the stderr
line rather than dying on it. Rare conjunction — stale entry, failed refresh, broken stderr —
which is exactly why it shouldn't be a panic.

### 2. Report how stale the entry is

```
get: refresh of stale cache entry 'vax.csv' (last fetched 28d ago) from 'ckan://…' failed: …; using cached copy
```

Whether a failed refresh matters depends almost entirely on the age of the cached copy, and
the warning didn't say. One unit, largest that fits.

### 3. Hint at `QSV_CKAN_TOKEN` for `ckan://` sources

The CKAN API URL is persisted on the entry; the token never is — it's read from
`QSV_CKAN_TOKEN` at refresh time. So a private CKAN resource silently stops refreshing in
any shell without that var set, and the resulting error is indistinguishable from any other
failure.

The hint is worded conditionally ("if this is a private CKAN resource, note that
QSV_CKAN_TOKEN is not set") rather than gated on a status code. CKAN may answer an
unauthorized private resource with 404 rather than 401/403, so a status gate would miss real
auth failures — and when it did fire it would still be guessing. Stating the fact and letting
the reader decide is both cheaper and more honest.

### Tests

Extended the existing `get_dc_failed_refresh_warns_and_uses_stale_copy` in place rather than
adding a near-duplicate — it now also asserts the entry name, the age, and (negatively) that
the CKAN hint stays out of non-CKAN warnings. Added unit tests for `fmt_age`'s unit
boundaries and `ckan_auth_hint`'s environment-independent branch.

- `cargo test -F all_features test_get::` — 51 passed
- `cargo test -F all_features --bin qsv diskcache` — 3 passed
- `cargo clippy -F all_features --tests` — no new warnings
- `python3 scripts/double-run-check.py --check` — OK
- `cargo check --bin qsvdp -F datapusher_plus` — clean (qsvdp has `get` without `feature_capable`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
