### PR TITLE
ci(viz-static): run when the UCUM display table changes (#4557)

### DIFF
--- a/.github/workflows/rust-viz-static.yml
+++ b/.github/workflows/rust-viz-static.yml
@@ -15,12 +15,30 @@ on:
     paths:
       - 'src/cmd/viz.rs'
       - 'tests/test_viz.rs'
+      # The UCUM display table feeds the hover rendering contract (issue #4557):
+      # viz.rs's `unit_suffix` calls `describegpt::dictionary::ucum_display_symbol`, so a
+      # symbol edited here lands in a hovertemplate. Note the browser is NOT the first line
+      # of defence for that — `viz_smart_hover_contract_fixture_reaches_the_bubble_template`
+      # is browser-free, carries no `viz_static` in its name, and so already catches a table
+      # change that alters the EMITTED template in every viz job. This entry covers the
+      # narrower case that guard cannot see: a symbol that emits fine but RENDERS wrong,
+      # i.e. one containing `<`, `&` or `%{`.
+      - 'src/cmd/describegpt/dictionary.rs'
       - '.github/workflows/rust-viz-static.yml'
   pull_request:
     branches: [ master ]
     paths:
       - 'src/cmd/viz.rs'
       - 'tests/test_viz.rs'
+      # The UCUM display table feeds the hover rendering contract (issue #4557):
+      # viz.rs's `unit_suffix` calls `describegpt::dictionary::ucum_display_symbol`, so a
+      # symbol edited here lands in a hovertemplate. Note the browser is NOT the first line
+      # of defence for that — `viz_smart_hover_contract_fixture_reaches_the_bubble_template`
+      # is browser-free, carries no `viz_static` in its name, and so already catches a table
+      # change that alters the EMITTED template in every viz job. This entry covers the
+      # narrower case that guard cannot see: a symbol that emits fine but RENDERS wrong,
+      # i.e. one containing `<`, `&` or `%{`.
+      - 'src/cmd/describegpt/dictionary.rs'
       - '.github/workflows/rust-viz-static.yml'
   schedule:
     # weekly, so driver/browser drift is caught even when viz.rs is untouched


### PR DESCRIPTION
Small CI follow-up to #4566.

## What

`.github/workflows/rust-viz-static.yml` now also triggers on `src/cmd/describegpt/dictionary.rs`.

## Why

`viz.rs`'s `unit_suffix` (line 7847) calls `describegpt::dictionary::ucum_display_symbol`, so a symbol edited in that table lands directly in a plotly hovertemplate — and the workflow that renders hovers in a browser did not watch the file.

**Verified, not assumed.** Deleting the `("%", "%")` entry at `dictionary.rs:397` drops the unit suffix from the bubble template:

```
EXPECTED: gdp % index: %{x} %<br>…
ACTUAL:   gdp % index: %{x}<br>…
```

## Deliberately modest — please don't over-read it

The browser is **not** the first line of defence here. The mutation above is caught by `viz_smart_hover_contract_fixture_reaches_the_bubble_template`, which is browser-free, carries no `viz_static` in its name, and therefore **already runs in every viz job on every PR**.

This entry covers only the narrower case that guard cannot see: a UCUM symbol that *emits* fine but *renders* wrong — one containing `<`, `&` or `%{`.

I'd rather state that plainly than let the path list imply coverage it doesn't provide.

## Verification

- YAML parses; both the `push` and `pull_request` path lists updated identically
- coupling proven by the mutation above, then reverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)
