### PR TITLE
viz: headline the region-deduped KPI total instead of omitting the tile

### DIFF
--- a/src/cmd/locales/de.yml
+++ b/src/cmd/locales/de.yml
@@ -257,6 +257,7 @@ viz:
     category_flow: "Kategorienfluss: %{q_dims}"
     kpi_mean: "Mittelwert von %{q_label}"
     kpi_total: "Summe von %{q_label}"
+    kpi_unattributed: "%{q_n} von %{q_total} Zeilen nicht zugeordnet"
     cyclic_records_by: "Datensätze nach %{q_axis} (%{q_date})"
     cyclic_hour_of_day: "Stunde des Tages"
     cyclic_day_of_week: "Wochentag"

--- a/src/cmd/locales/en.yml
+++ b/src/cmd/locales/en.yml
@@ -475,6 +475,12 @@ viz:
     # verdict, never by the locale.
     kpi_mean: "Mean %{q_label}"
     kpi_total: "Total %{q_label}"
+    # Suffix appended to a KPI tile's label when the measure is REGION-LEVEL and some
+    # rows carried no owning region, so its collapsed total covers only the regions
+    # that could be identified (issue #4534).
+    # Phrased as a count-of-total for the same reason as `denom_excluded` above: it
+    # stays grammatical at n = 1 without needing a plural rule.
+    kpi_unattributed: "%{q_n} of %{q_total} rows unattributed"
     cyclic_records_by: "Records by %{q_axis} (%{q_date})"
     cyclic_hour_of_day: "hour of day"
     cyclic_day_of_week: "day of week"

--- a/src/cmd/locales/es.yml
+++ b/src/cmd/locales/es.yml
@@ -268,6 +268,7 @@ viz:
     category_flow: "Flujo de categorías: %{q_dims}"
     kpi_mean: "Media de %{q_label}"
     kpi_total: "Total de %{q_label}"
+    kpi_unattributed: "%{q_n} de %{q_total} filas sin asignar"
     cyclic_records_by: "Registros por %{q_axis} (%{q_date})"
     cyclic_hour_of_day: "hora del día"
     cyclic_day_of_week: "día de la semana"

--- a/src/cmd/locales/fr.yml
+++ b/src/cmd/locales/fr.yml
@@ -257,6 +257,7 @@ viz:
     category_flow: "Flux de catégories : %{q_dims}"
     kpi_mean: "Moyenne de %{q_label}"
     kpi_total: "Total de %{q_label}"
+    kpi_unattributed: "%{q_n} sur %{q_total} lignes non attribuées"
     cyclic_records_by: "Enregistrements par %{q_axis} (%{q_date})"
     cyclic_hour_of_day: "heure de la journée"
     cyclic_day_of_week: "jour de la semaine"

--- a/src/cmd/locales/it.yml
+++ b/src/cmd/locales/it.yml
@@ -257,6 +257,7 @@ viz:
     category_flow: "Flusso delle categorie: %{q_dims}"
     kpi_mean: "Media di %{q_label}"
     kpi_total: "Totale di %{q_label}"
+    kpi_unattributed: "%{q_n} su %{q_total} righe non attribuite"
     cyclic_records_by: "Record per %{q_axis} (%{q_date})"
     cyclic_hour_of_day: "ora del giorno"
     cyclic_day_of_week: "giorno della settimana"

--- a/src/cmd/locales/ja.yml
+++ b/src/cmd/locales/ja.yml
@@ -257,6 +257,7 @@ viz:
     category_flow: "カテゴリの流れ: %{q_dims}"
     kpi_mean: "%{q_label} の平均"
     kpi_total: "%{q_label} の合計"
+    kpi_unattributed: "%{q_total} 行中 %{q_n} 行が未割り当て"
     cyclic_records_by: "%{q_axis} 別のレコード数(%{q_date})"
     cyclic_hour_of_day: "時刻"
     cyclic_day_of_week: "曜日"

--- a/src/cmd/locales/pt-BR.yml
+++ b/src/cmd/locales/pt-BR.yml
@@ -263,6 +263,7 @@ viz:
     category_flow: "Fluxo de categorias: %{q_dims}"
     kpi_mean: "Média de %{q_label}"
     kpi_total: "Total de %{q_label}"
+    kpi_unattributed: "%{q_n} de %{q_total} linhas não atribuídas"
     cyclic_records_by: "Registros por %{q_axis} (%{q_date})"
     cyclic_hour_of_day: "hora do dia"
     cyclic_day_of_week: "dia da semana"

--- a/src/cmd/locales/zh-CN.yml
+++ b/src/cmd/locales/zh-CN.yml
@@ -264,6 +264,7 @@ viz:
     category_flow: "类别流向: %{q_dims}"
     kpi_mean: "%{q_label} 平均值"
     kpi_total: "%{q_label} 总计"
+    kpi_unattributed: "%{q_total} 行中有 %{q_n} 行未归属"
     cyclic_records_by: "按 %{q_axis} 的记录数(%{q_date})"
     cyclic_hour_of_day: "一天中的小时"
     cyclic_day_of_week: "星期"

--- a/src/cmd/viz.rs
+++ b/src/cmd/viz.rs
@@ -30753,12 +30753,93 @@ fn is_repeated_region_level(
     stats.get(owner).is_some_and(|s| s.cardinality < row_count)
 }
 
+/// One measure's result from the region-dedupe row pass (issue #4534).
+///
+/// A REGION-LEVEL measure repeats identically on every row of its region, so the stats cache's
+/// row-wise `sum` is a MULTIPLE of the real one. Collapsing to one value per owning region is the
+/// only way for a dataset-wide headline to state it truthfully, and it needs the data: the cache
+/// carries no `(region, value)` pair count, which is exactly the limit
+/// [`owning_region_idx`]'s cardinality guard documents.
+#[derive(Clone, Copy, Debug, Default)]
+struct RegionDedupe {
+    /// Σ, over the owning regions that could be identified, of that region's single value.
+    sum:               f64,
+    /// how many owning regions contributed a value.
+    regions:           usize,
+    /// rows where the measure parsed but its OWNING-REGION cell was blank, so the value belongs to
+    /// no identifiable region. Reported as coverage beside the tile, never folded into `sum`.
+    ///
+    /// Deliberately NOT the full-weight treatment `measure_by_dim_panel` gives a blank region.
+    /// That rule is right for a grouped bar, where the grouping makes the compromise visible;
+    /// a single headline number has no such context, so adding unattributable rows to a
+    /// collapsed total would produce a figure that is neither the true total nor a defensible
+    /// approximation.
+    unattributed_rows: u64,
+    /// a known region showed two DIFFERENT values, so the measure is not constant within it after
+    /// all — the ownership guard is only a NECESSARY condition and was wrong here.
+    conflict:          bool,
+}
+
+/// Collapse each region-level measure to one value per owning region, in ONE row pass.
+///
+/// `targets` pairs a measure's column index with the region column that owns it (from
+/// [`owning_region_idx`]). Returns a map keyed by MEASURE index, so a caller can look up the
+/// measure it is about to headline.
+///
+/// This both VERIFIES and COMPUTES. The ownership guard cannot prove constancy from the stats
+/// cache, so a measure that disagrees with itself inside one region sets `conflict` and is handed
+/// back to the ordinary row-wise treatment — the same call `measure_by_dim_panel` makes for the
+/// grouped bar, and the correct one: a value that differs between two rows of the same region is a
+/// genuine per-row measure.
+fn region_deduped_totals(
+    args: &Args,
+    targets: &[(usize, usize)],
+) -> CliResult<HashMap<usize, RegionDedupe>> {
+    if targets.is_empty() {
+        return Ok(HashMap::new());
+    }
+    // first value seen per owning region, per target
+    let mut seen: Vec<HashMap<String, f64>> = vec![HashMap::new(); targets.len()];
+    let mut out: Vec<RegionDedupe> = vec![RegionDedupe::default(); targets.len()];
+
+    let (mut rdr, _headers, _nh) = reader_and_headers(args)?;
+    let mut record = csv::ByteRecord::new();
+    while rdr.read_byte_record(&mut record)? {
+        for (ti, &(measure_idx, region_idx)) in targets.iter().enumerate() {
+            let Some(v) = parse_f64(record.get(measure_idx)).filter(|v| v.is_finite()) else {
+                continue;
+            };
+            let cell = cell_to_string(record.get(region_idx));
+            let key = cell.trim();
+            if key.is_empty() {
+                out[ti].unattributed_rows += 1;
+                continue;
+            }
+            match seen[ti].get(key) {
+                // Relative epsilon, matching the choropleth path's own constancy test, so the
+                // same column is judged identically wherever it is read.
+                Some(&prev) if (prev - v).abs() > f64::EPSILON * prev.abs().max(1.0) => {
+                    out[ti].conflict = true;
+                },
+                Some(_) => {},
+                None => {
+                    seen[ti].insert(key.to_string(), v);
+                    out[ti].sum += v;
+                    out[ti].regions += 1;
+                },
+            }
+        }
+    }
+    Ok(targets.iter().map(|&(m, _)| m).zip(out).collect())
+}
+
 fn build_kpi_row(
     stats: &[crate::cmd::stats::StatsData],
     panels: &[Panel],
     dict: Option<&DictData>,
     col_sems: &[ColSemantics],
     row_count: u64,
+    deduped: Option<&HashMap<usize, RegionDedupe>>,
 ) -> Option<Panel> {
     if stats.is_empty() {
         return None;
@@ -30798,15 +30879,35 @@ fn build_kpi_row(
             continue;
         }
         // A region-level column that repeats across rows would headline a MULTIPLE of its real
-        // total -- "Total Population 28.8M" for 2.4M of residents -- and no aggregation available
-        // here can state the true figure without a region-keyed dedupe pass. Omit the tile rather
-        // than print a false one, the same rule the gauge guard applies just below: a missing
-        // number beats a misleading one (issue #4528).
-        if p.stat_idx
-            .is_some_and(|i| is_repeated_region_level(i, stats, col_sems, row_count))
-        {
-            continue;
-        }
+        // total -- "Total Population 28.8M" for 2.4M of residents (issue #4528). The dedupe row
+        // pass now supplies the figure the stats cache cannot, so the tile states the truth
+        // instead of vanishing (issue #4534). Three outcomes, in the order they are decided:
+        let region_dedupe = match p.stat_idx {
+            Some(i) if is_repeated_region_level(i, stats, col_sems, row_count) => {
+                match deduped.and_then(|d| d.get(&i)) {
+                    // The data says the value is NOT constant within its region, so the ownership
+                    // guard -- a NECESSARY condition only -- was wrong. A measure that differs
+                    // between two rows of one region is a genuine per-row measure, so the ordinary
+                    // row-wise tile is the CORRECT treatment rather than a fallback; the same call
+                    // `measure_by_dim_panel` makes for the grouped bar.
+                    Some(d) if d.conflict => None,
+                    // Verified region-level: headline the collapsed figure.
+                    Some(d) if d.regions > 0 => Some(*d),
+                    // No row pass available, or not one region could be identified, so there is no
+                    // figure to state. Omit the tile rather than print a false one -- the same rule
+                    // the gauge guard applies just below: a missing number beats a misleading one.
+                    //
+                    // This is the ONLY suppression condition, and it is deliberately
+                    // THRESHOLD-FREE. A total stated as covering the regions it
+                    // could identify, with the remainder reported beside it, is
+                    // honest at ANY coverage level, so there is no "suppress
+                    // below N% attributed" rule to tune -- and no granularity to guess, which is
+                    // what separates this from the denominator-geography case (issue #4526).
+                    _ => continue,
+                }
+            },
+            _ => None,
+        };
         let row = dict.and_then(|d| d.rows.get(&s.field));
         let label = match row {
             Some(r) if !r.label.is_empty() => r.label.clone(),
@@ -30826,8 +30927,17 @@ fn build_kpi_row(
             Some(_) => true,
             None => has_range || is_intensive_measure(&label, &s.field),
         };
-        let Some(value) = (if intensive { s.mean_f64() } else { s.sum }).filter(|v| v.is_finite())
-        else {
+        // A verified region-level measure headlines its COLLAPSED figure: the sum of the distinct
+        // regional values, or their unweighted mean. The row-wise `mean` is wrong for the same
+        // reason the row-wise `sum` is -- it weights each region by how many rows it happens to
+        // occupy, so "Mean Population" would drift toward whichever county files the most reports.
+        let Some(value) = (match (&region_dedupe, intensive) {
+            (Some(d), false) => Some(d.sum),
+            (Some(d), true) => Some(d.sum / d.regions as f64),
+            (None, true) => s.mean_f64(),
+            (None, false) => s.sum,
+        })
+        .filter(|v| v.is_finite()) else {
             continue;
         };
         // gauge only when a range is supplied AND actually contains the value (guardrail against a
@@ -30860,8 +30970,24 @@ fn build_kpi_row(
         } else {
             kpi_number_format(value)
         };
+        // A collapsed figure covers only the regions that could be identified, so when some rows
+        // carried no owning region the tile says so in place rather than only on stderr — the same
+        // reasoning as the rate panel's `denom_excluded` suffix, and phrased the same
+        // count-of-total way so it stays grammatical at 1 without a plural rule.
+        let label = match &region_dedupe {
+            Some(d) if d.unattributed_rows > 0 => format!(
+                "{} ({})",
+                kpi_title(&label, intensive),
+                t!(
+                    "viz.title.kpi_unattributed",
+                    q_n = d.unattributed_rows,
+                    q_total = row_count
+                )
+            ),
+            _ => kpi_title(&label, intensive),
+        };
         tiles.push(KpiTile {
-            label: kpi_title(&label, intensive),
+            label,
             value,
             format,
             gauge,
@@ -33843,12 +33969,24 @@ impl<'a> SmartCtx<'a> {
             // box-points builders pull it earlier), so this adds no I/O in practice. It tells the
             // tile builder whether regions repeat across rows (issue #4528).
             let row_count = self.row_count();
+            // Region-level measures need one value per OWNING region before a dataset-wide headline
+            // can state them, and only the data carries that (issue #4534). Deliberately a SUPERSET
+            // of what the tile builder will use — every numeric measure an owning region claims,
+            // whether or not it ends up with a tile — so a lookup there can never miss and fall
+            // back to suppressing a measure the pass actually covered. Empty on the overwhelmingly
+            // common path, where it costs no read at all.
+            let dedupe_targets: Vec<(usize, usize)> = (0..self.stats.len())
+                .filter(|&i| is_repeated_region_level(i, &self.stats, &self.col_sems, row_count))
+                .filter_map(|i| owning_region_idx(i, &self.stats, &self.col_sems).map(|o| (i, o)))
+                .collect();
+            let deduped = region_deduped_totals(&self.args, &dedupe_targets)?;
             if let Some(panel) = build_kpi_row(
                 &self.stats,
                 &self.panels,
                 self.dict_data.as_ref(),
                 &self.col_sems,
                 row_count,
+                Some(&deduped),
             ) {
                 self.panels.insert(0, panel);
             }
@@ -46227,8 +46365,8 @@ mod tests {
         // decorated title + recorded stat_idx => tile still built
         let decorated =
             vec![Panel::new("amount (right-skewed)".to_string(), kind()).with_stat_idx(0)];
-        let row =
-            build_kpi_row(&stats, &decorated, None, &[], 0).expect("KPI row for decorated panel");
+        let row = build_kpi_row(&stats, &decorated, None, &[], 0, None)
+            .expect("KPI row for decorated panel");
         let PanelKind::KpiRow { tiles } = &row.kind else {
             panic!("expected a KpiRow");
         };
@@ -46244,13 +46382,13 @@ mod tests {
         }];
         let positional = vec![Panel::new("col 1".to_string(), kind()).with_stat_idx(0)];
         assert!(
-            build_kpi_row(&headerless_stats, &positional, None, &[], 0).is_some(),
+            build_kpi_row(&headerless_stats, &positional, None, &[], 0, None).is_some(),
             "headerless columns must still produce a KPI tile"
         );
 
         // negative control: an overview panel carries no stats row, so it contributes no tile
         let overview = vec![Panel::new("amount".to_string(), kind())];
-        assert!(build_kpi_row(&stats, &overview, None, &[], 0).is_none());
+        assert!(build_kpi_row(&stats, &overview, None, &[], 0, None).is_none());
     }
 
     #[test]
@@ -46343,7 +46481,7 @@ mod tests {
         // 192e9 is the NYC Capital Projects headline from issue #4393: it used to render as
         // "192G" via d3's `.3~s`.
         let (stats, panels, _) = kpi_fixture(192e9, None);
-        let row = build_kpi_row(&stats, &panels, None, &[], 0).expect("KPI row");
+        let row = build_kpi_row(&stats, &panels, None, &[], 0, None).expect("KPI row");
         let tile = only_tile(&row);
         assert!((tile.value - 192.0).abs() < 1e-9, "value is scaled down");
         assert_eq!(tile.suffix.as_deref(), Some("B"));
@@ -46352,7 +46490,8 @@ mod tests {
         // ...and the small-magnitude path is untouched: below `kpi_number_format`'s own 10k SI
         // threshold a KPI still renders as a grouped whole number, not "5k".
         let (small_stats, small_panels, _) = kpi_fixture(5000.0, None);
-        let small = build_kpi_row(&small_stats, &small_panels, None, &[], 0).expect("KPI row");
+        let small =
+            build_kpi_row(&small_stats, &small_panels, None, &[], 0, None).expect("KPI row");
         let small_tile = only_tile(&small);
         assert!((small_tile.value - 5000.0).abs() < f64::EPSILON);
         assert_eq!(small_tile.suffix, None);
@@ -46372,7 +46511,7 @@ mod tests {
             ..DictRow::default()
         };
         let (stats, panels, dict) = kpi_fixture(2.4e9, Some(gauged));
-        let row = build_kpi_row(&stats, &panels, dict.as_ref(), &[], 0).expect("KPI row");
+        let row = build_kpi_row(&stats, &panels, dict.as_ref(), &[], 0, None).expect("KPI row");
         let tile = only_tile(&row);
         assert!(tile.gauge.is_some());
         assert_eq!(tile.suffix, None, "a gauge tile keeps its unscaled value");
@@ -46384,7 +46523,7 @@ mod tests {
             ..DictRow::default()
         };
         let (stats2, panels2, dict2) = kpi_fixture(2.4e9, Some(targeted));
-        let row2 = build_kpi_row(&stats2, &panels2, dict2.as_ref(), &[], 0).expect("KPI row");
+        let row2 = build_kpi_row(&stats2, &panels2, dict2.as_ref(), &[], 0, None).expect("KPI row");
         let tile2 = only_tile(&row2);
         assert!(tile2.target.is_some());
         assert_eq!(tile2.suffix, None, "a delta tile keeps its unscaled value");
@@ -46400,7 +46539,7 @@ mod tests {
             ..DictRow::default()
         };
         let (stats, panels, dict) = kpi_fixture(192e9, Some(money(Some("USD"))));
-        let row = build_kpi_row(&stats, &panels, dict.as_ref(), &[], 0).expect("KPI row");
+        let row = build_kpi_row(&stats, &panels, dict.as_ref(), &[], 0, None).expect("KPI row");
         let tile = only_tile(&row);
         // the headline reads "$192B": symbol from the prefix, magnitude from the suffix
         assert_eq!(tile.prefix.as_deref(), Some("$"));
@@ -46408,12 +46547,12 @@ mod tests {
 
         // an ISO code the register doesn't know still labels the number, using the bare code
         let (s2, p2, d2) = kpi_fixture(192e9, Some(money(Some("ZZZ"))));
-        let row2 = build_kpi_row(&s2, &p2, d2.as_ref(), &[], 0).expect("KPI row");
+        let row2 = build_kpi_row(&s2, &p2, d2.as_ref(), &[], 0, None).expect("KPI row");
         assert_eq!(only_tile(&row2).prefix.as_deref(), Some("ZZZ "));
 
         // no currency -> no prefix (a non-money measure is unmarked, as before)
         let (s3, p3, d3) = kpi_fixture(192e9, Some(money(None)));
-        let row3 = build_kpi_row(&s3, &p3, d3.as_ref(), &[], 0).expect("KPI row");
+        let row3 = build_kpi_row(&s3, &p3, d3.as_ref(), &[], 0, None).expect("KPI row");
         assert_eq!(only_tile(&row3).prefix, None);
     }
 
@@ -46434,7 +46573,7 @@ mod tests {
             999_500_000.0,
         ] {
             let (stats, panels, _) = kpi_fixture(v, None);
-            let row = build_kpi_row(&stats, &panels, None, &[], 0).expect("KPI row");
+            let row = build_kpi_row(&stats, &panels, None, &[], 0, None).expect("KPI row");
             let tile = only_tile(&row);
             let kpi_rendered = format!(
                 "{}{}",

--- a/src/cmd/viz.rs
+++ b/src/cmd/viz.rs
@@ -30786,6 +30786,15 @@ struct RegionDedupe {
 /// [`owning_region_idx`]). Returns a map keyed by MEASURE index, so a caller can look up the
 /// measure it is about to headline.
 ///
+/// KNOWN LIMITATION, deliberately left open (roborev 4542): the owning-region CELL is the identity.
+/// [`is_region_concept`] accepts city and county NAMES, which are not unique — two `Springfield`
+/// rows can be different cities in different states. When their values DIFFER that registers as a
+/// `conflict` and the tile is omitted, which is safe; when they are EXACTLY equal the two regions
+/// merge into one key and the total silently undercounts by one of them. Closing it needs a
+/// composite identity, and choosing the enclosing column to qualify by is the same granularity
+/// question issue #4526 records as unanswerable from cardinality — so this is scoped there rather
+/// than guessed at here. `measure_by_dim_panel` keys its own dedupe the same way.
+///
 /// This both VERIFIES and COMPUTES. The ownership guard cannot prove constancy from the stats
 /// cache, so a measure that disagrees with itself inside one region sets `conflict` and is handed
 /// back to the ordinary row-wise treatment — the same call `measure_by_dim_panel` makes for the
@@ -30885,24 +30894,34 @@ fn build_kpi_row(
         let region_dedupe = match p.stat_idx {
             Some(i) if is_repeated_region_level(i, stats, col_sems, row_count) => {
                 match deduped.and_then(|d| d.get(&i)) {
-                    // The data says the value is NOT constant within its region, so the ownership
-                    // guard -- a NECESSARY condition only -- was wrong. A measure that differs
-                    // between two rows of one region is a genuine per-row measure, so the ordinary
-                    // row-wise tile is the CORRECT treatment rather than a fallback; the same call
-                    // `measure_by_dim_panel` makes for the grouped bar.
-                    Some(d) if d.conflict => None,
-                    // Verified region-level: headline the collapsed figure.
-                    Some(d) if d.regions > 0 => Some(*d),
-                    // No row pass available, or not one region could be identified, so there is no
-                    // figure to state. Omit the tile rather than print a false one -- the same rule
-                    // the gauge guard applies just below: a missing number beats a misleading one.
+                    // Verified constant within every region that could be identified: headline the
+                    // collapsed figure.
+                    Some(d) if !d.conflict && d.regions > 0 => Some(*d),
+                    // Everything else leaves this tile with no figure it can state truthfully, so
+                    // omit it -- the same rule the gauge guard applies just below: a missing number
+                    // beats a misleading one. Two ways to get here:
                     //
-                    // This is the ONLY suppression condition, and it is deliberately
-                    // THRESHOLD-FREE. A total stated as covering the regions it
-                    // could identify, with the remainder reported beside it, is
-                    // honest at ANY coverage level, so there is no "suppress
-                    // below N% attributed" rule to tune -- and no granularity to guess, which is
-                    // what separates this from the denominator-geography case (issue #4526).
+                    //   - CONFLICT. The measure is not constant within its owning region. That does
+                    //     NOT prove it is per-row: it may be region x PERIOD level -- a population
+                    //     per county per YEAR -- and then the row-wise total is inflated by exactly
+                    //     the factor issue #4528 exists to remove. A conflict is AMBIGUOUS, so
+                    //     falling back to the row-wise total would reintroduce that bug for the
+                    //     region-per-period reading of the same data.
+                    //
+                    //     `measure_by_dim_panel` DOES fall back for the grouped bar, and the two
+                    //     sites are meant to differ here for the same reason they differ on a blank
+                    //     region key (see `RegionDedupe::unattributed_rows`): a grouped bar shows
+                    //     its per-group figures, so a reader can see what was aggregated and judge
+                    //     it, while a lone headline number carries no such context.
+                    //
+                    //   - NOT ONE REGION IDENTIFIABLE, or no row pass ran. Nothing to collapse.
+                    //
+                    // Suppression is deliberately THRESHOLD-FREE: partial coverage is NOT a reason
+                    // to suppress, because a total stated over the regions it could identify, with
+                    // the remainder reported beside it, is honest at ANY coverage level. There is
+                    // no "suppress below N% attributed" rule to tune -- and no granularity to
+                    // guess, which is what separates this from the denominator-geography case
+                    // (issue #4526).
                     _ => continue,
                 }
             },

--- a/src/cmd/viz.rs
+++ b/src/cmd/viz.rs
@@ -30775,8 +30775,16 @@ struct RegionDedupe {
     /// collapsed total would produce a figure that is neither the true total nor a defensible
     /// approximation.
     unattributed_rows: u64,
-    /// a known region showed two DIFFERENT values, so the measure is not constant within it after
-    /// all — the ownership guard is only a NECESSARY condition and was wrong here.
+    /// a known region showed two DIFFERENT values, so the measure is not constant within that
+    /// region alone.
+    ///
+    /// This does NOT establish what the measure IS. It may be genuinely per-row (a stale sidecar
+    /// tagging a row-level column `measure.population`), or it may be region x PERIOD level — a
+    /// population per county per YEAR — which disagrees with itself inside a county for an
+    /// entirely legitimate reason. The two are indistinguishable here, so a conflict is treated as
+    /// AMBIGUOUS and the KPI tile is omitted rather than falling back to a row-wise total, which
+    /// would be inflated in the second reading (roborev 4542). `measure_by_dim_panel` does fall
+    /// back for the grouped bar; see `unattributed_rows` for why the two sites differ.
     conflict:          bool,
 }
 
@@ -30796,10 +30804,9 @@ struct RegionDedupe {
 /// than guessed at here. `measure_by_dim_panel` keys its own dedupe the same way.
 ///
 /// This both VERIFIES and COMPUTES. The ownership guard cannot prove constancy from the stats
-/// cache, so a measure that disagrees with itself inside one region sets `conflict` and is handed
-/// back to the ordinary row-wise treatment — the same call `measure_by_dim_panel` makes for the
-/// grouped bar, and the correct one: a value that differs between two rows of the same region is a
-/// genuine per-row measure.
+/// cache, so a measure that disagrees with itself inside one region sets `conflict` — which the
+/// KPI caller treats as AMBIGUOUS and omits, since a conflict cannot tell a genuine per-row
+/// measure from a legitimate region-per-period one. See [`RegionDedupe::conflict`].
 fn region_deduped_totals(
     args: &Args,
     targets: &[(usize, usize)],

--- a/tests/test_viz.rs
+++ b/tests/test_viz.rs
@@ -9878,13 +9878,12 @@ fn viz_smart_kpi_region_level_states_unattributed_coverage() {
 }
 
 #[test]
-fn viz_smart_kpi_region_level_conflict_restores_the_ordinary_total() {
-    // The ownership guard is a NECESSARY condition only: `cardinality(measure) <= cardinality(
-    // region)` can be satisfied by a genuinely PER-ROW measure, and a stale sidecar can tag one
-    // `measure.population`. Before the row pass such a tile was suppressed on that guess. The pass
-    // sees the measure disagree with itself inside one county and hands it back to the ordinary
-    // row-wise total -- the same call `measure_by_dim_panel` makes for the grouped bar.
-    let wrk = Workdir::new("viz_smart_kpi_region_level_conflict_restores_the_ordinary_total");
+fn viz_smart_kpi_region_level_conflict_omits_the_tile() {
+    // A conflict means the measure is not constant within its owning region. It does NOT follow
+    // that the measure is per-row -- see the region-per-period test below, which produces an
+    // identical conflict from data whose row-wise total is inflated 8x. A conflict is AMBIGUOUS,
+    // so the tile is omitted rather than falling back to the row-wise total.
+    let wrk = Workdir::new("viz_smart_kpi_region_level_conflict_omits_the_tile");
     let counties = [
         "Albany", "Bronx", "Erie", "Kings", "Monroe", "Nassau", "Queens", "Suffolk",
     ];
@@ -9917,13 +9916,77 @@ fn viz_smart_kpi_region_level_conflict_restores_the_ordinary_total() {
 
     let html = wrk.read_to_string("k.html").unwrap();
     assert!(
-        html.contains(r#""text":"Total Population""#),
-        "a genuine per-row measure must keep its ordinary tile: {html}"
+        !html.contains(r#""text":"Total Population"#),
+        "an ambiguous measure must not be headlined at all: {html}"
     );
-    // 36,800 -- the plain row-wise sum, scaled by the KPI magnitude suffix
+    // 36,800 is the row-wise sum; falling back to it would be a guess that the measure is per-row
     assert!(
-        html.contains(r#""value":36.8"#),
-        "a conflicting measure must headline the ordinary row-wise sum: {html}"
+        !html.contains(r#""value":36.8"#),
+        "the row-wise sum must not be used as a conflict fallback: {html}"
+    );
+    assert!(
+        html.contains(r#""text":"Total Requests""#),
+        "other measures keep their tiles: {html}"
+    );
+}
+
+#[test]
+fn viz_smart_kpi_region_level_varying_by_period_is_not_row_wise() {
+    // roborev 4542: a region-level measure can legitimately vary BY REPORTING PERIOD -- a
+    // population per county per YEAR. That produces exactly the same within-region disagreement a
+    // genuinely per-row measure does, so a conflict cannot be read as proof of per-row-ness. If it
+    // were, this dataset's tile would headline 86,400,000 against a true per-year total of
+    // 10,800,000 -- reintroducing the very inflation issue #4528 removed.
+    //
+    // The value pool is deliberately only 8 wide so `cardinality(population) <=
+    // cardinality(county)` still holds: with per-year values drawn from a wider pool the
+    // ownership guard rejects the claim upstream and this path is never reached at all.
+    let wrk = Workdir::new("viz_smart_kpi_region_level_varying_by_period_is_not_row_wise");
+    let counties = [
+        "Albany", "Bronx", "Erie", "Kings", "Monroe", "Nassau", "Queens", "Suffolk",
+    ];
+    let vals = [
+        300_000, 600_000, 900_000, 1_200_000, 1_500_000, 1_800_000, 2_100_000, 2_400_000,
+    ];
+    let mut s = String::from("county,year,population,requests\n");
+    for (yi, year) in [2023, 2024].iter().enumerate() {
+        for (i, c) in counties.iter().enumerate() {
+            let p = vals[(i + yi) % 8];
+            for j in 1..=4 {
+                s.push_str(&format!("{c},{year},{p},{}\n", (i + 1) * j));
+            }
+        }
+    }
+    wrk.create_from_string("c.csv", &s);
+    wrk.create_from_string(
+        "d.schema.json",
+        &region_level_dict().replace(
+            r#""requests":{"type":"integer""#,
+            r#""year":{"type":"integer","title":"Year","x-qsv":{"concept":"time.year","role":"dimension","qsv_type":"Integer"}},
+   "requests":{"type":"integer""#,
+        ),
+    );
+
+    let out_html = wrk.path("k.html").to_string_lossy().to_string();
+    let mut cmd = wrk.command("viz");
+    cmd.args([
+        "smart",
+        "c.csv",
+        "--dictionary",
+        "d.schema.json",
+        "-o",
+        &out_html,
+    ]);
+    wrk.assert_success(&mut cmd);
+
+    let html = wrk.read_to_string("k.html").unwrap();
+    assert!(
+        !html.contains(r#""value":86.4"#),
+        "the row-wise total of a per-period regional measure must never be headlined: {html}"
+    );
+    assert!(
+        !html.contains(r#""text":"Total Population"#),
+        "an ambiguous measure is omitted rather than guessed at: {html}"
     );
 }
 

--- a/tests/test_viz.rs
+++ b/tests/test_viz.rs
@@ -9928,6 +9928,63 @@ fn viz_smart_kpi_region_level_conflict_restores_the_ordinary_total() {
 }
 
 #[test]
+fn viz_smart_kpi_region_level_mean_is_unweighted_by_region_row_count() {
+    // The INTENSIVE arm. A row-wise mean of a region-level measure weights each region by how many
+    // rows it happens to occupy, so "Mean Population" drifts toward whichever county files the most
+    // reports -- wrong for the same reason the row-wise sum is. The collapse makes it the
+    // unweighted mean over the regions themselves.
+    //
+    // Rows per region are deliberately UNEQUAL (2/3/5/50): with equal counts the weighted and
+    // unweighted means coincide and this test would pass without exercising anything.
+    let wrk = Workdir::new("viz_smart_kpi_region_level_mean_is_unweighted_by_region_row_count");
+    let data = [
+        ("Albany", 300_000, 2),
+        ("Bronx", 1_500_000, 3),
+        ("Erie", 900_000, 5),
+        ("Kings", 2_400_000, 50),
+    ];
+    let mut s = String::from("county,population,requests\n");
+    for (i, (c, p, n)) in data.iter().enumerate() {
+        for j in 1..=*n {
+            s.push_str(&format!("{c},{p},{}\n", (i + 1) * j));
+        }
+    }
+    wrk.create_from_string("c.csv", &s);
+    // `aggregation: mean` routes the region-level measure down the intensive path.
+    wrk.create_from_string(
+        "d.schema.json",
+        &region_level_dict().replace(
+            r#""concept":"measure.population","role":"measure","qsv_type":"Integer""#,
+            r#""concept":"measure.population","role":"measure","qsv_type":"Integer","aggregation":"mean""#,
+        ),
+    );
+
+    let out_html = wrk.path("k.html").to_string_lossy().to_string();
+    let mut cmd = wrk.command("viz");
+    cmd.args([
+        "smart",
+        "c.csv",
+        "--dictionary",
+        "d.schema.json",
+        "-o",
+        &out_html,
+    ]);
+    wrk.assert_success(&mut cmd);
+
+    let html = wrk.read_to_string("k.html").unwrap();
+    // (300k + 1.5M + 900k + 2.4M) / 4 = 1,275,000, scaled to millions by the KPI suffix.
+    assert!(
+        html.contains(r#""value":1.275"#),
+        "the mean must be unweighted across regions: {html}"
+    );
+    // the row-weighted mean would be 2,160,000
+    assert!(
+        !html.contains(r#""value":2.16"#),
+        "the row-weighted mean must never be headlined: {html}"
+    );
+}
+
+#[test]
 fn viz_smart_kpi_region_level_without_an_identifiable_region_is_omitted() {
     // The one suppression condition, and deliberately threshold-free: not a single owning region
     // could be identified, so there is no figure to state at all. Here the region column carries

--- a/tests/test_viz.rs
+++ b/tests/test_viz.rs
@@ -9758,6 +9758,223 @@ fn viz_smart_kpi_row_does_not_orphan_eighth_axis() {
     assert!(!html.contains(r#""xaxis":"x9""#));
 }
 
+// ---------------------------------------------------------------------------------------------
+// Region-level KPI tiles (issue #4534, building on #4528)
+//
+// A REGION-LEVEL measure -- a population, an area -- repeats identically on every row of its
+// region, so the stats cache's row-wise `sum` is a MULTIPLE of the real one. #4528 suppressed the
+// tile rather than print the inflated figure; the region-dedupe row pass supplies the number the
+// cache cannot, so the tile now states the truth.
+//
+// NOTE for anyone extending these: the concept MUST be a token describegpt's `CONCEPT_VOCAB` can
+// emit (`geo.county`). A plausible-looking but off-vocabulary concept (`geo.county_name`) makes
+// `is_region_concept` reject the column, so `owning_region_idx` returns None, no guard fires, and
+// the test passes while asserting nothing.
+fn region_level_dict() -> &'static str {
+    r#"{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"object",
+ "properties":{
+   "county":{"type":"string","title":"County","x-qsv":{"concept":"geo.county","role":"dimension"}},
+   "population":{"type":"integer","title":"Population","x-qsv":{"concept":"measure.population","role":"measure","qsv_type":"Integer"}},
+   "requests":{"type":"integer","title":"Requests","x-qsv":{"concept":"measure.count","role":"measure","qsv_type":"Integer"}}
+ }}"#
+}
+
+/// 8 counties x 12 rows, `population` constant within each county. True total 11,564,413; the
+/// row-wise sum would be 138,772,956 (12x).
+fn region_level_csv(trailing: &str) -> String {
+    let pops = [
+        ("Albany", 314_848),
+        ("Bronx", 1_472_654),
+        ("Erie", 954_236),
+        ("Kings", 2_736_074),
+        ("Monroe", 759_443),
+        ("Nassau", 1_395_774),
+        ("Queens", 2_405_464),
+        ("Suffolk", 1_525_920),
+    ];
+    let mut s = String::from("county,population,requests\n");
+    for (i, (c, p)) in pops.iter().enumerate() {
+        for j in 1..=12 {
+            s.push_str(&format!("{c},{p},{}\n", (i + 1) * j));
+        }
+    }
+    s.push_str(trailing);
+    s
+}
+
+#[test]
+fn viz_smart_kpi_region_level_headlines_the_deduped_total() {
+    let wrk = Workdir::new("viz_smart_kpi_region_level_headlines_the_deduped_total");
+    wrk.create_from_string("c.csv", &region_level_csv(""));
+    wrk.create_from_string("d.schema.json", region_level_dict());
+
+    let out_html = wrk.path("k.html").to_string_lossy().to_string();
+    let mut cmd = wrk.command("viz");
+    cmd.args([
+        "smart",
+        "c.csv",
+        "--dictionary",
+        "d.schema.json",
+        "-o",
+        &out_html,
+    ]);
+    wrk.assert_success(&mut cmd);
+
+    let html = wrk.read_to_string("k.html").unwrap();
+    // 11,564,413 -- the sum of the eight DISTINCT county populations, scaled to millions by the
+    // KPI magnitude suffix. Not 138,772,956 (the 12x row-wise sum), and not absent.
+    assert!(
+        html.contains(r#""text":"Total Population""#),
+        "the tile must be present, not suppressed: {html}"
+    );
+    assert!(
+        html.contains(r#""value":11.564413"#),
+        "the tile must headline the region-deduped total: {html}"
+    );
+    assert!(
+        !html.contains("138.772956"),
+        "the row-wise sum must never be headlined: {html}"
+    );
+}
+
+#[test]
+fn viz_smart_kpi_region_level_states_unattributed_coverage() {
+    // A blank owning-region cell cannot be collapsed -- there is no identity to collapse it to --
+    // and folding it into the total at full weight (the rule `measure_by_dim_panel` uses for a
+    // GROUPED bar, where the grouping makes the compromise visible) would make a headline that is
+    // neither the true total nor a defensible approximation. So the total covers the regions it
+    // could identify and says so in place.
+    let wrk = Workdir::new("viz_smart_kpi_region_level_states_unattributed_coverage");
+    let mut trailing = String::new();
+    for i in 1..=20 {
+        trailing.push_str(&format!(",900000,{i}\n"));
+    }
+    wrk.create_from_string("c.csv", &region_level_csv(&trailing));
+    wrk.create_from_string("d.schema.json", region_level_dict());
+
+    let out_html = wrk.path("k.html").to_string_lossy().to_string();
+    let mut cmd = wrk.command("viz");
+    cmd.args([
+        "smart",
+        "c.csv",
+        "--dictionary",
+        "d.schema.json",
+        "-o",
+        &out_html,
+    ]);
+    wrk.assert_success(&mut cmd);
+
+    let html = wrk.read_to_string("k.html").unwrap();
+    // unchanged total -- the 20 unattributable rows are NOT added to it ...
+    assert!(
+        html.contains(r#""value":11.564413"#),
+        "unattributed rows must not enter the total: {html}"
+    );
+    // ... and the label states the coverage (the label is word-wrapped, so it may carry <br>)
+    assert!(
+        html.contains("20 of 116") && html.contains("rows unattributed"),
+        "the tile must state its coverage: {html}"
+    );
+}
+
+#[test]
+fn viz_smart_kpi_region_level_conflict_restores_the_ordinary_total() {
+    // The ownership guard is a NECESSARY condition only: `cardinality(measure) <= cardinality(
+    // region)` can be satisfied by a genuinely PER-ROW measure, and a stale sidecar can tag one
+    // `measure.population`. Before the row pass such a tile was suppressed on that guess. The pass
+    // sees the measure disagree with itself inside one county and hands it back to the ordinary
+    // row-wise total -- the same call `measure_by_dim_panel` makes for the grouped bar.
+    let wrk = Workdir::new("viz_smart_kpi_region_level_conflict_restores_the_ordinary_total");
+    let counties = [
+        "Albany", "Bronx", "Erie", "Kings", "Monroe", "Nassau", "Queens", "Suffolk",
+    ];
+    let mut s = String::from("county,population,requests\n");
+    let mut total = 0u32;
+    for (i, c) in counties.iter().enumerate() {
+        for j in 0..12 {
+            // 8 distinct values overall, so the cardinality guard still passes, but they VARY
+            // within each county.
+            let v = (j % 8 + 1) * 100;
+            total += v as u32;
+            s.push_str(&format!("{c},{v},{}\n", (i + 1) * (j + 1)));
+        }
+    }
+    assert_eq!(total, 36_800);
+    wrk.create_from_string("c.csv", &s);
+    wrk.create_from_string("d.schema.json", region_level_dict());
+
+    let out_html = wrk.path("k.html").to_string_lossy().to_string();
+    let mut cmd = wrk.command("viz");
+    cmd.args([
+        "smart",
+        "c.csv",
+        "--dictionary",
+        "d.schema.json",
+        "-o",
+        &out_html,
+    ]);
+    wrk.assert_success(&mut cmd);
+
+    let html = wrk.read_to_string("k.html").unwrap();
+    assert!(
+        html.contains(r#""text":"Total Population""#),
+        "a genuine per-row measure must keep its ordinary tile: {html}"
+    );
+    // 36,800 -- the plain row-wise sum, scaled by the KPI magnitude suffix
+    assert!(
+        html.contains(r#""value":36.8"#),
+        "a conflicting measure must headline the ordinary row-wise sum: {html}"
+    );
+}
+
+#[test]
+fn viz_smart_kpi_region_level_without_an_identifiable_region_is_omitted() {
+    // The one suppression condition, and deliberately threshold-free: not a single owning region
+    // could be identified, so there is no figure to state at all. Here the region column carries
+    // enough distinct values to satisfy the cardinality guard, but is blank on exactly the rows
+    // where the measure parses.
+    let wrk = Workdir::new("viz_smart_kpi_region_level_without_an_identifiable_region_is_omitted");
+    // Shape matters here, and a careless fixture makes this test VACUOUS: the measure must still
+    // earn a distribution panel (a heavily-null column does not, so its tile could never exist and
+    // the assertion would prove nothing). 10% null keeps it charted, while `cardinality(population)
+    // <= cardinality(county)` keeps the ownership guard satisfied, so the omission below really is
+    // this branch and not an upstream filter. Verified by mutation.
+    let mut s = String::from("county,population,requests\n");
+    for i in 0..20 {
+        s.push_str(&format!("County{i:03},,{}\n", i + 1));
+    }
+    for i in 0..180 {
+        s.push_str(&format!(",{},{}\n", (i % 20 + 1) * 137_000, i + 1));
+    }
+    wrk.create_from_string("c.csv", &s);
+    wrk.create_from_string("d.schema.json", region_level_dict());
+
+    let out_html = wrk.path("k.html").to_string_lossy().to_string();
+    let mut cmd = wrk.command("viz");
+    cmd.args([
+        "smart",
+        "c.csv",
+        "--dictionary",
+        "d.schema.json",
+        "-o",
+        &out_html,
+    ]);
+    wrk.assert_success(&mut cmd);
+
+    let html = wrk.read_to_string("k.html").unwrap();
+    // Match the LABEL PREFIX, not the exact string: a wrongly-emitted tile would carry the
+    // "(180 of 200 rows unattributed)" coverage suffix and slip past an exact-match assertion.
+    assert!(
+        !html.contains(r#""text":"Total Population"#),
+        "with no identifiable region there is no truthful figure, so no tile: {html}"
+    );
+    // the ordinary measure beside it is unaffected
+    assert!(
+        html.contains(r#""text":"Total Requests""#),
+        "other measures keep their tiles: {html}"
+    );
+}
+
 #[test]
 fn viz_treemap_requires_two_cols() {
     let wrk = Workdir::new("viz_treemap_requires_two_cols");


### PR DESCRIPTION
Fixes #4534.

## The bug

A REGION-LEVEL measure — a population, an area — repeats identically on every row of its region, so the stats cache's row-wise `sum` is a **multiple** of the real one. #4528 stopped the KPI tile printing "Total Population 138.8M" for 11.5M of residents by **suppressing the tile**. Correct, but missing: the cache cannot supply the true figure, because it carries no `(region, value)` pair count — the limit `owning_region_idx` documents.

One row pass does, and it both **verifies** and **computes**. `region_deduped_totals` collapses each region-level measure to one value per owning region, reusing the `dedup`/`conflict` shape `measure_by_dim_panel` already uses for the grouped bar so the two sites cannot drift.

## Behaviour

| row-pass outcome | tile |
| --- | --- |
| constant within every identified region | **deduped total** (11,564,413, previously suppressed) |
| some rows carry no owning region | same total, **coverage stated in the label** |
| measure conflicts within a region | **omitted** — ambiguous |
| not one region identifiable | omitted, as before |

The **mean** path collapses too: `sum / regions`, an unweighted mean. A row-wise mean weights each region by how many rows it happens to occupy, so "Mean Population" would drift toward whichever county files the most reports.

**Coverage, not full weight.** `measure_by_dim_panel` carries blank-region rows at full weight — settled across roborev 4528/4529/4530 and *not* re-opened here. That rule is right where the grouping makes the compromise visible; a lone headline number has no such context. On a fixture with 20 unattributable rows the options were 11,564,413 (truthful, needs a caveat), 29,564,413 (dedupe + full weight — neither the true total nor a defensible approximation) and 156,772,956 (the raw row-wise sum). The tile states the first and says `(20 of 116 rows unattributed)`, the way the rate panel's `denom_excluded` suffix does.

**Suppression is threshold-free**, and that is the point. Partial coverage is *not* a trigger: a total stated over the regions it could identify, with the remainder reported beside it, is honest at any coverage level. There is no "suppress below N% attributed" rule to tune and no granularity to guess — which is exactly what separates this half from #4526, where no data-derived statistic works.

## A correction made during review

The first commit also made conflicts fall back to the **ordinary row-wise tile**, reasoning that the cardinality guard had been wrong and the measure must be per-row. **Local review rejected that, correctly.**

A conflict proves only that the measure is not constant within its *owning region*. It does not prove per-row-ness — the measure may be region × **period** level, a population per county per YEAR. Measured on 8 counties × 2 years, the fallback headlined **86,400,000** against a true per-year total of **10,800,000**, reintroducing the very inflation #4528 removed, in a case #4528 had correctly suppressed. It also contradicted this PR's own argument about blanks, which applies to conflicts identically.

The fallback is withdrawn. The cost is that a genuinely per-row measure mis-tagged `measure.population` by a stale sidecar keeps no tile — that is #4528's existing behaviour, not a regression, and it is the side of the trade the project's own rule picks: a missing number beats a misleading one.

Worth noting the *realistic* per-period shape never reaches this code at all: per-year values give the measure more distinct values than the region key has, so the cardinality guard rejects ownership upstream. Only a narrow pool-sharing variant reaches it, which is what the new test constructs.

## Known limitation, deliberately not fixed here

The owning-region **cell** is the identity, and `is_region_concept` accepts city and county NAMES, which are not unique. Two same-named regions with **exactly equal** values merge into one key and the total silently undercounts — 4,260,700 against a true 4,560,700. Differing values register as a conflict and are now omitted, so the unsafe half is closed.

Closing the rest needs a composite identity, and choosing which enclosing column qualifies the key is the granularity question **#4526** records as unanswerable from cardinality — where two cardinality rules have already shipped and been reviewed as defects. Building it here would re-open that. Recorded as a `KNOWN LIMITATION` on `region_deduped_totals` and scoped to #4526. `measure_by_dim_panel` keys its dedupe identically, so this is a property of the merged #4529 design rather than new here.

## Please review: unverified translations

`kpi_unattributed` was added to **all 8 locale catalogs**, which `every_locale_yaml_has_the_same_keys_as_english` requires. **I authored all 8 strings, including `ja` and `zh-CN`, with no native-speaker check.** The parity test validates *keys only*, never values, so nothing in CI catches a bad translation — and #4502 shows the project treats these as a known gap. Please review or stub them rather than taking them as verified.

## Verification

- `viz` integration: **546 passed**, 10 ignored (was 540 on master)
- unit: **1071 passed**
- `cargo +nightly fmt --check`, `scripts/double-run-check.py --check`: clean
- `cargo clippy -F all_features`: no new warnings (the 2 reported are pre-existing at `viz.rs:5104` and `viz.rs:27586`, verified identical on a master build)
- **Every one of the 6 new tests was mutation-tested.** One was **vacuous** as first written — a heavily-null measure earns no distribution panel, so the tile it asserted absent could never have existed. The fixture was reshaped until the mutation flipped it. The intensive-mean test needed unequal rows per region for the same reason: with equal counts the weighted and unweighted means coincide.
- **Rendered in a browser** at 5 tiles and at a 760px viewport: the coverage label sits on one line, no clipping, no overlap.

**Gallery unaffected.** Only `district_requests_dict.schema.json` carries a trigger, and its figure rebuilds byte-identical to a master-built baseline apart from the `Compiled:` timestamp — so `gen_gallery.py` was deliberately not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
