### PR TITLE
fix: a failed write is an I/O error, not a qsv crash

### DIFF
--- a/src/clitypes.rs
+++ b/src/clitypes.rs
@@ -7,11 +7,24 @@ use std::{
 
 use cached::{RedbCacheError, RedisCacheError};
 
+// None of these macros may `.unwrap()` their write. A panic here is routed through
+// `util::qsv_custom_panic` and reaches the user as a crash report asking them to file a bug,
+// for what is really just a failed write — a full disk, a closed fd (issue #4516).
+//
+// The two stream classes are handled differently ON PURPOSE:
+//   - stdout carries DATA. Losing it silently is unacceptable, so the first failure is recorded in
+//     `WRITE_ERROR` and `QsvExitCode::report` turns it into a non-zero exit.
+//   - stderr carries DIAGNOSTICS. A warning that cannot be delivered must not change the outcome of
+//     an otherwise successful run, so it is dropped. The `log` record, emitted before the write,
+//     survives either way.
+
 /// write to stdout
 macro_rules! wout {
     ($($arg:tt)*) => ({
         use std::io::Write;
-        (writeln!(&mut ::std::io::stdout(), $($arg)*)).unwrap();
+        if let Err(e) = writeln!(&mut ::std::io::stdout(), $($arg)*) {
+            crate::clitypes::record_write_error("stdout", &e);
+        }
     });
 }
 
@@ -22,7 +35,9 @@ macro_rules! woutinfo {
         use log::info;
         let info = format!($($arg)*);
         info!("{info}");
-        (writeln!(&mut ::std::io::stdout(), $($arg)*)).unwrap();
+        if let Err(e) = writeln!(&mut ::std::io::stdout(), $($arg)*) {
+            crate::clitypes::record_write_error("stdout", &e);
+        }
     });
 }
 
@@ -33,7 +48,7 @@ macro_rules! werr {
         use log::error;
         let error = format!($($arg)*);
         error!("{error}");
-        (writeln!(&mut ::std::io::stderr(), $($arg)*)).unwrap();
+        let _ = writeln!(&mut ::std::io::stderr(), $($arg)*);
     });
 }
 
@@ -44,7 +59,7 @@ macro_rules! wwarn {
         use log::warn;
         let warning = format!($($arg)*);
         warn!("{warning}");
-        (writeln!(&mut ::std::io::stderr(), $($arg)*)).unwrap();
+        let _ = writeln!(&mut ::std::io::stderr(), $($arg)*);
     });
 }
 
@@ -55,7 +70,7 @@ macro_rules! winfo {
         use log::info;
         let info = format!($($arg)*);
         info!("{info}");
-        (writeln!(&mut ::std::io::stderr(), $($arg)*)).unwrap();
+        let _ = writeln!(&mut ::std::io::stderr(), $($arg)*);
     });
 }
 
@@ -125,6 +140,23 @@ macro_rules! fail_format {
 
 pub static CURRENT_COMMAND: OnceLock<String> = OnceLock::new();
 
+/// The first failed write to a DATA stream (stdout), recorded instead of panicked on.
+///
+/// `wout!`/`woutinfo!` are used as statements in hundreds of places and cannot return an error
+/// to their caller, but silently losing data output is not acceptable either. So the first
+/// failure is stashed here and `QsvExitCode::report` — the single point every binary's `main`
+/// funnels through — turns it into a message and a non-zero exit.
+///
+/// Diagnostic writes (stderr) deliberately do NOT set this.
+pub static WRITE_ERROR: OnceLock<String> = OnceLock::new();
+
+/// Record a failed data-stream write. Only the FIRST is kept: whatever breaks one write
+/// (a full device, a closed fd) breaks every subsequent one too, and one accurate message
+/// beats several thousand identical ones.
+pub fn record_write_error(stream: &str, e: &io::Error) {
+    let _ = WRITE_ERROR.set(format!("error writing to {stream}: {e}"));
+}
+
 #[repr(u8)]
 pub enum QsvExitCode {
     Good           = 0,
@@ -136,9 +168,65 @@ pub enum QsvExitCode {
     Warning        = 255,
 }
 
+/// The status a run should actually report, given whether a data-stream write failed.
+///
+/// A run that would otherwise have SUCCEEDED must not claim success when its output never
+/// made it; an already-failing run keeps its more specific code. Split out from `report` so
+/// the promotion rule is testable without a real `ExitCode` or the process-global
+/// `WRITE_ERROR`.
+const fn effective_exit_code(code: u8, had_write_error: bool) -> u8 {
+    if had_write_error && code == QsvExitCode::Good as u8 {
+        QsvExitCode::Bad as u8
+    } else {
+        code
+    }
+}
+
 impl Termination for QsvExitCode {
     fn report(self) -> ExitCode {
-        ExitCode::from(self as u8)
+        // Surface a data-stream write failure that `wout!`/`woutinfo!` recorded rather than
+        // panicked on. This is the one place all three binaries' `main` funnels through, so
+        // the check cannot be forgotten by a new exit path.
+        let write_error = WRITE_ERROR.get();
+        if let Some(err) = write_error {
+            use std::io::Write;
+
+            log::error!("{err}");
+            let _ = writeln!(&mut io::stderr(), "{err}");
+        }
+        ExitCode::from(effective_exit_code(self as u8, write_error.is_some()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{QsvExitCode, effective_exit_code};
+
+    // A failed data write must never be reported as success — and must never mask a more
+    // specific failure that already happened.
+    #[test]
+    fn a_failed_data_write_promotes_only_a_successful_run() {
+        // clean run, working stdout => unchanged
+        assert_eq!(
+            effective_exit_code(QsvExitCode::Good as u8, false),
+            QsvExitCode::Good as u8
+        );
+        // clean run whose output never landed => must fail
+        assert_eq!(
+            effective_exit_code(QsvExitCode::Good as u8, true),
+            QsvExitCode::Bad as u8
+        );
+        // an already-failing run keeps its own, more informative code
+        for code in [
+            QsvExitCode::IncorrectUsage,
+            QsvExitCode::NetworkError,
+            QsvExitCode::OutOfMemory,
+            QsvExitCode::EncodingError,
+            QsvExitCode::Warning,
+        ] {
+            let code = code as u8;
+            assert_eq!(effective_exit_code(code, true), code);
+        }
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -271,13 +271,19 @@ pub fn bytes_to_cow_str(c: &[u8]) -> std::borrow::Cow<'_, str> {
 /// Does this panic payload come from Rust's own print machinery?
 ///
 /// `println!`/`eprintln!` go through `std::io::_print`, which PANICS on a write error rather
-/// than returning it — `panic!("failed printing to {label}: {e}")`. That is an I/O failure,
-/// not a qsv bug, and it is not reachable from qsv's own `wout!`/`werr!` macros (they handle
-/// their `Result`). Kept as a free function so the classification is unit-testable without
+/// than returning it — `panic!("failed printing to {label}: {e}")` (`library/std/src/io/
+/// stdio.rs`, unchanged across every toolchain checked). That is an I/O failure, not a qsv
+/// bug, and it is not reachable from qsv's own `wout!`/`werr!` macros (they handle their
+/// `Result`). Kept as a free function so the classification is unit-testable without
 /// provoking a real panic.
+///
+/// The trailing `": "` is part of that format string and is matched DELIBERATELY: without it
+/// the prefix would also swallow any future panic merely beginning "failed printing to
+/// stdout…", and a false positive here costs a real bug its crash report. Matching the full
+/// literal prefix costs nothing, since std always emits the separator.
 fn is_io_print_panic(payload: &str) -> bool {
-    payload.starts_with("failed printing to stdout")
-        || payload.starts_with("failed printing to stderr")
+    payload.starts_with("failed printing to stdout: ")
+        || payload.starts_with("failed printing to stderr: ")
 }
 
 /// The panic payload as a string, covering both `panic!("literal")` (`&str`) and
@@ -5418,6 +5424,14 @@ mod tests {
             "assertion failed: failed printing to stdout"
         ));
         assert!(!is_io_print_panic("failed printing to a file"));
+
+        // the separator is matched too, so a hypothetical future panic that merely BEGINS
+        // the same way keeps its crash report rather than being mistaken for a write failure
+        assert!(!is_io_print_panic(
+            "failed printing to stdout buffer invariant violated"
+        ));
+        assert!(!is_io_print_panic("failed printing to stdout"));
+        assert!(!is_io_print_panic("failed printing to stderr, somehow"));
     }
 
     /// A non-2xx response must be an ERROR, never a file.

--- a/src/util.rs
+++ b/src/util.rs
@@ -37,7 +37,7 @@ use zip::read::root_dir_common_filter;
 #[cfg(feature = "polars")]
 use crate::cmd::count::polars_count_input;
 use crate::{
-    CURRENT_COMMAND, CliError, CliResult,
+    CURRENT_COMMAND, CliError, CliResult, QsvExitCode,
     cmd::stats::{JsonTypes, STATSDATA_TYPES_MAP, StatsData},
     config,
     config::{
@@ -268,6 +268,28 @@ pub fn bytes_to_cow_str(c: &[u8]) -> std::borrow::Cow<'_, str> {
     }
 }
 
+/// Does this panic payload come from Rust's own print machinery?
+///
+/// `println!`/`eprintln!` go through `std::io::_print`, which PANICS on a write error rather
+/// than returning it — `panic!("failed printing to {label}: {e}")`. That is an I/O failure,
+/// not a qsv bug, and it is not reachable from qsv's own `wout!`/`werr!` macros (they handle
+/// their `Result`). Kept as a free function so the classification is unit-testable without
+/// provoking a real panic.
+fn is_io_print_panic(payload: &str) -> bool {
+    payload.starts_with("failed printing to stdout")
+        || payload.starts_with("failed printing to stderr")
+}
+
+/// The panic payload as a string, covering both `panic!("literal")` (`&str`) and
+/// `panic!("{}", fmt)` (`String`).
+fn panic_payload_str<'a>(info: &'a std::panic::PanicHookInfo<'_>) -> Option<&'a str> {
+    let payload = info.payload();
+    payload
+        .downcast_ref::<&str>()
+        .copied()
+        .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+}
+
 pub fn qsv_custom_panic() {
     setup_panic!(
         human_panic::Metadata::new(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"))
@@ -275,6 +297,31 @@ pub fn qsv_custom_panic() {
             .homepage("https://qsv.dathere.com")
             .support("- Open a GitHub issue at https://github.com/dathere/qsv/issues")
     );
+
+    // Intercept the ONE panic shape that is an I/O failure rather than a bug: a failed
+    // `println!`/`eprintln!`. Left alone, it reaches the user through human_panic as "qsv had
+    // a problem and crashed", with a crash report to file — which is exactly what issue #2661
+    // reported (`qsv sniff --json | jaq <bad filter>`) and what #4516 tracks for the
+    // remaining cases (a full disk, a closed fd).
+    //
+    // Deliberately NARROW: only this known payload prefix is intercepted, so a genuine qsv
+    // panic still gets the full crash report. This does not replace `reset_sigpipe` — on Unix
+    // a closed PIPE never reaches here at all, since SIGPIPE is SIG_DFL (see #2664), and that
+    // must stay that way.
+    //
+    // In a debug build `setup_panic!` installs nothing, so this wraps the default hook
+    // instead; the interception behaves identically either way.
+    let previous_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        if let Some(payload) = panic_payload_str(info)
+            && is_io_print_panic(payload)
+        {
+            // Best-effort: the stream we are complaining about may be the broken one.
+            let _ = writeln!(&mut std::io::stderr(), "{payload}");
+            std::process::exit(QsvExitCode::Bad as i32);
+        }
+        previous_hook(info);
+    }));
 }
 
 fn default_user_agent() -> String {
@@ -5343,6 +5390,35 @@ mod tests {
     // only used by the hash_blake3_file tests, which are gated out of qsvlite
     #[cfg(not(feature = "lite"))]
     use std::io::Write;
+
+    use super::is_io_print_panic;
+
+    // The panic-hook guard must intercept a failed `println!`/`eprintln!` (an I/O failure)
+    // while leaving every genuine qsv panic on the human_panic crash-report path. Matching is
+    // deliberately narrow, so both directions matter — a false positive here would swallow a
+    // real bug report.
+    #[test]
+    fn io_print_panics_are_recognized_and_nothing_else_is() {
+        // the exact shapes std emits (issue #2661 reported the first one verbatim)
+        assert!(is_io_print_panic(
+            "failed printing to stdout: Broken pipe (os error 32)"
+        ));
+        assert!(is_io_print_panic(
+            "failed printing to stderr: No space left on device (os error 28)"
+        ));
+
+        // a genuine qsv panic must still reach the crash report
+        assert!(!is_io_print_panic(
+            "called `Option::unwrap()` on a `None` value"
+        ));
+        assert!(!is_io_print_panic("index out of bounds: the len is 3"));
+        assert!(!is_io_print_panic("attempt to divide by zero"));
+        // near-misses: the prefix is anchored, so a message merely MENTIONING it is a bug
+        assert!(!is_io_print_panic(
+            "assertion failed: failed printing to stdout"
+        ));
+        assert!(!is_io_print_panic("failed printing to a file"));
+    }
 
     /// A non-2xx response must be an ERROR, never a file.
     ///


### PR DESCRIPTION
Resolves #4516.

### The correction that shaped this PR

#4516 (which I filed) attributed the crash-report-on-write-failure to qsv's `w*!` macros.
That is only half right, and the half it misses is the important one.

#2661's backtrace lands in `library/std/src/io/stdio.rs` with `failed printing to stdout` —
that panic message exists only in Rust's `print_to`, which the `print!`/`println!`/`eprint!`/
`eprintln!` family uses. The reported repro was `qsv sniff --json | jaq <bad filter>`, and
that command's output call is a **`println!`** (`src/cmd/sniff.rs:1196`), not a `wout!`.

So there are two independent routes to the crash report, and fixing only the macros — as
#4516 originally proposed — would have left the one that caused #2661 untouched:

| route | sites | panics | reachable from `clitypes.rs`? |
|---|---|---|---|
| `w*!` macros | 219 | qsv's own `.unwrap()` | yes |
| `println!` / `print!` | 201 | inside Rust's stdio | no |
| `eprintln!` / `eprint!` | 134 | inside Rust's stdio | no |

### What this does

**1. The macros stop unwrapping.** The two stream classes are treated differently on purpose:

- **stdout carries data.** Losing it silently is not acceptable, so the first failure is
  recorded in a `WRITE_ERROR` `OnceLock` (mirroring the existing `CURRENT_COMMAND` static) and
  `QsvExitCode::report` — the single point all three binaries' `main` funnels through — prints
  it and fails a run that would otherwise have reported success. Only the first is kept: a full
  disk fails every subsequent write too.
- **stderr carries diagnostics.** A warning that cannot be delivered must not change the
  outcome of an otherwise good run, so it is dropped. The `log` record, emitted before the
  write, survives either way.

Routing through `report` rather than `process::exit` preserves `util::log_end`.

**2. `qsv_custom_panic` gains a narrow guard** for the 335 sites the macros can't reach. It
wraps the panic hook and intercepts exactly one payload shape — `failed printing to
std{out,err}` — degrading it to a one-line error and a non-zero exit. Every other panic still
gets the full human_panic crash report. In a debug build `setup_panic!` installs nothing, so
this wraps the default hook; behavior is identical either way.

### `reset_sigpipe` is deliberately untouched

`SIG_DFL` is load-bearing. It is the #2664 fix for #2661 and is what makes `qsv ... | head`
exit quietly like any Unix CLI. Reverting it would reintroduce the crash-report wall for the
commonest case of all. On Unix a closed pipe therefore never reaches the new hook at all.

### Testing

- Full suite: **3811 passed, 0 failed** (`cargo test -F all_features`) — worth running in full
  here, since 219 call sites change behavior.
- New unit tests: the panic classifier in both directions (a real `Option::unwrap` panic and
  near-misses like `assertion failed: failed printing to stdout` must NOT be intercepted), and
  the exit-code promotion rule (a failed data write promotes `Good` to `Bad` but never masks a
  more specific failure).
- `cargo clippy -F all_features --tests` clean; `scripts/double-run-check.py --check` OK.
- All three binaries build: `qsv` (all_features), `qsvlite` (lite), `qsvdp` (datapusher_plus).

**Honest gap:** I could not reproduce a real `ENOSPC`/`EBADF` write failure end-to-end on
macOS — there is no `/dev/full`, and the `>&-` and `1>&0` shell tricks don't substitute
(closing fd 1 lets the next `open()` claim it; the read-only-fd dup didn't take). The
promotion rule is unit-tested via a pure function instead of the process-global, but the
"a failing write actually reaches the recorder" link is covered only by inspection. On Linux
`qsv count data.csv > /dev/full` should exercise it directly, and is worth a manual check
before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
