### PR TITLE
viz: skip the rate panel when an `x-qsv.denominator` is constant across regions (#4547)

### DIFF
--- a/src/cmd/viz.rs
+++ b/src/cmd/viz.rs
@@ -29597,17 +29597,22 @@ fn build_smart_summary_choropleth_panels(
                     );
                     None
                 } else if let Some(constant) = single_distinct_denominator(usable) {
-                    // Name both numbers, the way the constancy note names its region: the constant
-                    // tells the reader whether this is a placeholder or a genuinely uniform
-                    // denominator, and the region count shows the check had something to compare.
-                    let n_regions = usable.len();
+                    // Name the constant AND both region counts. The constant tells the reader
+                    // whether this is a placeholder or a genuinely uniform denominator. The counts
+                    // must be reported as "N of M": the check ranges over the regions that HAVE a
+                    // usable denominator, which is not always every matched region, and calling
+                    // that subset "all M matched regions" overstates it (roborev 4605). The `N of
+                    // M` shape matches the `denominator_excluded` note's own vocabulary.
+                    let n_usable = usable.len();
+                    let n_matched = count_locs.len();
                     viz_skip_note!(
                         VIZ_SMART_PREFIX,
                         "viz.omit.denominator_invalid",
                         q_col = name,
                         q_reason = format!(
-                            "it takes a single distinct value ({constant}) across all {n_regions} \
-                             matched regions, so a rate would be the count rescaled by a constant"
+                            "it takes a single distinct value ({constant}) across the {n_usable} \
+                             of {n_matched} matched regions that have one, so a rate would be the \
+                             count rescaled by a constant"
                         )
                     );
                     None

--- a/src/cmd/viz.rs
+++ b/src/cmd/viz.rs
@@ -7973,6 +7973,40 @@ struct RateSeries {
     excluded:     usize,
 }
 
+/// The single value a denominator map holds, when every matched region agrees on it (issue #4547).
+///
+/// A denominator that is constant across regions makes the rate panel the count panel rescaled by
+/// a constant: every rank, every relative comparison and the shape of the map are identical, and
+/// only the axis label and the magnitude change. That happens for unrelated reasons (a placeholder
+/// column, a join that collapsed, a genuinely uniform denominator) and the caller need not tell
+/// them apart — the panel carries no actionable information in any of them.
+///
+/// `None` for fewer than two regions: one region is not a degenerate comparison, it is not a
+/// comparison at all, and the rate panel already declines to draw it (`series.locs.len() >= 2`).
+/// Reporting it as degenerate would tell the reader something false.
+///
+/// Equality here is the exact negation of the row pass's within-region constancy test
+/// (`(prev - d).abs() > f64::EPSILON * prev.abs().max(1.0)`), so a pair that check calls equal can
+/// never read as distinct here. The anchor is the MINIMUM rather than whichever entry the map
+/// happens to yield first: `HashMap` iteration order is nondeterministic, and under a tolerance
+/// predicate the choice of anchor is observable.
+///
+/// Deliberately threshold-free, and deliberately NOT a ratio of distinct values to regions. The
+/// ratio form was investigated on issue #4526 and disproved with measured data — a legitimate
+/// per-city denominator scores 0.227 while the coarse-geography bug scores 0.500, so the classes
+/// are inverted and no threshold separates them. This says only that the panel is degenerate; it
+/// infers nothing about which geography the denominator describes.
+fn single_distinct_denominator(denoms: &HashMap<String, f64>) -> Option<f64> {
+    if denoms.len() < 2 {
+        return None;
+    }
+    let anchor = denoms.values().copied().fold(f64::INFINITY, f64::min);
+    denoms
+        .values()
+        .all(|d| (anchor - d).abs() <= f64::EPSILON * anchor.abs().max(1.0))
+        .then_some(anchor)
+}
+
 /// Pair each region with its denominator and compute the raw per-region ratio, dropping regions
 /// with no usable denominator. `locs`/`values` are aligned 1:1 (region key, numerator); `denoms`
 /// maps region key -> positive denominator. Order is preserved, so the caller's first-seen region
@@ -20496,6 +20530,13 @@ enum Route {
 #[derive(Clone, PartialEq, Eq, Debug)]
 enum DenominatorSource {
     /// A dataset column index, whose value must be constant within a region.
+    ///
+    /// INVARIANT: this variant is constructed in exactly one place — the dictionary-hint arm of
+    /// `denom_source` — and that arm has already filtered `denom_by_cand[ci]` down to the POSITIVE
+    /// denominators before yielding it, because the degeneracy check there (issue #4547) has to
+    /// see the same map the panel is drawn from. Anything reading `denom_by_cand` for this variant
+    /// therefore gets pre-filtered values and must NOT filter again. A new variant that reads that
+    /// map from somewhere else does not inherit the filter and has to do its own.
     Column(usize),
     /// A dotted property path on each `--geojson` feature (e.g. `properties.POP2020`).
     GeojsonProperty(String),
@@ -29537,16 +29578,42 @@ fn build_smart_summary_choropleth_panels(
                     q_reason = format!("it is not constant within region '{region}'")
                 );
                 None
-            } else if !denom_by_cand[ci].values().any(|d| *d > 0.0) {
-                viz_skip_note!(
-                    VIZ_SMART_PREFIX,
-                    "viz.omit.denominator_invalid",
-                    q_col = name,
-                    q_reason = "it holds no positive numbers for the matched regions"
-                );
-                None
             } else {
-                Some(DenominatorSource::Column(*idx))
+                // Drop the unusable values HERE, once, and let every check below plus the
+                // consumption site read the same filtered map. They had to survive the constancy
+                // check to be compared against their region's other rows, but that check is
+                // already done — it ran during the row pass and its verdict is `denom_conflict`
+                // above. From this point down we are describing the panel that will ACTUALLY be
+                // drawn, and the rate panel only ever charts positive denominators, so a check
+                // that counted the others would describe a different panel than the reader sees.
+                denom_by_cand[ci].retain(|_, d| *d > 0.0);
+                let usable = &denom_by_cand[ci];
+                if usable.is_empty() {
+                    viz_skip_note!(
+                        VIZ_SMART_PREFIX,
+                        "viz.omit.denominator_invalid",
+                        q_col = name,
+                        q_reason = "it holds no positive numbers for the matched regions"
+                    );
+                    None
+                } else if let Some(constant) = single_distinct_denominator(usable) {
+                    // Name both numbers, the way the constancy note names its region: the constant
+                    // tells the reader whether this is a placeholder or a genuinely uniform
+                    // denominator, and the region count shows the check had something to compare.
+                    let n_regions = usable.len();
+                    viz_skip_note!(
+                        VIZ_SMART_PREFIX,
+                        "viz.omit.denominator_invalid",
+                        q_col = name,
+                        q_reason = format!(
+                            "it takes a single distinct value ({constant}) across all {n_regions} \
+                             matched regions, so a rate would be the count rescaled by a constant"
+                        )
+                    );
+                    None
+                } else {
+                    Some(DenominatorSource::Column(*idx))
+                }
             }
         },
         (None, None) => None,
@@ -29573,10 +29640,10 @@ fn build_smart_summary_choropleth_panels(
                 ),
             ),
             DenominatorSource::Column(idx) => {
-                // drop the unusable values only now: they had to survive the constancy check
-                // above to be compared against their region's other rows.
-                let mut m = std::mem::take(&mut denom_by_cand[ci]);
-                m.retain(|_, d| *d > 0.0);
+                // Already filtered to the positive values by the `Ok(idx)` arm above, which had to
+                // see the same map this panel is drawn from for its degeneracy check to describe
+                // the right panel (issue #4547). Do NOT re-add a filter here: one source of truth.
+                let m = std::mem::take(&mut denom_by_cand[ci]);
                 let unit = resolve_denominator_unit(
                     args.flag_denominator_unit.as_deref(),
                     col_sems[region_idx].denominator_unit.as_deref(),
@@ -44480,6 +44547,96 @@ mod tests {
         assert_eq!(s.denominators, vec![10_000.0, 50_000.0]);
         assert_eq!(s.rates, vec![0.003, 0.0012]);
         assert_eq!(s.excluded, 2, "B and D have no denominator");
+    }
+
+    // issue #4547. The degeneracy check itself, away from the panel plumbing:
+    // `denominator_excluded` only ever fires INSIDE the `series.locs.len() >= 2` guard, so the
+    // one-region half of this rule has no end-to-end signal to assert against and would pass
+    // vacuously as an integration test. Pinned here instead, where the guard is directly
+    // observable.
+    #[test]
+    fn single_distinct_denominator_needs_two_regions_to_be_degenerate() {
+        let one: HashMap<String, f64> = [("A".to_string(), 50_000.0)].into_iter().collect();
+        assert_eq!(
+            single_distinct_denominator(&one),
+            None,
+            "one region is not a degenerate comparison, it is not a comparison at all — the rate \
+             panel already declines to draw it, and reporting it as degenerate would tell the \
+             reader something false"
+        );
+        assert_eq!(
+            single_distinct_denominator(&HashMap::new()),
+            None,
+            "no regions, nothing to compare"
+        );
+
+        let two_equal: HashMap<String, f64> =
+            [("A".to_string(), 50_000.0), ("B".to_string(), 50_000.0)]
+                .into_iter()
+                .collect();
+        assert_eq!(
+            single_distinct_denominator(&two_equal),
+            Some(50_000.0),
+            "two regions agreeing on one value is the degenerate case, and the constant is \
+             reported so the reader can tell a placeholder from a uniform denominator"
+        );
+    }
+
+    #[test]
+    fn single_distinct_denominator_ignores_a_genuine_spread() {
+        // The MUTATION GUARD on the whole check: a denominator that actually varies must keep its
+        // rate panel. Without this, a `single_distinct_denominator` that always returned `Some`
+        // would still pass the degenerate-case test above.
+        let varied: HashMap<String, f64> = [
+            ("A".to_string(), 10_000.0),
+            ("B".to_string(), 200_000.0),
+            ("C".to_string(), 50_000.0),
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(single_distinct_denominator(&varied), None);
+
+        // Two distinct values across four regions is the issue #4526 coarse-geography repro (four
+        // counties carrying two distinct STATE populations). It is a real bug and it stays open —
+        // this check deliberately does NOT fire on it. The ratio form that would was disproved
+        // with measured data on that issue: a legitimate per-city denominator scores 0.227 while
+        // this bug scores 0.500, so the classes are inverted and no threshold separates them.
+        // Do not "finish the job" by generalizing this into a ratio.
+        let coarse: HashMap<String, f64> = [
+            ("A".to_string(), 1_000_000.0),
+            ("B".to_string(), 1_000_000.0),
+            ("C".to_string(), 2_000_000.0),
+            ("D".to_string(), 2_000_000.0),
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(
+            single_distinct_denominator(&coarse),
+            None,
+            "D=2/R=4 is issue #4526, not this check"
+        );
+    }
+
+    #[test]
+    fn single_distinct_denominator_agrees_with_the_row_pass_constancy_test() {
+        // Equality here is the exact negation of the within-region constancy test in the row pass
+        // (`(prev - d).abs() > f64::EPSILON * prev.abs().max(1.0)`). If the two ever disagree, a
+        // pair the row pass calls constant would read as two distinct values here and the panel
+        // would survive as a rate that is really a rescaled count.
+        let a = 50_000.0_f64;
+        let b = a + a * f64::EPSILON * 0.5; // within the row pass's tolerance
+        assert!(
+            (a - b).abs() <= f64::EPSILON * a.abs().max(1.0),
+            "fixture check: the row pass must consider these constant"
+        );
+        let near: HashMap<String, f64> = [("A".to_string(), a), ("B".to_string(), b)]
+            .into_iter()
+            .collect();
+        assert_eq!(
+            single_distinct_denominator(&near),
+            Some(a),
+            "a pair the row pass calls constant must not read as two distinct values"
+        );
     }
 
     #[test]

--- a/tests/test_viz.rs
+++ b/tests/test_viz.rs
@@ -18881,15 +18881,66 @@ fn viz_smart_single_value_hint_denominator_skips_the_rate_panel() {
     );
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
-        stderr.contains("single distinct value (50000) across all 3 matched regions"),
-        "the note must name the constant AND the region count — the constant tells the reader \
-         whether this is a placeholder or a genuinely uniform denominator, the count shows the \
-         check had something to compare: {stderr}"
+        stderr.contains("single distinct value (50000) across the 3 of 3 matched regions"),
+        "the note must name the constant AND both region counts — the constant tells the reader \
+         whether this is a placeholder or a genuinely uniform denominator, and `N of M` says how \
+         much of the map the check actually ranged over: {stderr}"
     );
     let html = String::from_utf8_lossy(&out.stdout);
     assert!(
         !html.contains("per 1,000 residents"),
         "no rate panel: {html}"
+    );
+    assert!(
+        html.contains("add --denominator-key for a rate"),
+        "the count panel must fall back to its caveat: {html}"
+    );
+}
+
+// roborev 4605. A region EXCLUDED for want of a usable denominator does not disable the check:
+// the panel that would be drawn still covers only the regions that have one, and over that domain
+// it is still the count panel rescaled by a constant. A placeholder or collapsed-join denominator
+// — the very shape this check exists to catch — routinely carries blanks and zeros, so requiring
+// every matched region to be usable would disable the check on its primary target.
+//
+// It also pins the note's `N of M` wording, which is why this case matters: the check ranges over
+// the USABLE regions, and calling that subset "all M matched regions" overstates it.
+#[test]
+fn viz_smart_single_value_denominator_still_fires_when_a_region_is_excluded() {
+    let wrk =
+        Workdir::new("viz_smart_single_value_denominator_still_fires_when_a_region_is_excluded");
+    let mut csv = String::from("region,pop\n");
+    csv.push_str(&"A,50000\n".repeat(30));
+    csv.push_str(&"B,50000\n".repeat(300));
+    csv.push_str(&"C,50000\n".repeat(60));
+    // consistently zero, so it is an EXCLUSION rather than a within-region conflict
+    csv.push_str(&"D,0\n".repeat(90));
+    wrk.create_from_string("rg.csv", &csv);
+    wrk.create_from_string("regions.geojson", denom_geojson());
+    wrk.create_from_string("d.schema.json", &denom_dictionary(true));
+
+    let mut cmd = wrk.command("viz");
+    cmd.args([
+        "smart",
+        "rg.csv",
+        "--geojson",
+        "regions.geojson",
+        "--dictionary",
+        "d.schema.json",
+    ]);
+    let out = wrk.output(&mut cmd);
+    assert!(out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("single distinct value (50000) across the 3 of 4 matched regions"),
+        "the check must still fire with a region excluded, and must report the USABLE count \
+         against the MATCHED count rather than calling 3 regions 'all 4': {stderr}"
+    );
+    let html = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !html.contains("residents"),
+        "no rate panel — a constant denominator over 3 of 4 regions is still a rescaled count \
+         over those 3: {html}"
     );
     assert!(
         html.contains("add --denominator-key for a rate"),

--- a/tests/test_viz.rs
+++ b/tests/test_viz.rs
@@ -18847,6 +18847,110 @@ fn viz_smart_consistently_zero_hint_denominator_is_an_exclusion() {
     assert!(html.contains("1 of 3 without a denominator"), "{html}");
 }
 
+// issue #4547: a dictionary `x-qsv.denominator` that resolves to ONE distinct value across every
+// matched region makes the rate panel the count panel rescaled by a constant — same ranks, same
+// relative comparisons, same map shape, only the axis label and magnitude differ. It carries no
+// information a reader can act on, so the panel is skipped with a note rather than drawn.
+#[test]
+fn viz_smart_single_value_hint_denominator_skips_the_rate_panel() {
+    let wrk = Workdir::new("viz_smart_single_value_hint_denominator_skips_the_rate_panel");
+    // The row counts (30/300/60) are load-bearing — they are what the region panel is built from.
+    // Only the DENOMINATOR is flattened: every region reports the same population, as a collapsed
+    // join or a placeholder column would.
+    let mut csv = String::from("region,pop\n");
+    csv.push_str(&"A,50000\n".repeat(30));
+    csv.push_str(&"B,50000\n".repeat(300));
+    csv.push_str(&"C,50000\n".repeat(60));
+    wrk.create_from_string("rg.csv", &csv);
+    wrk.create_from_string("regions.geojson", denom_geojson());
+    wrk.create_from_string("d.schema.json", &denom_dictionary(true));
+
+    let mut cmd = wrk.command("viz");
+    cmd.args([
+        "smart",
+        "rg.csv",
+        "--geojson",
+        "regions.geojson",
+        "--dictionary",
+        "d.schema.json",
+    ]);
+    let out = wrk.output(&mut cmd);
+    assert!(
+        out.status.success(),
+        "a degenerate hint is not a hard error"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("single distinct value (50000) across all 3 matched regions"),
+        "the note must name the constant AND the region count — the constant tells the reader \
+         whether this is a placeholder or a genuinely uniform denominator, the count shows the \
+         check had something to compare: {stderr}"
+    );
+    let html = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !html.contains("per 1,000 residents"),
+        "no rate panel: {html}"
+    );
+    assert!(
+        html.contains("add --denominator-key for a rate"),
+        "the count panel must fall back to its caveat: {html}"
+    );
+}
+
+// The BOUNDARY of the check above, and the reason it is deliberately partial. Four regions
+// carrying two distinct STATE populations is the verified repro on issue #4526 — a real
+// coarse-geography bug that stays OPEN and silent. `D == 1` does not fire on it, and this test
+// exists to stop a future reviewer "finishing the job" by generalizing the check into a ratio:
+// that form was investigated on #4526 and disproved with measured data, because a legitimate
+// per-city denominator scores 0.227 while this bug scores 0.500 — the classes are inverted and no
+// threshold separates them.
+#[test]
+fn viz_smart_two_value_denominator_still_rates_the_coarse_geography_repro() {
+    let wrk =
+        Workdir::new("viz_smart_two_value_denominator_still_rates_the_coarse_geography_repro");
+    let mut csv = String::from("region,pop\n");
+    csv.push_str(&"A,1000000\n".repeat(30));
+    csv.push_str(&"B,1000000\n".repeat(300));
+    csv.push_str(&"C,2000000\n".repeat(60));
+    csv.push_str(&"D,2000000\n".repeat(90));
+    wrk.create_from_string("rg.csv", &csv);
+    wrk.create_from_string("regions.geojson", denom_geojson());
+    wrk.create_from_string("d.schema.json", &denom_dictionary(true));
+
+    let mut cmd = wrk.command("viz");
+    cmd.args([
+        "smart",
+        "rg.csv",
+        "--geojson",
+        "regions.geojson",
+        "--dictionary",
+        "d.schema.json",
+    ]);
+    let out = wrk.output(&mut cmd);
+    assert!(out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("single distinct value"),
+        "D=2/R=4 is issue #4526, NOT the degenerate-denominator check — it must not fire here: \
+         {stderr}"
+    );
+    let html = String::from_utf8_lossy(&out.stdout);
+    // `per 100,000` rather than the `per 1,000` of the sibling fixtures: these are STATE-sized
+    // populations, and `rate_scale` picks the rung that keeps the rate readable. This assertion is
+    // therefore coupled to rung selection — if `rate_scale` is ever retuned it fails for a reason
+    // that has nothing to do with what this test is about. Re-aim it at the new rung; do NOT
+    // weaken it, and do not delete the caveat assertion below, which is the scale-independent one
+    // and carries the real signal that a rate panel was charted at all.
+    assert!(
+        html.contains("per 100,000 residents"),
+        "the rate panel still renders — this bug is not closed by #4547: {html}"
+    );
+    assert!(
+        !html.contains("add --denominator-key for a rate"),
+        "the count panel must NOT fall back to its raw-count caveat — a rate was charted: {html}"
+    );
+}
+
 // issue #4414: `--denominator-key` derived its label from the property path's last segment and
 // divided by the raw value, so real published boundary files — which carry land area in square
 // METRES — rendered "per 100,000 AREALAND" at a rate that clamped to the widest rung and still


### PR DESCRIPTION
Closes #4547.

## Problem

A dictionary `x-qsv.denominator` that resolves to **one distinct value** across every matched region makes the rate panel the count panel rescaled by a constant. Every region's rank, every relative comparison and the shape of the map are identical to the raw count map — only the axis label and the magnitude change. It carries no information a reader can act on.

That happens for several unrelated reasons (a placeholder column, a join that collapsed, a genuinely uniform denominator), and the fix does not need to tell them apart: the panel is uninformative in all of them.

## What changed

- **`single_distinct_denominator`** (`src/cmd/viz.rs`) — returns the constant when ≥2 matched regions all agree on it, `None` otherwise. The hint arm skips the rate panel and emits a note naming **both** the constant and the region count: the constant tells the reader whether this is a placeholder or a real uniform denominator, the count shows the check had something to compare.
- **The positive-value filter moves up** into the dictionary-hint arm, so the check sees the same map the panel is actually drawn from — a check that counted the non-positives would describe a different panel than the reader gets. The now-redundant filter at the consumption site is removed, and the invariant is recorded on `DenominatorSource::Column` itself (which has exactly one construction site) so a future variant reading that map knows it does not inherit the filter.
- **Equality is the exact negation of the row pass's within-region constancy test**, so a pair that check calls constant can never read as two distinct values here. The anchor is the minimum rather than whichever entry the map yields first — `HashMap` order is nondeterministic, and under a tolerance predicate the anchor is observable.
- Degrades the way every other denominator problem does — skip with a note, never error. A dictionary is a hand-editable sidecar, so a bad hint must not take the Data Schematic down.

**No locale changes.** Reuses the `viz.omit.denominator_invalid` key, whose `q_reason` is documented as an English clause from the code, so the 359-key parity across the 8 locale files is untouched.

## ⚠️ This is PARTIAL — it does NOT close #4526

- #4526's verified repro is `D = 2`, `R = 4` (four counties carrying two distinct state populations). `D == 1` does not fire on it. **That bug stays open and silent after this lands.**
- The related **ratio** check (`D/R` below some threshold) was investigated on #4526 and disproved with measured data — a legitimate per-city denominator scores 0.227 while the bug scores 0.500, so the classes are inverted and no threshold separates them.
- `viz_smart_two_value_denominator_still_rates_the_coarse_geography_repro` pins that boundary, specifically so this check is not later generalized into a ratio.

## Tests

3 unit + 2 end-to-end:

| test | pins |
| --- | --- |
| `single_distinct_denominator_needs_two_regions_to_be_degenerate` | the `R >= 2` guard (one region is not a degenerate comparison; `denominator_excluded` only fires inside the `locs.len() >= 2` guard, so this half has no end-to-end signal and would pass vacuously as an integration test) |
| `single_distinct_denominator_ignores_a_genuine_spread` | a real spread keeps its panel, incl. the #4526 `D=2/R=4` repro |
| `single_distinct_denominator_agrees_with_the_row_pass_constancy_test` | the epsilon matches the row pass exactly |
| `viz_smart_single_value_hint_denominator_skips_the_rate_panel` | the note, no rate panel, count caveat restored |
| `viz_smart_two_value_denominator_still_rates_the_coarse_geography_repro` | `D=2/R=4` still charts a rate |

**All five were mutation-tested** — dropping the `R >= 2` guard, always-degenerate, exact equality instead of the epsilon, the check disabled, and a ratio-style generalization each fail exactly one intended test.

553 viz integration tests and 1135 unit tests green; `scripts/double-run-check.py --check` clean; 3 pre-existing clippy warnings unchanged (lines 5130 / 25241 / 28644, all outside this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
