### PR TITLE
describegpt/viz: close the place_fips, country_code and timezone geo concept gaps (#4524)

### DIFF
--- a/src/cmd/describegpt/dictionary.rs
+++ b/src/cmd/describegpt/dictionary.rs
@@ -6043,6 +6043,15 @@ mod tests {
             coerced_role_concept("time_zone", "dimension", "geo.timezone", "String"),
             ("dimension".to_string(), "geo.timezone".to_string())
         );
+        // Seeding `time_zone` moved it from the namespace-mismatch branch to the deterministic
+        // one, so this is the arm whose OUTPUT actually changed: a dissenting `time.*` concept
+        // used to be reset to the routeless `"unknown"`, and is now reset to the specific
+        // `geo.timezone`. Strictly better — the column keeps a routable identity — and the route
+        // is `Route::Dimension` either way, so nothing downstream of viz moves.
+        assert_eq!(
+            coerced_role_concept("time_zone", "dimension", "time.event_timestamp", "String"),
+            ("dimension".to_string(), "geo.timezone".to_string())
+        );
     }
 
     #[test]

--- a/src/cmd/describegpt/dictionary.rs
+++ b/src/cmd/describegpt/dictionary.rs
@@ -173,7 +173,18 @@ pub(crate) const CONCEPT_VOCAB: &[&str] = &[
     "geo.county_fips",
     "geo.state",
     "geo.state_fips",
+    // a 7-digit place GEOID (2-digit state + 5-digit place), the key of TIGERweb's "Incorporated
+    // Places" layer. Distinct from `geo.city`, which is a NAME needing forward geocoding to key a
+    // polygon; a place FIPS keys one directly. Issue #4524 -- `viz_census::Layer::Place` was fully
+    // implemented and probed by `--geojson auto`, but no dictionary could nominate a column for
+    // it.
+    "geo.place_fips",
     "geo.country",
+    // the ISO-3166 alpha-2 code, as distinct from `geo.country` (the name). Split for the same
+    // reason `geo.state`/`geo.state_fips` and `geo.county`/`geo.county_fips` are: "US" and "United
+    // States" denote the same country but are NOT join-compatible, and `geocode countryinfo` takes
+    // the alpha-2 form only. Issue #4524.
+    "geo.country_code",
     "geo.latitude",
     "geo.longitude",
     "geo.coordinate_pair",
@@ -181,6 +192,14 @@ pub(crate) const CONCEPT_VOCAB: &[&str] = &[
     "geo.census_tract",
     "geo.crs_stateplane_x",
     "geo.crs_stateplane_y",
+    // an IANA tz database zone ("America/New_York"). Spatial rather than temporal: it names a
+    // REGION that observes a clock rule, and it is the region — not the clock — that another
+    // dataset joins on. Seeded from the `time_zone` content_type. Issue #4524.
+    "geo.timezone",
+    // a Geonames feature id, the join key of the gazetteer `qsv geocode` indexes. The one concept
+    // here with no `content_type` to seed it (a Geonames id is an undistinguished integer), so it
+    // arrives only from a hand-authored sidecar or a literally-named column. Issue #4524.
+    "geo.geonames_id",
     // temporal
     "time.event_timestamp",
     "time.created_at",
@@ -313,7 +332,9 @@ pub(super) fn concept_from_content_type(content_type_base: &str) -> Option<&'sta
         "zip_code" => "geo.zip_code",
         "city" => "geo.city",
         "state" | "state_abbr" => "geo.state",
-        "country" | "country_code" => "geo.country",
+        "country" => "geo.country",
+        "country_code" => "geo.country_code",
+        "time_zone" => "geo.timezone",
         "latitude" => "geo.latitude",
         "longitude" => "geo.longitude",
         "street_address" | "street_name" => "geo.street_address",
@@ -1709,6 +1730,12 @@ const DENOMINATOR_REGION_CONCEPTS: &[&str] = &[
     "geo.state",
     "geo.state_fips",
     "geo.country",
+    // both added with the `geo.place_fips` / `geo.country_code` concepts (issue #4524). A place is
+    // a boundary region a per-region denominator hangs on exactly as a county is, and splitting
+    // the country concept must not cost a code-form country column its hint. Consistent with this
+    // list's stated bias toward hinting MORE columns than will chart.
+    "geo.country_code",
+    "geo.place_fips",
     "geo.city",
 ];
 
@@ -5962,6 +5989,71 @@ mod tests {
             Some("time.event_timestamp")
         );
         assert_eq!(concept_from_content_type("free_text"), None);
+    }
+
+    #[test]
+    fn concept_from_content_type_splits_country_name_from_country_code() {
+        // issue #4524: a name and a code are not join-compatible, which is why the vocabulary
+        // already splits `geo.state`/`geo.state_fips` and `geo.county`/`geo.county_fips`. Both
+        // country content_types used to collapse onto `geo.country`.
+        assert_eq!(concept_from_content_type("country"), Some("geo.country"));
+        assert_eq!(
+            concept_from_content_type("country_code"),
+            Some("geo.country_code")
+        );
+        // a time zone names the REGION observing a clock rule, so it is a `geo.*` identity
+        // rather than a `time.*` axis. It had no concept at all before #4524.
+        assert_eq!(concept_from_content_type("time_zone"), Some("geo.timezone"));
+    }
+
+    #[test]
+    fn every_deterministic_concept_is_in_the_vocabulary() {
+        // `coerce_role_concept` writes a deterministic seed straight onto the entry without
+        // re-validating it, and `parse_llm_dictionary_response` rejects any concept outside
+        // `CONCEPT_VOCAB` — so a seed missing from the vocabulary would emit a token the
+        // dictionary's own parser refuses to read back. Guards every future mapping, not just
+        // the ones #4524 added.
+        for &content_type in CONTENT_TYPE_VOCAB {
+            if let Some(concept) = concept_from_content_type(content_type) {
+                assert!(
+                    CONCEPT_VOCAB.contains(&concept),
+                    "content_type `{content_type}` seeds `{concept}`, which is not in \
+                     CONCEPT_VOCAB"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn coerce_role_concept_resets_a_country_name_concept_on_a_country_code() {
+        // the split only bites if the reconciliation enforces it: `country_code` has no
+        // admissible refinements, so the name concept is a contradiction and is reset (#4524).
+        assert_eq!(
+            coerced_role_concept("country_code", "dimension", "geo.country", "String"),
+            ("dimension".to_string(), "geo.country_code".to_string())
+        );
+        // ... and the reverse direction, so a code concept cannot squat on a name column.
+        assert_eq!(
+            coerced_role_concept("country", "dimension", "geo.country_code", "String"),
+            ("dimension".to_string(), "geo.country".to_string())
+        );
+        // a time zone is a dimension, never a temporal axis: `is_temporal_content_type` matches
+        // `time`, not `time_zone`, so a stray `time.*` concept is the dissenter here.
+        assert_eq!(
+            coerced_role_concept("time_zone", "dimension", "geo.timezone", "String"),
+            ("dimension".to_string(), "geo.timezone".to_string())
+        );
+    }
+
+    #[test]
+    fn denominator_region_concepts_cover_the_new_region_identities() {
+        // a place is a boundary region a per-region denominator hangs on exactly as a county is,
+        // and splitting the country concept must not cost a code-form column its hint (#4524).
+        assert!(DENOMINATOR_REGION_CONCEPTS.contains(&"geo.place_fips"));
+        assert!(DENOMINATOR_REGION_CONCEPTS.contains(&"geo.country_code"));
+        // a timezone or a gazetteer id keys no polygon, so neither can carry a denominator.
+        assert!(!DENOMINATOR_REGION_CONCEPTS.contains(&"geo.timezone"));
+        assert!(!DENOMINATOR_REGION_CONCEPTS.contains(&"geo.geonames_id"));
     }
 
     #[test]

--- a/src/cmd/describegpt/dictionary.rs
+++ b/src/cmd/describegpt/dictionary.rs
@@ -186,7 +186,7 @@ pub(crate) const CONCEPT_VOCAB: &[&str] = &[
     // incorporated place's, and a zero-match layer simply loses the probe and is reported as a
     // per-candidate failure. Same shape as `geo.country`, a region concept with no Census
     // layer at all. Adding the CDP layer would widen coverage; it is not needed for the
-    // concept to be correct.
+    // concept to be correct, and is tracked as issue #4540.
     "geo.place_fips",
     "geo.country",
     // the ISO-3166 alpha-2 code, as distinct from `geo.country` (the name). Split for the same

--- a/src/cmd/describegpt/dictionary.rs
+++ b/src/cmd/describegpt/dictionary.rs
@@ -173,11 +173,20 @@ pub(crate) const CONCEPT_VOCAB: &[&str] = &[
     "geo.county_fips",
     "geo.state",
     "geo.state_fips",
-    // a 7-digit place GEOID (2-digit state + 5-digit place), the key of TIGERweb's "Incorporated
-    // Places" layer. Distinct from `geo.city`, which is a NAME needing forward geocoding to key a
-    // polygon; a place FIPS keys one directly. Issue #4524 -- `viz_census::Layer::Place` was fully
-    // implemented and probed by `--geojson auto`, but no dictionary could nominate a column for
-    // it.
+    // a 7-digit place GEOID (2-digit state + 5-digit place). Distinct from `geo.city`, which is a
+    // NAME needing forward geocoding to key a polygon; a place FIPS keys one directly. Issue #4524
+    // -- `viz_census::Layer::Place` was fully implemented and probed by `--geojson auto`, but no
+    // dictionary could nominate a column for it.
+    //
+    // The concept describes the DATA, and is deliberately broader than what `--geojson auto` can
+    // draw: Census places span INCORPORATED places and CENSUS DESIGNATED places, while
+    // `Layer::Place` matches only the "Incorporated Places" catalog entry, so a CDP-keyed column
+    // resolves against nothing. That degrades softly rather than mis-drawing -- the two kinds
+    // share one per-state place-FIPS numbering space, so a CDP code cannot collide with an
+    // incorporated place's, and a zero-match layer simply loses the probe and is reported as a
+    // per-candidate failure. Same shape as `geo.country`, a region concept with no Census
+    // layer at all. Adding the CDP layer would widen coverage; it is not needed for the
+    // concept to be correct.
     "geo.place_fips",
     "geo.country",
     // the ISO-3166 alpha-2 code, as distinct from `geo.country` (the name). Split for the same

--- a/src/cmd/viz.rs
+++ b/src/cmd/viz.rs
@@ -8430,6 +8430,35 @@ fn assemble_map_hover(
     lines.join("<br>")
 }
 
+/// Which reverse-geocoded components a chosen dataset hover column already supplies, so
+/// [`geocode_hover_place`] can drop them (gap-filling: dataset fields win).
+///
+/// `geo.country_code` supplies the country exactly as `geo.country` does. It has to be named
+/// explicitly because the value-level `shown` check in `geocode_hover_place` cannot catch it: that
+/// test asks whether the geocoded component already appears in the point's dataset line, and "US"
+/// does not contain "United States", so the hover would print both spellings of one country
+/// side by side. Found by review on issue #4524's PR, which added the concept to
+/// [`MAP_GEO_CONTEXT_CONCEPTS`] and so made a code-form country column selectable here.
+///
+/// Extracted from the caller purely so this is unit-testable — the hover assembly it came from is
+/// `#[cfg(feature = "geocode")]` and reaches for a live geocode engine.
+#[cfg(feature = "geocode")]
+fn hover_supplied_geo_components(
+    col_sems: &[ColSemantics],
+    hover_field_idxs: &[usize],
+) -> (bool, bool, bool) {
+    let (mut sup_city, mut sup_admin1, mut sup_country) = (false, false, false);
+    for &idx in hover_field_idxs {
+        match col_sems.get(idx).map_or("", |s| s.concept.as_str()) {
+            "geo.city" => sup_city = true,
+            "geo.state" => sup_admin1 = true,
+            "geo.country" | "geo.country_code" => sup_country = true,
+            _ => {},
+        }
+    }
+    (sup_city, sup_admin1, sup_country)
+}
+
 /// Format a reverse-geocoded `GeoLabel` into a "City, County, Admin1, Country" hover line for
 /// gap-filling — dataset fields win, so a component is dropped when (a) a chosen dataset column
 /// already covers it by concept (`sup_*`), or (b) its value already appears in this point's
@@ -29339,17 +29368,8 @@ fn build_map_panel(
     #[cfg(feature = "geocode")]
     let (core_places, out_places): (Vec<String>, Vec<String>) = {
         // which geocoded components are already supplied by a chosen dataset column (gap-filling)
-        let mut sup_city = false;
-        let mut sup_admin1 = false;
-        let mut sup_country = false;
-        for &idx in &hover_field_idxs {
-            match col_sems.get(idx).map(|s| s.concept.as_str()).unwrap_or("") {
-                "geo.city" => sup_city = true,
-                "geo.state" => sup_admin1 = true,
-                "geo.country" => sup_country = true,
-                _ => {},
-            }
-        }
+        let (sup_city, sup_admin1, sup_country) =
+            hover_supplied_geo_components(col_sems, &hover_field_idxs);
         // Always reverse-geocode when a map renders: even if the dataset already supplies
         // city/state/country, the lookup still contributes the county (always-on) and — under
         // --smarter — the US FIPS code. `geocode_hover_place` suppresses (via the sup_* flags) any
@@ -41380,6 +41400,45 @@ mod tests {
         assert_eq!(
             select_map_hover_fields(&stats, &sems, Some(&dict), 1, 2, true),
             vec![0, 3, 4]
+        );
+    }
+
+    #[cfg(feature = "geocode")]
+    #[test]
+    fn hover_country_code_suppresses_the_geocoded_country_name() {
+        // Adding `geo.country_code` to `MAP_GEO_CONTEXT_CONCEPTS` made a code-form country column
+        // selectable as a hover field, but the gap-filling flags only recognized `geo.country`, so
+        // reverse geocoding appended "United States" beside the dataset's "US". The value-level
+        // `shown` check in `geocode_hover_place` cannot catch that — the two spellings share no
+        // substring — so the concept has to be named here.
+        let sems = vec![
+            csem("id.natural_key"),
+            csem("geo.latitude"),
+            csem("geo.longitude"),
+            csem("geo.country_code"),
+        ];
+        assert_eq!(
+            hover_supplied_geo_components(&sems, &[0, 3]),
+            (false, false, true),
+            "a geo.country_code hover column must supply the country component"
+        );
+        // the name form still does, and neither form claims city or state
+        let named = vec![csem("geo.country")];
+        assert_eq!(
+            hover_supplied_geo_components(&named, &[0]),
+            (false, false, true)
+        );
+        // a column that is NOT in the hover set supplies nothing, so an unrelated geo column
+        // cannot suppress a component the hover never shows.
+        assert_eq!(
+            hover_supplied_geo_components(&sems, &[0]),
+            (false, false, false)
+        );
+        // `geo.state_fips` is deliberately not handled: it is absent from
+        // `MAP_GEO_CONTEXT_CONCEPTS`, so it can never be chosen as the geo-context field.
+        assert_eq!(
+            hover_supplied_geo_components(&[csem("geo.state_fips")], &[0]),
+            (false, false, false)
         );
     }
 

--- a/src/cmd/viz.rs
+++ b/src/cmd/viz.rs
@@ -24283,7 +24283,11 @@ const MAP_MEASURE_CONCEPTS: &[&str] = &[
     "measure.ratio",
 ];
 const MAP_CATEGORY_CONCEPTS: &[&str] = &["category.status", "category.type", "category.channel"];
-const MAP_GEO_CONTEXT_CONCEPTS: &[&str] = &["geo.country", "geo.state", "geo.city"];
+// `geo.country_code` follows `geo.country` rather than replacing it: splitting the concept
+// (issue #4524) would otherwise drop a code-form country column out of hover context entirely,
+// and where a dataset carries both forms the NAME is the more readable hover value.
+const MAP_GEO_CONTEXT_CONCEPTS: &[&str] =
+    &["geo.country", "geo.country_code", "geo.state", "geo.city"];
 
 /// Observed numeric range (`|max - min|`) of a column from its stats, or 0.0 when unparseable.
 fn stat_range(s: &crate::cmd::stats::StatsData) -> f64 {
@@ -27970,6 +27974,16 @@ const REGION_CODE_LEAVES: &[&str] = &[
     "state",
     "state_fips",
     "country",
+    // the ISO-3166 alpha-2 code form of `country`, split off as its own concept in issue #4524.
+    // Listed here so splitting the concept does not silently cost a code-form country column its
+    // choropleth candidacy against a custom `--geojson` file.
+    "country_code",
+    // a 7-digit place GEOID, the key of `viz_census::Layer::Place`. The layer was already
+    // implemented and probed by `--geojson auto`, but with no leaf here no dictionary could
+    // nominate a column for it (issue #4524). A bare `place` is deliberately NOT a lenient alias:
+    // it reads equally as a place NAME, which keys no polygon without forward geocoding, and
+    // guessing between the two is the ambiguity issue #4417 settled as a refusal.
+    "place_fips",
     "fips",
 ];
 
@@ -41341,6 +41355,93 @@ mod tests {
             vec![0, 3, 4],
             "a measure.money column must be hover-eligible like any other measure"
         );
+    }
+
+    #[test]
+    fn select_map_hover_fields_geo_context_accepts_a_country_code() {
+        // `MAP_GEO_CONTEXT_CONCEPTS` is a CLOSED enumeration, so splitting `geo.country_code`
+        // off `geo.country` (issue #4524) would have dropped a code-form country column out of
+        // hover context entirely. The column is eligible only because the token was added.
+        let stats = vec![
+            stat("String", 1000, Some(0.99)), // 0: id
+            stat("Float", 9, Some(0.5)),      // 1: lat
+            stat("Float", 9, Some(0.5)),      // 2: lon
+            stat("Float", 100, Some(0.5)),    // 3: measure
+            stat("String", 4, Some(0.04)),    // 4: country code
+        ];
+        let sems = vec![
+            csem("id.natural_key"),
+            csem("geo.latitude"),
+            csem("geo.longitude"),
+            csem("measure.amount"),
+            csem("geo.country_code"),
+        ];
+        let dict = DictData::default();
+        assert_eq!(
+            select_map_hover_fields(&stats, &sems, Some(&dict), 1, 2, true),
+            vec![0, 3, 4]
+        );
+    }
+
+    #[test]
+    fn region_code_candidates_accept_place_fips_and_country_code() {
+        // issue #4524. `viz_census::Layer::Place` is fully implemented and probed by
+        // `--geojson auto`, but with no `place_fips` leaf no dictionary could nominate a column
+        // for it, so the layer was unreachable from `viz smart`.
+        let stats = vec![
+            stat("String", 30, Some(0.3)),  // 0: place GEOID
+            stat("String", 4, Some(0.04)),  // 1: ISO-3166 alpha-2
+            stat("Float", 100, Some(0.99)), // 2: a measure, never a region key
+        ];
+        let sems = vec![
+            csem("geo.place_fips"),
+            csem("geo.country_code"),
+            csem("measure.amount"),
+        ];
+        assert_eq!(region_code_candidates(&stats, &sems), vec![0, 1]);
+
+        // A bare `place` is deliberately NOT a lenient alias the way `zip`/`fips` are: it reads
+        // equally as a place NAME, which keys no polygon without forward geocoding.
+        let bare = vec![
+            csem("geo.place"),
+            csem("geo.country_code"),
+            csem("measure.amount"),
+        ];
+        assert_eq!(region_code_candidates(&stats, &bare), vec![1]);
+        // ... and it is not silently absorbed by the geocodable NAME pool either.
+        assert!(geocodable_name_candidates(&stats, &bare).is_empty());
+    }
+
+    #[test]
+    fn is_region_concept_accepts_place_fips_and_country_code() {
+        // `REGION_CODE_LEAVES` has a second consumer beyond choropleth candidacy: the
+        // region-deduped KPI/bar path (issues #4528/#4534). A place and a country are both
+        // regions a per-region measure can be constant within, so widening it here is correct.
+        assert!(is_region_concept("geo.place_fips"));
+        assert!(is_region_concept("geo.country_code"));
+        // A timezone or a gazetteer id names no boundary, so neither may own a region-level
+        // measure — which is why #4524's other two concepts stay out of the leaf lists.
+        assert!(!is_region_concept("geo.timezone"));
+        assert!(!is_region_concept("geo.geonames_id"));
+    }
+
+    #[test]
+    fn new_geo_concepts_route_to_dimension() {
+        // Issue #4524's checklist asked for `route_from_concept` arms for these leaves; the
+        // `geo` arm's catch-all already routes every one of them, so that item is a no-op.
+        // Pinned here so a future arm-by-arm rewrite of that match cannot silently drop one.
+        for concept in [
+            "geo.place_fips",
+            "geo.country_code",
+            "geo.timezone",
+            "geo.geonames_id",
+        ] {
+            assert_eq!(
+                route_from_concept(concept),
+                Some((Route::Dimension, None)),
+                "{concept} must route to a dimension"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
PR A of the three-way split proposed in https://github.com/dathere/qsv/issues/4524#issuecomment-5540248962 — the mechanical items (1, 3, 5). `geo.zcta` and `geo.ip_address` are deliberately left out; see **Deferred** below.

## What changed

**`geo.place_fips` (item 1).** `viz_census::Layer::Place` is fully implemented and probed by `--geojson auto`, but `REGION_CODE_LEAVES` had no place leaf, so no data dictionary could nominate a column for it and the layer was unreachable from `viz smart`. Adds the concept and the leaf.

Two refinements on the issue's framing, worth knowing when reviewing:

* Place was never *dead* — `viz choropleth --locations placecol --geojson census:place` works on master. Only the smart path was blocked.
* The leaf gates **candidacy only, not layer choice**: `resolve` already probes every `Layer::ALL` member regardless of the column's leaf, so a 7-digit place column mis-tagged `geo.county_fips` already charted as places by accident. This makes it *correct*, not newly possible.

**`geo.country_code` (item 3).** Split off `geo.country`, for the reason the vocabulary already splits `geo.state`/`geo.state_fips` and `geo.county`/`geo.county_fips`: `US` and `United States` denote the same country but are not join-compatible, and `geocode countryinfo` takes the alpha-2 form only.

The split has **three consumers the issue's checklist did not list**, and this is the part most worth reviewing:

| Consumer | Without the addition |
|---|---|
| `REGION_CODE_LEAVES` | code-form country column loses choropleth candidacy |
| `MAP_GEO_CONTEXT_CONCEPTS` | loses map-hover geo context (it is a CLOSED enumeration, not a prefix test) |
| `DENOMINATOR_REGION_CONCEPTS` | loses its per-region denominator hint |

The code form is added to each, so the split is a consistency fix rather than a regression.

**`geo.timezone` / `geo.geonames_id` (item 5).** `time_zone` had no concept at all; it is now seeded deterministically. `geo.geonames_id` is LLM-only — a Geonames id is an undistinguished integer, so no `content_type` can seed it.

## Decisions taken

**A bare `place` leaf is deliberately NOT added**, though the issue's checklist listed it. It reads equally as a place *code* and a place *NAME*, and a name keys no polygon without forward geocoding — `REGION_CODE_LEAVES`' own doc comment excludes name columns for exactly that reason, which is why `CITY_NAME_LEAVES` exists. Guessing between the two is the ambiguity #4417 settled as a refusal. A test pins that `geo.place` lands in neither pool.

**`geo.timezone` is `is_linkable_concept`**, i.e. advertised as a cross-dataset join key. That is intended — IANA zone names genuinely join. Flagging it because it is the *same* namespace-implies-join-key property that blocks `geo.ip_address` below; the difference is that an IP address is personal data in many jurisdictions and an IANA zone is not.

## Two checklist items that turned out to be no-ops

Reporting rather than silently "doing" them:

* **`route_from_concept` arms.** The `"geo" =>` arm already ends in `_ => (Route::Dimension, None)`, so all four new leaves already routed correctly. Nothing to change — but a test now pins it, so a future arm-by-arm rewrite of that match cannot silently drop one.
* **MCP skill JSON / help regen.** No `CONCEPT_VOCAB` token reaches a USAGE string (`concept_vocab_list()` feeds prompt templates only). Verified by actually running `--update-mcp-skills` and `--generate-help-md`: zero diff.

## Known caveat: existing describegpt caches will not pick this up

`get_cache_key_with_flag` hashes flags, file content and the dictionary — **not** the vocabulary lists or the qsv version. So on a file already described with `--infer-content-type`, the next run returns the cached response and the new concepts do not appear until `--no-cache` or a cache purge.

This is pre-existing and general to every vocabulary change, not introduced here, so it is filed separately as #4538 rather than fixed in this PR — the fix has its own design question (fingerprint the rendered prompt vs. a manual epoch vs. warn-only) and would bust every existing describegpt cache.

## Deferred to follow-up PRs

* **`geo.zcta` (item 2).** The ZCTA-vs-ZIP caveat the issue wants stamped into provenance **does not exist on master** — the only such text is the `DenominatorGeography` doc comment explaining why ZCTAs aren't a denominator geography. So it is new feature work needing a design (where does the caveat surface?), not a routing addition.
* **`geo.ip_address` (item 4).** Blocked on a namespace decision, not a missing mapping line. Any `geo.` prefix makes a concept `is_linkable_concept`, so `geo.ip_address` would advertise an IP address as a cross-dataset join key; `pii.ip_address` is safer but routes to `Route::Skip`, defeating the purpose. Also note the issue slightly overstates current behavior: `role_from_content_type` only coerces to `identifier` when the role is already `measure`, so an IP column normally keeps `dimension` today.

## Testing

* 10 new tests. **Every new assertion was mutation-tested** — dropping each new token from its constant makes the corresponding test fail (6/6 caught). This repo has been bitten twice by viz assertions that passed while asserting nothing, so the tests are not trusted without it.
* Includes an `every_deterministic_concept_is_in_the_vocabulary` invariant guarding *all* future mappings: `coerce_role_concept` writes a deterministic seed without re-validating it, while `parse_llm_dictionary_response` rejects out-of-vocab concepts — so a seed missing from `CONCEPT_VOCAB` would emit a token the dictionary's own parser refuses to read back.
* One assertion was added in the second commit after review caught it was vacuous: seeding `time_zone` moved it from `coerce_role_concept`'s namespace-mismatch branch to the deterministic branch, and the original assertion passed on either. The behavior that actually changed is a *dissenting* concept — a `time.*` tag on a tz column used to reset to the routeless `"unknown"` and now resets to `geo.timezone`.
* 1079 unit tests + 651 viz/describegpt integration tests pass. `cargo clippy` clean (3 warnings, all pre-existing at `viz.rs:47482`/`48121`). `scripts/double-run-check.py --check` OK.

Closes nothing on its own — #4524 stays open for items 2 and 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
