### PR TITLE
feat(get): show entry age and staleness in cache-list

### DIFF
--- a/src/cmd/get.rs
+++ b/src/cmd/get.rs
@@ -422,22 +422,31 @@ fn run_cache_list(cache_dir: &str, json: bool, info: bool, verify: bool) -> CliR
     }
 
     println!(
-        "{:<24} {:>10} {:>12} {:>12} {:>4} {:<5} {:<16} SOURCE",
-        "NAME", "RECORDS", "COMP", "UNCOMP", "IDX", "DELIM", "BLAKE3"
+        "{:<24} {:>10} {:>12} {:>12} {:>4} {:<5} {:>5} {:<5} {:<16} SOURCE",
+        "NAME", "RECORDS", "COMP", "UNCOMP", "IDX", "DELIM", "AGE", "STALE", "BLAKE3"
     );
     for e in &entries {
         let records = e
             .record_count
             .map_or_else(|| "?".to_string(), |c| c.to_string());
         let b3 = &e.blake3[..e.blake3.len().min(16)];
+        // Staleness comes from the same predicate the refresh path gates on, so the listing
+        // cannot claim an entry is fresh that the next `dc:` read would re-fetch.
+        let age_secs = diskcache::entry_age_secs(e);
         println!(
-            "{:<24} {:>10} {:>12} {:>12} {:>4} {:<5} {:<16} {}",
+            "{:<24} {:>10} {:>12} {:>12} {:>4} {:<5} {:>5} {:<5} {:<16} {}",
             truncate(&e.logical_name, 24),
             records,
             e.size_compressed,
             e.size_uncompressed,
             if e.indexed { "yes" } else { "no" },
             delim_label(e.sniffed.as_ref()),
+            util::fmt_duration_compact(age_secs),
+            if diskcache::is_due_for_refresh(e, age_secs) {
+                "yes"
+            } else {
+                "no"
+            },
             b3,
             e.source_uri,
         );

--- a/src/diskcache.rs
+++ b/src/diskcache.rs
@@ -2916,9 +2916,16 @@ mod rich {
         Ok(resolved.csv_path)
     }
 
-    /// How long ago this entry was last fetched, in seconds.
+    /// How long ago this entry was last fetched, in seconds. Never negative.
+    ///
+    /// Clamped at zero because `downloaded_at` can legitimately be in the FUTURE: a backward
+    /// clock step (NTP correction, a resumed VM), or metadata written by a machine whose clock
+    /// ran ahead of this one — `QSV_CACHE_DIR` may point at a shared mount. Unclamped, that
+    /// yields a negative age, which `cache-list` renders as nonsense like "-30s" and which
+    /// reads as "not yet due" even for a zero TTL. Treating a future timestamp as "just
+    /// fetched" is the sane reading, and keeps both consumers honest.
     pub fn entry_age_secs(meta: &CacheEntry) -> i64 {
-        unix_now().saturating_sub(meta.downloaded_at)
+        unix_now().saturating_sub(meta.downloaded_at).max(0)
     }
 
     /// Will this entry re-fetch on its next `dc:` use?
@@ -3217,8 +3224,12 @@ mod rich {
         for de in rd.flatten() {
             if de.path().extension().is_some_and(|e| e == "json")
                 && let Ok(e) = load_entry_at(&de.path())
-                // Inclusive: `--older-than 0` prunes everything (age >= 0).
-                && now.saturating_sub(e.meta.downloaded_at) >= older_than_secs
+                // Inclusive: `--older-than 0` prunes everything (age >= 0). Clamped at zero
+                // for the same reason as `entry_age_secs` — a future `downloaded_at` would
+                // otherwise go negative and survive the very sweep documented to take
+                // everything. `now` stays hoisted so all entries are judged against one
+                // instant, which is why this does not just call `entry_age_secs`.
+                && now.saturating_sub(e.meta.downloaded_at).max(0) >= older_than_secs
                 && let Some(kh) = de.path().file_stem().map(|s| s.to_string_lossy().into_owned())
             {
                 stale_keys.push(kh);
@@ -3286,7 +3297,8 @@ mod rich {
         use std::io::Cursor;
 
         use super::{
-            CacheEntry, RefreshPolicy, ckan_auth_hint, emit_preview_reservoir, is_due_for_refresh,
+            CacheEntry, RefreshPolicy, ckan_auth_hint, emit_preview_reservoir, entry_age_secs,
+            is_due_for_refresh, unix_now,
         };
 
         /// A metadata record with only the fields the staleness rule reads.
@@ -3296,6 +3308,28 @@ mod rich {
                 refresh_policy,
                 ..Default::default()
             }
+        }
+
+        // A `downloaded_at` in the FUTURE — a backward clock step, or a cache dir shared with
+        // a machine whose clock ran ahead — must read as "just fetched", not as a negative
+        // age. Unclamped it would print as "-30s" in cache-list, and would read as "not yet
+        // due" even for a zero TTL, which is precisely backwards.
+        #[test]
+        fn a_future_timestamp_reads_as_zero_age_never_negative() {
+            let mut skewed = meta(100, RefreshPolicy::OnStale);
+            skewed.downloaded_at = unix_now() + 3_600;
+            assert_eq!(entry_age_secs(&skewed), 0);
+
+            // and a zero-TTL entry stays due despite the skew
+            let mut skewed_zero_ttl = meta(0, RefreshPolicy::OnStale);
+            skewed_zero_ttl.downloaded_at = unix_now() + 3_600;
+            let age = entry_age_secs(&skewed_zero_ttl);
+            assert!(is_due_for_refresh(&skewed_zero_ttl, age));
+
+            // a normal past timestamp still measures normally
+            let mut normal = meta(100, RefreshPolicy::OnStale);
+            normal.downloaded_at = unix_now() - 300;
+            assert!((295..=305).contains(&entry_age_secs(&normal)));
         }
 
         // THE definition of `dc:` staleness, shared by the refresh path and `cache-list`, so

--- a/src/diskcache.rs
+++ b/src/diskcache.rs
@@ -488,7 +488,12 @@ mod rich {
     }
 
     /// Per-entry metadata recorded in the cache index, surfaced by `cache-list`.
-    #[derive(Serialize, Deserialize, Clone)]
+    ///
+    /// `Default` is derived for TESTS only — it lets a test build a record carrying just the
+    /// fields a rule reads (`..Default::default()`) instead of twenty irrelevant ones. It is
+    /// not a meaningful cache entry and nothing in the cache path constructs one this way; the
+    /// derive changes no serialized representation.
+    #[derive(Serialize, Deserialize, Clone, Default)]
     pub struct CacheEntry {
         /// The `dc:` handle / alias for this entry.
         pub logical_name:       String,
@@ -2911,20 +2916,24 @@ mod rich {
         Ok(resolved.csv_path)
     }
 
-    /// Render a cache entry's age as a compact, human-scale string ("30d", "6h").
-    /// Used only in the stale-refresh warning, where precision beyond one unit is noise —
-    /// the number exists to answer "do I care?", not to be arithmetic.
-    fn fmt_age(secs: i64) -> String {
-        const MINUTE: i64 = 60;
-        const HOUR: i64 = 60 * MINUTE;
-        const DAY: i64 = 24 * HOUR;
+    /// How long ago this entry was last fetched, in seconds.
+    pub fn entry_age_secs(meta: &CacheEntry) -> i64 {
+        unix_now().saturating_sub(meta.downloaded_at)
+    }
 
-        match secs {
-            s if s >= DAY => format!("last fetched {}d ago", s / DAY),
-            s if s >= HOUR => format!("last fetched {}h ago", s / HOUR),
-            s if s >= MINUTE => format!("last fetched {}m ago", s / MINUTE),
-            s => format!("last fetched {s}s ago"),
-        }
+    /// Will this entry re-fetch on its next `dc:` use?
+    ///
+    /// THE definition of `dc:` staleness — `resolve_dc_uncached` gates its refresh on this, and
+    /// `qsv get cache-list` reports it, so the two can never disagree about what "stale" means.
+    /// Takes the age rather than computing it because the refresh path needs the same value for
+    /// its warning message, and two `unix_now()` calls could straddle a second boundary.
+    ///
+    /// Note this is TTL-driven, not policy-driven: `RefreshPolicy::Always` does not make an
+    /// entry due sooner, it only makes the eventual fetch unconditional.
+    pub fn is_due_for_refresh(meta: &CacheEntry, age_secs: i64) -> bool {
+        meta.refresh_policy != RefreshPolicy::Never
+            && meta.ttl_secs >= 0
+            && age_secs >= meta.ttl_secs
     }
 
     /// A hint for the silent `ckan://` refresh failure that is otherwise undiagnosable: the
@@ -2964,79 +2973,75 @@ mod rich {
             ))
         })?;
 
-        // qsv-level staleness: refresh from the original source when past TTL.
-        if entry.meta.refresh_policy != RefreshPolicy::Never && entry.meta.ttl_secs >= 0 {
-            let age = unix_now().saturating_sub(entry.meta.downloaded_at);
-            if age >= entry.meta.ttl_secs {
-                let refresh_opts = GetOptions {
-                    source:         entry.meta.source_uri.clone(),
-                    name:           Some(name.to_string()),
-                    cache_dir:      cache_dir.to_string(),
-                    ttl_secs:       entry.meta.ttl_secs,
-                    refresh_policy: entry.meta.refresh_policy,
-                    compression:    entry.meta.compression,
-                    force:          false,
-                    // Re-resolve a ckan:// entry against the SAME CKAN instance it
-                    // was originally fetched from (the persisted `--ckan-api`),
-                    // falling back to the ambient env / default only for older
-                    // entries that predate this field.
-                    ckan_api_url:   entry
-                        .meta
-                        .ckan_api_url
-                        .clone()
-                        .or_else(|| std::env::var("QSV_CKAN_API").ok())
-                        .or_else(|| Some(DEFAULT_CKAN_API.to_string())),
-                    ckan_token:     std::env::var("QSV_CKAN_TOKEN").ok(),
-                    timeout_secs:   30,
-                    // Replay the persisted store identity (endpoint/region/…) so
-                    // a cloud `dc:` refresh rebuilds the SAME store and resolves
-                    // to the SAME cache entry. Credentials still come from the
-                    // ambient environment (they are never persisted). Empty for
-                    // non-cloud entries.
-                    cloud_opts:     entry
-                        .meta
-                        .cloud_identity
-                        .iter()
-                        .map(|(k, v)| format!("{k}={v}"))
-                        .collect(),
-                };
-                // Best-effort: on refresh failure, fall back to the stale copy but make
-                // the degraded result visible to callers instead of silently succeeding.
-                match get_resource(&refresh_opts) {
-                    Ok(_) => {
-                        if let Some(refreshed) = load_entry_by_name(root, name)? {
-                            entry = refreshed;
-                        }
-                    },
-                    Err(err) => {
-                        // Deliberately NOT `wwarn!`. Every other `wwarn!` call site is in a
-                        // command or in `main`; this one is in a shared path reached by every
-                        // command that reads a `dc:` handle, and the macro ends in
-                        // `writeln!(..).unwrap()`. A write that FAILS here — EBADF from a
-                        // closed fd (`2>&-`), ENOSPC from a full device — must drop the
-                        // warning, not panic a command that was otherwise about to succeed.
-                        //
-                        // This does NOT cover a closed stderr PIPE: `util::reset_sigpipe`
-                        // restores SIG_DFL at startup, so that case kills the process before
-                        // any `Result` comes back, and no error handling here can change it.
-                        // The log record always survives.
-                        use std::io::Write as _;
+        // qsv-level staleness: refresh from the original source when due. `age` is computed
+        // once and reused by both the gate and the warning below.
+        let age = entry_age_secs(&entry.meta);
+        if is_due_for_refresh(&entry.meta, age) {
+            let refresh_opts = GetOptions {
+                source:         entry.meta.source_uri.clone(),
+                name:           Some(name.to_string()),
+                cache_dir:      cache_dir.to_string(),
+                ttl_secs:       entry.meta.ttl_secs,
+                refresh_policy: entry.meta.refresh_policy,
+                compression:    entry.meta.compression,
+                force:          false,
+                // Re-resolve a ckan:// entry against the SAME CKAN instance it
+                // was originally fetched from (the persisted `--ckan-api`),
+                // falling back to the ambient env / default only for older
+                // entries that predate this field.
+                ckan_api_url:   entry
+                    .meta
+                    .ckan_api_url
+                    .clone()
+                    .or_else(|| std::env::var("QSV_CKAN_API").ok())
+                    .or_else(|| Some(DEFAULT_CKAN_API.to_string())),
+                ckan_token:     std::env::var("QSV_CKAN_TOKEN").ok(),
+                timeout_secs:   30,
+                // Replay the persisted store identity (endpoint/region/…) so
+                // a cloud `dc:` refresh rebuilds the SAME store and resolves
+                // to the SAME cache entry. Credentials still come from the
+                // ambient environment (they are never persisted). Empty for
+                // non-cloud entries.
+                cloud_opts:     entry
+                    .meta
+                    .cloud_identity
+                    .iter()
+                    .map(|(k, v)| format!("{k}={v}"))
+                    .collect(),
+            };
+            // Best-effort: on refresh failure, fall back to the stale copy but make
+            // the degraded result visible to callers instead of silently succeeding.
+            match get_resource(&refresh_opts) {
+                Ok(_) => {
+                    if let Some(refreshed) = load_entry_by_name(root, name)? {
+                        entry = refreshed;
+                    }
+                },
+                Err(err) => {
+                    // Deliberately NOT `wwarn!`. Every other `wwarn!` call site is in a
+                    // command or in `main`; this one is in a shared path reached by every
+                    // command that reads a `dc:` handle, and the macro ends in
+                    // `writeln!(..).unwrap()`. A write that FAILS here — EBADF from a
+                    // closed fd (`2>&-`), ENOSPC from a full device — must drop the
+                    // warning, not panic a command that was otherwise about to succeed.
+                    //
+                    // This does NOT cover a closed stderr PIPE: `util::reset_sigpipe`
+                    // restores SIG_DFL at startup, so that case kills the process before
+                    // any `Result` comes back, and no error handling here can change it.
+                    // The log record always survives.
+                    use std::io::Write as _;
 
-                        let msg = format!(
-                            "get: refresh of stale cache entry '{}' ({}) from '{}' failed: {err}; \
-                             using cached copy{}",
-                            name,
-                            fmt_age(age),
-                            refresh_opts.source,
-                            ckan_auth_hint(
-                                &refresh_opts.source,
-                                refresh_opts.ckan_token.as_deref()
-                            )
-                        );
-                        log::warn!("{msg}");
-                        let _ = writeln!(std::io::stderr(), "{msg}");
-                    },
-                }
+                    let msg = format!(
+                        "get: refresh of stale cache entry '{}' (last fetched {} ago) from '{}' \
+                         failed: {err}; using cached copy{}",
+                        name,
+                        util::fmt_duration_compact(age),
+                        refresh_opts.source,
+                        ckan_auth_hint(&refresh_opts.source, refresh_opts.ckan_token.as_deref())
+                    );
+                    log::warn!("{msg}");
+                    let _ = writeln!(std::io::stderr(), "{msg}");
+                },
             }
         }
 
@@ -3280,21 +3285,44 @@ mod rich {
     mod tests {
         use std::io::Cursor;
 
-        use super::{ckan_auth_hint, emit_preview_reservoir, fmt_age};
+        use super::{
+            CacheEntry, RefreshPolicy, ckan_auth_hint, emit_preview_reservoir, is_due_for_refresh,
+        };
 
-        // The stale-refresh warning reports ONE unit, the largest that fits, so the unit
-        // boundaries are the whole contract.
+        /// A metadata record with only the fields the staleness rule reads.
+        fn meta(ttl_secs: i64, refresh_policy: RefreshPolicy) -> CacheEntry {
+            CacheEntry {
+                ttl_secs,
+                refresh_policy,
+                ..Default::default()
+            }
+        }
+
+        // THE definition of `dc:` staleness, shared by the refresh path and `cache-list`, so
+        // the two cannot disagree about which entries will re-fetch.
         #[test]
-        fn fmt_age_picks_the_largest_fitting_unit() {
-            assert_eq!(fmt_age(0), "last fetched 0s ago");
-            assert_eq!(fmt_age(59), "last fetched 59s ago");
-            assert_eq!(fmt_age(60), "last fetched 1m ago");
-            assert_eq!(fmt_age(3_599), "last fetched 59m ago");
-            assert_eq!(fmt_age(3_600), "last fetched 1h ago");
-            assert_eq!(fmt_age(86_399), "last fetched 23h ago");
-            assert_eq!(fmt_age(86_400), "last fetched 1d ago");
-            // the `qsv get` default TTL
-            assert_eq!(fmt_age(2_419_200), "last fetched 28d ago");
+        fn refresh_is_due_only_past_a_non_negative_ttl_under_a_refreshing_policy() {
+            let m = meta(100, RefreshPolicy::OnStale);
+            assert!(!is_due_for_refresh(&m, 99), "inside the TTL: not due");
+            assert!(is_due_for_refresh(&m, 100), "AT the TTL: due");
+            assert!(is_due_for_refresh(&m, 101), "past the TTL: due");
+
+            // `always` governs HOW the fetch is made, not WHETHER one is due
+            let always = meta(100, RefreshPolicy::Always);
+            assert!(!is_due_for_refresh(&always, 99));
+            assert!(is_due_for_refresh(&always, 100));
+
+            // `never` pins the entry no matter how old it gets
+            let never = meta(100, RefreshPolicy::Never);
+            assert!(!is_due_for_refresh(&never, 1_000_000));
+
+            // a negative TTL means "never expire", even under a refreshing policy
+            let pinned = meta(-1, RefreshPolicy::OnStale);
+            assert!(!is_due_for_refresh(&pinned, 1_000_000));
+
+            // a zero TTL is due on every resolution
+            let zero = meta(0, RefreshPolicy::OnStale);
+            assert!(is_due_for_refresh(&zero, 0));
         }
 
         // The hint takes the refresh's own token rather than reading the environment, so every

--- a/src/util.rs
+++ b/src/util.rs
@@ -180,6 +180,29 @@ const WHITESPACE_MARKERS: &[(char, &str)] = &[
     ('\u{200B}', "《zwsp》"),  // zero width space
 ];
 
+/// Render a duration in seconds as a compact, single-unit string: "28d", "6h", "45m", "3s".
+///
+/// Deliberately ONE unit, the largest that fits, and deliberately WORDLESS. Callers that want a
+/// phrase build it around this ("last fetched {} ago"); callers that want a table cell use it
+/// as-is. An earlier version baked the phrase in, which made it unusable as a column value.
+///
+/// Precision beyond one unit is noise for both consumers — the number exists to answer "do I
+/// care?", not to be arithmetic. Days are the largest unit: `qsv get --older-than` also accepts
+/// weeks on INPUT, but "28d" reads more plainly in a cache listing than "4w", and no caller
+/// round-trips this back through that parser.
+pub fn fmt_duration_compact(secs: i64) -> String {
+    const MINUTE: i64 = 60;
+    const HOUR: i64 = 60 * MINUTE;
+    const DAY: i64 = 24 * HOUR;
+
+    match secs {
+        s if s >= DAY => format!("{}d", s / DAY),
+        s if s >= HOUR => format!("{}h", s / HOUR),
+        s if s >= MINUTE => format!("{}m", s / MINUTE),
+        s => format!("{s}s"),
+    }
+}
+
 pub fn reset_sigpipe() {
     cfg_select! {
         unix => unsafe {
@@ -5397,7 +5420,22 @@ mod tests {
     #[cfg(not(feature = "lite"))]
     use std::io::Write;
 
-    use super::is_io_print_panic;
+    use super::{fmt_duration_compact, is_io_print_panic};
+
+    // One unit, the largest that fits, so the unit boundaries are the whole contract. Shared by
+    // the stale-refresh warning and the `qsv get cache-list` AGE column.
+    #[test]
+    fn fmt_duration_compact_picks_the_largest_fitting_unit() {
+        assert_eq!(fmt_duration_compact(0), "0s");
+        assert_eq!(fmt_duration_compact(59), "59s");
+        assert_eq!(fmt_duration_compact(60), "1m");
+        assert_eq!(fmt_duration_compact(3_599), "59m");
+        assert_eq!(fmt_duration_compact(3_600), "1h");
+        assert_eq!(fmt_duration_compact(86_399), "23h");
+        assert_eq!(fmt_duration_compact(86_400), "1d");
+        // the `qsv get` default TTL — days are the largest unit, so this is not "4w"
+        assert_eq!(fmt_duration_compact(2_419_200), "28d");
+    }
 
     // The panic-hook guard must intercept a failed `println!`/`eprintln!` (an I/O failure)
     // while leaving every genuine qsv panic on the human_panic crash-report path. Matching is

--- a/tests/test_get.rs
+++ b/tests/test_get.rs
@@ -2208,3 +2208,107 @@ fn get_dc_approx_cardinality_does_not_take_all_unique_shortcut() {
          input:\n{got}"
     );
 }
+
+// Issue #4515: `cache-list`'s human-readable table reported no age and no TTL, so there was no
+// way to see how stale an entry was, or which ones would re-fetch, without dropping to --json.
+//
+// The STALE column is driven by `diskcache::is_due_for_refresh` — the SAME predicate the
+// refresh path gates on — so this also guards against the listing and the refresh disagreeing.
+//
+// Each entry needs DISTINCT content: the cache is content-addressed, so two names for the same
+// bytes are one entry, and TTL/policy are entry-level — setting a TTL through one alias would
+// silently apply to the other.
+#[test]
+fn get_cache_list_reports_age_and_staleness() {
+    let wrk = Workdir::new("get_cache_list_reports_age_and_staleness");
+    let cache_dir = wrk.path("qsvcache");
+    wrk.create_from_string("fresh_src.csv", "a,b\n1,2\n");
+    wrk.create_from_string("due_src.csv", "x,y\n9,9\n");
+    wrk.create_from_string("pinned_src.csv", "p,q\n7,7\n");
+
+    // default TTL (28d) => nowhere near due
+    let mut fresh = wrk.command("get");
+    fresh
+        .env("QSV_CACHE_DIR", &cache_dir)
+        .args(["--name", "fresh.csv"])
+        .arg("fresh_src.csv");
+    wrk.assert_success(&mut fresh);
+
+    // zero TTL => due on every resolution
+    let mut due = wrk.command("get");
+    due.env("QSV_CACHE_DIR", &cache_dir)
+        .args(["--name", "due.csv", "--ttl", "0"])
+        .arg("due_src.csv");
+    wrk.assert_success(&mut due);
+
+    // negative TTL => never expires, however old it gets
+    let mut pinned = wrk.command("get");
+    pinned
+        .env("QSV_CACHE_DIR", &cache_dir)
+        .args(["--name", "pinned.csv", "--ttl", "-1"])
+        .arg("pinned_src.csv");
+    wrk.assert_success(&mut pinned);
+
+    let mut list = wrk.command("get");
+    list.env("QSV_CACHE_DIR", &cache_dir).arg("cache-list");
+    let out = wrk.output(&mut list);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        out.status.success(),
+        "cache-list exited non-zero:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        stdout.contains("AGE") && stdout.contains("STALE"),
+        "cache-list header should carry AGE and STALE columns:\n{stdout}"
+    );
+
+    // Read the columns BY POSITION, never by substring: IDX is also "yes"/"no", so a bare
+    // `contains(" yes ")` would match that instead and assert nothing about staleness.
+    // Columns: NAME RECORDS COMP UNCOMP IDX DELIM AGE STALE BLAKE3 SOURCE
+    let cells = |name: &str| -> Vec<String> {
+        let line = stdout
+            .lines()
+            .find(|l| l.starts_with(name))
+            .unwrap_or_else(|| panic!("no cache-list row for {name}:\n{stdout}"));
+        line.split_whitespace().map(str::to_string).collect()
+    };
+    let age_of = |name: &str| cells(name)[6].clone();
+    let stale_of = |name: &str| cells(name)[7].clone();
+
+    // The AGE VALUE is not asserted: these entries are seconds old, but under a loaded full
+    // suite run the elapsed time drifts, and pinning it to "0s"/"1s" made this test flaky.
+    // `fmt_duration_compact`'s output is unit-tested directly; here it only has to be a
+    // well-formed duration in the right column.
+    for name in ["fresh.csv", "due.csv", "pinned.csv"] {
+        let age = age_of(name);
+        let (digits, unit) = age.split_at(age.len() - 1);
+        assert!(
+            !digits.is_empty()
+                && digits.chars().all(|c| c.is_ascii_digit())
+                && ["s", "m", "h", "d"].contains(&unit),
+            "{name} AGE should be a compact duration like \"3s\"; got {age:?}"
+        );
+    }
+
+    // a zero TTL is due immediately; the default and a pinned entry are not
+    assert_eq!(
+        stale_of("due.csv"),
+        "yes",
+        "a --ttl 0 entry must be reported STALE:\n{}",
+        stdout
+    );
+    assert_eq!(
+        stale_of("fresh.csv"),
+        "no",
+        "a default-TTL entry just fetched must not be STALE:\n{}",
+        stdout
+    );
+    assert_eq!(
+        stale_of("pinned.csv"),
+        "no",
+        "a --ttl -1 entry never expires, so it must not be STALE:\n{}",
+        stdout
+    );
+}


### PR DESCRIPTION
Resolves #4515.

`cache-list`'s human-readable table showed no age and no TTL, so there was no way to see how
stale an entry was — or which entries would re-fetch on next use — without dropping to
`--json`. Presentation only: no new persisted field, no change to the `--json` shape.

```
NAME              RECORDS    COMP   UNCOMP  IDX DELIM   AGE STALE BLAKE3           SOURCE
due.csv                 1      17        8  yes csv      0s yes   b91d33eb3dac5082 /tmp/two.csv
fresh.csv               1      17        8  yes csv      0s no    c42223f1fbf292f6 /tmp/one.csv
pinned.csv              1      17        8  yes csv      0s no    933aad3ab0363f59 /tmp/three.csv
```

### `fmt_age` → `util::fmt_duration_compact`

Moved as suggested, but the move only makes sense together with a split. The old `fmt_age`
baked in `"last fetched {} ago"` — warning phrasing, not a duration, and unusable as a table
cell. It now returns a bare `"28d"`/`"6h"` and the warning site composes the phrase around it.

That is what earns `util.rs`: the helper no longer carries cache-specific meaning, and `util.rs`
is compiled into every binary while diskcache's rich tier is `get`-gated. Moving the old
version would just have relocated a cache-specific string.

Days stay the largest unit. `--older-than` also accepts **weeks** on input, but `28d` reads more
plainly in a listing than `4w`, and nothing round-trips this back through that parser. The
asymmetry noted in #4515 is therefore left in place deliberately — recorded in the doc comment
so it isn't "fixed" later by accident.

### STALE is not a second opinion

The obvious risk with a STALE column is inventing a second definition of staleness that drifts
from the real one. So `is_due_for_refresh` is **extracted from `resolve_dc_uncached`'s own
gate**, and both call it — the listing cannot report an entry fresh that the next `dc:` read
would re-fetch. It takes the age rather than computing it, because the refresh path needs the
same value for its warning message and two `unix_now()` calls could straddle a second boundary.

### Tests

- The staleness rule directly: TTL boundary (`99`/`100`/`101`), each refresh policy (`always`
  does not make an entry due *sooner*; `never` pins it forever), and negative/zero TTLs.
- `fmt_duration_compact`'s unit boundaries, including the 28d default TTL.
- A `cache-list` integration test over three entries — default TTL, `--ttl 0`, `--ttl -1`.

Two things that test does deliberately, both of which bit me while writing it:

1. **Distinct content per entry.** The cache is content-addressed and TTL/policy are
   entry-level, so three names for the same bytes are *one* record — my first manual check
   showed `--ttl 0` as not-stale for exactly this reason, and it looked like a code bug.
2. **Columns read by position, not substring.** IDX is also `yes`/`no`, so `contains(" yes ")`
   matches *that* and asserts nothing about staleness. My first version had this bug and passed
   anyway.

It also does not assert the age *value* — pinning it to `"0s"` made it flaky under a loaded
full-suite run (it failed once at ~192s in, passed standalone). The formatter is unit-tested on
its own; the integration test only checks the cell is a well-formed duration in the right column.

`CacheEntry` gains a `Default` derive, used only so a test can build a record with just the
fields a rule reads. No serialized representation changes.

### Validation

- Full suite: **1046 unit + 3814 integration passed, 0 failed**, run twice (once to catch the
  flake above, once to confirm it was gone).
- `cargo clippy -F all_features --tests` clean; `scripts/double-run-check.py --check` OK.
- USAGE is untouched (it never enumerated the columns), so no help-doc or MCP-skill-JSON
  regeneration is triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
