### PR TITLE
build: gate dead code out of the binary flavors that cannot reach it

### DIFF
--- a/docs/contributor/STATS_QUICK_REFERENCE.md
+++ b/docs/contributor/STATS_QUICK_REFERENCE.md
@@ -10,7 +10,7 @@ The `stats` command in qsv is a high-performance CSV statistics engine that:
 - **Computes up to 48 summary statistics** per column (beyond the `field`/`type` identifiers)
 
 ## File Location
-`src/cmd/stats.rs` (~6,320 lines)
+`src/cmd/stats.rs` (~7,027 lines)
 
 ## Key Entry Points
 
@@ -175,7 +175,7 @@ Bob,25,87.2" | ./target/release/qsv stats
 - Full technical guide: `STATS_TECHNICAL_GUIDE.md` (this repo)
 - qsv wiki: https://github.com/dathere/qsv/wiki
 - stats command docs: `/docs/PERFORMANCE.md`
-- Test cases: `/tests/test_stats.rs` (~8,338 lines)
+- Test cases: `tests/test_stats.rs` (~9,319 lines)
 
 ## Quick Debugging
 
@@ -200,7 +200,7 @@ cat file.stats.csv.data.jsonl | jq . | head
 
 | File | Purpose |
 |------|---------|
-| `src/cmd/stats.rs` | Main implementation (~6,910 lines) |
+| `src/cmd/stats.rs` | Main implementation (~7,027 lines) |
 | `src/config.rs` | CSV reader configuration |
 | `src/select.rs` | Column selection logic |
 | `src/util.rs` | Utility functions |

--- a/src/clitypes.rs
+++ b/src/clitypes.rs
@@ -246,6 +246,7 @@ pub enum CliError {
     // An LLM inference/completion failure (HTTP/API error, empty response, etc.), as opposed
     // to an infrastructure error (cache backend, IO). Lets callers degrade gracefully on a
     // failed inference while still propagating infrastructure failures.
+    #[cfg(not(feature = "lite"))]
     Inference(String),
     Other(String),
 }
@@ -258,11 +259,12 @@ impl fmt::Display for CliError {
             CliError::Csv(e) => e.fmt(f),
             CliError::Io(e) => e.fmt(f),
             CliError::NoMatch() => f.write_str("no_match"),
+            #[cfg(not(feature = "lite"))]
+            CliError::Inference(s) => f.write_str(s),
             CliError::Other(s)
             | CliError::IncorrectUsage(s)
             | CliError::Encoding(s)
             | CliError::OutOfMemory(s)
-            | CliError::Inference(s)
             | CliError::Network(s) => f.write_str(s),
         }
     }

--- a/src/cmd/frequency.rs
+++ b/src/cmd/frequency.rs
@@ -464,6 +464,7 @@ struct FrequencyCacheMetadata {
 /// A neutral, read-only view of a frequency cache for consumers outside the
 /// `frequency` command (currently `viz smart`) that want each column's top
 /// value/count pairs without re-scanning the data.
+#[cfg(all(feature = "viz", feature = "feature_capable"))]
 pub(crate) struct FreqCacheView {
     /// Map of column field name -> per-column data. For `--no-headers` caches the keys are
     /// 1-based positional strings ("1", "2", ...). The `<HIGH_CARDINALITY>` / `<ALL_UNIQUE>`
@@ -475,6 +476,7 @@ pub(crate) struct FreqCacheView {
 /// and the count of empty/null cells (the cache's empty-string bucket). Kept separate so a
 /// consumer can render the null bucket as its own bar (or drop it) rather than mixing it into
 /// the value list.
+#[cfg(all(feature = "viz", feature = "feature_capable"))]
 pub(crate) struct FreqCacheColumn {
     /// Non-null `(value, count)` pairs, in the cache's stored order (count descending).
     pub pairs:      Vec<(String, u64)>,
@@ -487,6 +489,7 @@ pub(crate) struct FreqCacheColumn {
 /// Delegates to `Args::cache_path_for` so the path is derived EXACTLY as
 /// `read_frequency_cache_view` derives it — including its internal canonicalization, which is what
 /// makes `data.csv`, `./data.csv` and a symlink to it all resolve to the same cache file.
+#[cfg(all(feature = "viz", feature = "feature_capable"))]
 pub(crate) fn frequency_cache_path(path: &std::path::Path) -> std::path::PathBuf {
     Args::cache_path_for(path)
 }
@@ -511,6 +514,7 @@ pub(crate) fn frequency_cache_path(path: &std::path::Path) -> std::path::PathBuf
 ///   reordering.
 /// - Duplicate column names (across ALL entries, including sentinels) would make a name-keyed
 ///   lookup return the wrong column's data, so such caches are refused.
+#[cfg(all(feature = "viz", feature = "feature_capable"))]
 pub(crate) fn read_frequency_cache_view(
     path: &std::path::Path,
     no_nulls: bool,

--- a/src/cmd/geocode.rs
+++ b/src/cmd/geocode.rs
@@ -652,6 +652,10 @@ struct Args {
     flag_new_column:     Option<String>,
     flag_output:         Option<String>,
     flag_delimiter:      Option<Delimiter>,
+    #[cfg_attr(
+        not(any(feature = "feature_capable", feature = "lite")),
+        allow(dead_code)
+    )]
     flag_progressbar:    bool,
     flag_api_key:        Option<String>,
     flag_rate_limit:     u32,
@@ -3682,6 +3686,7 @@ fn resolve_geocode_cache_dir(fallback_cache_dir: &str) -> CliResult<PathBuf> {
 /// [`country_context`] lookup); `us_state_fips`/`us_county_fips` are the 2-digit state and 5-digit
 /// combined county FIPS codes for US matches. `Default` lets test literals spread `..`.
 #[derive(Clone, Debug, Default)]
+#[cfg(all(feature = "viz", feature = "feature_capable"))]
 pub struct GeoLabel {
     pub city:           String,
     pub admin1:         String,
@@ -3701,6 +3706,7 @@ pub struct GeoLabel {
 /// `lang` selects the language for the returned names (defaults to `"en"`); note the index must
 /// have been built with that language for non-English names to resolve.
 #[allow(clippy::cast_possible_truncation)]
+#[cfg(all(feature = "viz", feature = "feature_capable"))]
 pub fn reverse_geocode_points(
     points: &[(f64, f64)],
     lang: Option<&str>,
@@ -3807,18 +3813,21 @@ pub struct GeoRegion {
 /// no extra scanning or scoring. It has to be generous: a prefix match scores exactly 1.0 and ties
 /// break by population descending, so a small town in the hinted subdivision sits below every
 /// same-named larger city (measured: `Springfield` + `US.CO` needs far more than 10).
+#[cfg(all(feature = "viz", feature = "feature_capable"))]
 static SUGGEST_HINT_LIMIT: usize = 250;
 
 /// Matches a bare (unqualified) admin1 hint token, e.g. `AL`, `NYL`, `40`.
 ///
 /// Minimum 2 characters: the admin1 code scan is a `starts_with`, so a 1-character `A` would
 /// prefix-match `US.AK`, `US.AL`, `US.AR` and `US.AZ` alike.
+#[cfg(all(feature = "viz", feature = "feature_capable"))]
 static ADMIN1_BARE_REGEX: fn() -> &'static Regex = || regex_oncelock!(r"^[A-Za-z0-9]{2,8}$");
 
 /// The outcome of resolving one place name, distinguishing "nothing matched" from "a place matched
 /// but the caller's hint excluded it" so a caller can report the difference instead of silently
 /// dropping the row (issue #4427).
 #[derive(Clone, Debug)]
+#[cfg(all(feature = "viz", feature = "feature_capable"))]
 pub enum ForwardMatch {
     /// A place matched, and satisfied the hint (if any).
     Matched(GeoRegion),
@@ -3835,11 +3844,13 @@ pub enum ForwardMatch {
 /// Fields are private because [`Admin1Filter`] is an internal detail; build one with
 /// [`RegionHint::parse`]. A default (empty) hint filters nothing, which is the pre-#4427 behavior.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[cfg(all(feature = "viz", feature = "feature_capable"))]
 pub struct RegionHint {
     countries: Option<Vec<String>>,
     admin1:    Option<Vec<Admin1Filter>>,
 }
 
+#[cfg(all(feature = "viz", feature = "feature_capable"))]
 impl RegionHint {
     /// Parse one row's raw hint cells.
     ///
@@ -3922,6 +3933,7 @@ impl RegionHint {
 /// return its owned result. Centralizes the index-resolution + tokio + `as_engine` boilerplate so
 /// the engine (which borrows `EngineData`) stays alive for the whole batch and is dropped after
 /// `f` returns. Returns `Err` only on a hard setup failure (tokio runtime, index download/load).
+#[cfg(all(feature = "viz", feature = "feature_capable"))]
 fn with_geocode_engine<F, R>(f: F) -> CliResult<R>
 where
     F: FnOnce(&Engine) -> R,
@@ -3945,6 +3957,7 @@ where
 /// Derive a [`GeoRegion`] from a matched `CitiesRecord`. Returns `None` when the record has no
 /// country (the minimum needed for a region code). `iso3` is resolved via a country-info lookup;
 /// `us_state_code` is the 2-letter state code only when the country is the US.
+#[cfg(all(feature = "viz", feature = "feature_capable"))]
 fn cityrecord_to_region(
     engine: &Engine,
     cityrecord: &CitiesRecord,
@@ -4002,6 +4015,7 @@ fn cityrecord_to_region(
 /// It does NOT fix county-level error either — the nearest populated place is not the containing
 /// region, which is why lat/lon is not a route to county resolution (see issue #4417).
 #[allow(clippy::cast_possible_truncation)]
+#[cfg(all(feature = "viz", feature = "feature_capable"))]
 pub fn reverse_geocode_regions(
     points: &[(f64, f64)],
     hints: &[RegionHint],
@@ -4042,6 +4056,7 @@ pub fn reverse_geocode_regions(
 /// matches nothing at all — so a typo like `UK` (for `GB`) resolves zero rows and reads as "none of
 /// your places exist". Shared by BOTH region resolvers: the forward path is not the only one that
 /// can be handed a bad code (roborev #4291).
+#[cfg(all(feature = "viz", feature = "feature_capable"))]
 fn validate_hint_countries<'a>(
     engine: &Engine,
     hints: impl IntoIterator<Item = &'a RegionHint>,
@@ -4078,6 +4093,7 @@ fn validate_hint_countries<'a>(
 ///
 /// `lang` selects the localized-name language. `Err` only on a hard setup failure, or on a hint the
 /// engine cannot honor.
+#[cfg(all(feature = "viz", feature = "feature_capable"))]
 pub fn forward_geocode_regions(
     names: &[&str],
     hints: &[RegionHint],
@@ -4137,6 +4153,7 @@ pub fn forward_geocode_regions(
 /// names) with two deliberate differences: hint codes are compared for EQUALITY, since
 /// [`RegionHint::parse`] has already qualified them, and there is no `unwrap_or(first_result)` —
 /// an excluded candidate is reported, not substituted.
+#[cfg(all(feature = "viz", feature = "feature_capable"))]
 fn resolve_hinted_name(
     engine: &Engine,
     name: &str,
@@ -4193,6 +4210,7 @@ fn resolve_hinted_name(
 /// map's spatial-extent summary. `continent` is the Geonames continent name (`""` when
 /// unavailable).
 #[derive(Clone, Debug, Default)]
+#[cfg(all(feature = "viz", feature = "feature_capable"))]
 pub struct CountryContext {
     pub continent: String,
 }
@@ -4201,6 +4219,7 @@ pub struct CountryContext {
 /// `None` for a code that doesn't resolve (or carries no continent). `Err` only on a hard setup
 /// failure — callers (like `viz smart`) treat `Err` as "no context" and degrade gracefully.
 /// `continent` is expanded to a human-readable name (Geonames stores a 2-letter continent code).
+#[cfg(all(feature = "viz", feature = "feature_capable"))]
 pub fn country_context(iso2s: &[&str]) -> CliResult<Vec<Option<CountryContext>>> {
     with_geocode_engine(|engine| {
         iso2s
@@ -4219,6 +4238,7 @@ pub fn country_context(iso2s: &[&str]) -> CliResult<Vec<Option<CountryContext>>>
 
 /// Expand a Geonames 2-letter continent code to its human-readable name; unknown codes pass through
 /// unchanged (so a future/unrecognized code still shows something rather than nothing).
+#[cfg(any(all(feature = "viz", feature = "feature_capable"), test))]
 fn continent_name(code: &str) -> &str {
     match code {
         "AF" => "Africa",
@@ -4240,6 +4260,7 @@ fn lookup_us_state_fips_code(state: &str) -> Option<&'static str> {
 /// Derive `(us_state_fips, us_county_fips)` string codes for a matched city, for the enriched
 /// [`GeoLabel`]. Thin wrapper over [`us_fips_from_codes`] that pulls the admin1/admin2 codes off
 /// the record.
+#[cfg(all(feature = "viz", feature = "feature_capable"))]
 fn us_fips_strings(cityrecord: &CitiesRecord) -> (String, String) {
     us_fips_from_codes(
         cityrecord
@@ -4258,6 +4279,7 @@ fn us_fips_strings(cityrecord: &CitiesRecord) -> (String, String) {
 /// `us_county_fips` is the 5-digit combined state+county FIPS ("42003") or `""` when no valid US
 /// county code is present. The county segment is the LAST dotted component of the admin2 code (e.g.
 /// `US.NY.119` -> `119`), which is robust regardless of its leading digit.
+#[cfg(any(all(feature = "viz", feature = "feature_capable"), test))]
 fn us_fips_from_codes(admin1_code: Option<&str>, admin2_code: Option<&str>) -> (String, String) {
     let state_fips = admin1_code
         .and_then(|code| code.strip_prefix("US."))

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -105,10 +105,9 @@ pub mod safenames;
 pub mod sample;
 #[cfg(any(feature = "feature_capable", feature = "lite"))]
 pub mod schema;
-#[cfg(all(
-    feature = "polars",
-    any(feature = "feature_capable", feature = "datapusher_plus")
-))]
+// qsvdp does not register `scoresql` (no Command variant, no dispatch arm, no usage-text
+// line), so it is gated to the binaries that actually expose it.
+#[cfg(all(feature = "polars", feature = "feature_capable"))]
 pub mod scoresql;
 pub mod search;
 pub mod searchset;

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -123,6 +123,10 @@ struct Args {
     flag_size_limit:     usize,
     flag_dfa_size_limit: usize,
     flag_not_one:        bool,
+    #[cfg_attr(
+        not(any(feature = "feature_capable", feature = "lite")),
+        allow(dead_code)
+    )]
     flag_progressbar:    bool,
     flag_quiet:          bool,
     flag_jobs:           Option<usize>,

--- a/src/cmd/sortcheck.rs
+++ b/src/cmd/sortcheck.rs
@@ -112,6 +112,10 @@ struct Args {
     flag_all:         bool,
     flag_no_headers:  bool,
     flag_delimiter:   Option<Delimiter>,
+    #[cfg_attr(
+        not(any(feature = "feature_capable", feature = "lite")),
+        allow(dead_code)
+    )]
     flag_progressbar: bool,
     flag_json:        bool,
     flag_pretty_json: bool,
@@ -189,6 +193,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         return Ok(());
     }
 
+    #[cfg(any(feature = "feature_capable", feature = "lite"))]
     let record_count;
 
     // prep progress bar
@@ -207,10 +212,6 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             progress.set_draw_target(ProgressDrawTarget::hidden());
             0
         };
-    }
-    #[cfg(feature = "datapusher_plus")]
-    {
-        record_count = 0;
     }
 
     let do_json = args.flag_json || args.flag_pretty_json;

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -943,7 +943,19 @@ impl StatsData {
     pub fn mean_f64(&self) -> Option<f64> {
         stat_rendering_f64(self.mean.as_ref(), &self.r#type)
     }
+}
 
+/// The quartile and fence renderings as numbers.
+///
+/// Only `viz`, `frequency --filter` (luau) and the unit tests read these, so they are
+/// compiled out of builds that have neither (notably qsvlite). The two OUTER fences narrow
+/// this further - `viz` reads the quartiles and the inner fences, but never the outer pair.
+#[cfg(any(
+    feature = "luau",
+    all(feature = "viz", feature = "feature_capable"),
+    test
+))]
+impl StatsData {
     /// The numeric value of `q1`, or `None` when it is a date rendering.
     #[inline]
     pub fn q1_f64(&self) -> Option<f64> {
@@ -963,6 +975,7 @@ impl StatsData {
     }
 
     /// The numeric value of `lower_outer_fence`, or `None` when it is a date rendering.
+    #[cfg(any(feature = "luau", test))]
     #[inline]
     pub fn lower_outer_fence_f64(&self) -> Option<f64> {
         stat_rendering_f64(self.lower_outer_fence.as_ref(), &self.r#type)
@@ -981,6 +994,7 @@ impl StatsData {
     }
 
     /// The numeric value of `upper_outer_fence`, or `None` when it is a date rendering.
+    #[cfg(any(feature = "luau", test))]
     #[inline]
     pub fn upper_outer_fence_f64(&self) -> Option<f64> {
         stat_rendering_f64(self.upper_outer_fence.as_ref(), &self.r#type)

--- a/src/config.rs
+++ b/src/config.rs
@@ -531,6 +531,9 @@ impl Config {
         self
     }
 
+    // `color` and `transpose` are the only callers: `color` gates on the `color` feature,
+    // `transpose` on `feature_capable`/`lite`.
+    #[cfg(any(feature = "color", feature = "feature_capable", feature = "lite"))]
     pub fn set_write_buffer(mut self, buffer: usize) -> Config {
         self.write_buffer = u32::try_from(buffer).unwrap_or_else(|_| {
             warn!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -428,6 +428,7 @@ fn main() -> QsvExitCode {
                 util::log_end(qsv_args, now);
                 QsvExitCode::EncodingError
             },
+            #[cfg(not(feature = "lite"))]
             Err(CliError::Inference(msg)) => {
                 werr!("inference error: {msg}");
                 util::log_end(qsv_args, now);

--- a/src/maindp.rs
+++ b/src/maindp.rs
@@ -298,6 +298,7 @@ fn main() -> QsvExitCode {
                 util::log_end(qsv_args, now);
                 QsvExitCode::EncodingError
             },
+            #[cfg(not(feature = "lite"))]
             Err(CliError::Inference(msg)) => {
                 werr!("inference error: {msg}");
                 util::log_end(qsv_args, now);

--- a/src/mainlite.rs
+++ b/src/mainlite.rs
@@ -225,11 +225,6 @@ fn main() -> QsvExitCode {
                 util::log_end(qsv_args, now);
                 QsvExitCode::EncodingError
             },
-            Err(CliError::Inference(msg)) => {
-                werr!("inference error: {msg}");
-                util::log_end(qsv_args, now);
-                QsvExitCode::Bad
-            },
         },
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -23,7 +23,9 @@ use csv_index::RandomAccessSimple;
 use docopt::Docopt;
 use filetime::FileTime;
 use human_panic::setup_panic;
-use indicatif::{HumanCount, ProgressBar, ProgressDrawTarget, ProgressStyle};
+#[cfg(any(feature = "feature_capable", feature = "lite"))]
+use indicatif::ProgressDrawTarget;
+use indicatif::{HumanCount, ProgressBar, ProgressStyle};
 use log::{info, log_enabled, warn};
 #[cfg(feature = "polars")]
 use polars::prelude::Schema;
@@ -190,6 +192,9 @@ const WHITESPACE_MARKERS: &[(char, &str)] = &[
 /// care?", not to be arithmetic. Days are the largest unit: `qsv get --older-than` also accepts
 /// weeks on INPUT, but "28d" reads more plainly in a cache listing than "4w", and no caller
 /// round-trips this back through that parser.
+// `diskcache::rich`'s stale-refresh warning and `get cache-list`'s AGE column are the only
+// callers, and both live under the `get` feature.
+#[cfg(any(feature = "get", test))]
 pub fn fmt_duration_compact(secs: i64) -> String {
     const MINUTE: i64 = 60;
     const HOUR: i64 = 60 * MINUTE;
@@ -5280,6 +5285,7 @@ pub fn run_qsv_cmd(
 /// success; use when the caller only needs the child's on-disk side effects (e.g. `moarstats`'
 /// stats/bivariate cache sidecars), not its stdout. Callers that render their own progress bar
 /// should suspend it around this call so the two don't collide.
+#[cfg(all(feature = "viz", feature = "feature_capable"))]
 pub fn run_qsv_cmd_streaming(
     command: &str,
     args: &[&str],


### PR DESCRIPTION
`cargo build -F lite` emitted 8 dead-code warnings and `-F datapusher_plus` emitted 69. Every item is now gated on the feature its **actual consumers** are gated on, so it is no longer compiled into a binary that cannot reach it.

| binary | before | after |
|---|---|---|
| `qsvlite` (`-F lite`) | 8 | **0** |
| `qsvdp` (`-F datapusher_plus`) | 69 | **0** |
| `qsvmcp` (`-F qsvmcp`) | 2 | **0** |
| `qsv` (`-F all_features`) | 0 | **0** |

## What moved

- **`StatsData` quartile/fence accessors** — split into a second `impl` block gated on `luau` / `viz`. The two *outer* fences narrow further (`any(luau, test)`), since `viz` reads only the quartiles and the inner fences.
- **`frequency`'s cache-view API** (`FreqCacheView`, `FreqCacheColumn`, `frequency_cache_path`, `read_frequency_cache_view`) and **`util::run_qsv_cmd_streaming`** — `viz`-only.
- **`util::fmt_duration_compact`** — gated on `get`. Both callers (`diskcache::rich`'s stale-refresh warning and `get cache-list`'s AGE column) live under that feature. This also clears two long-standing **qsvmcp** warnings.
- **`CliError::Inference`** — `describegpt`-only, so gated `not(lite)`, and the now-unreachable handler arm is dropped from `mainlite.rs`. The `Display` arm had to leave the or-pattern: `#[cfg]` is illegal on an or-pattern alternative but legal on a match arm.
- **`geocode`'s trailing `viz smart` section** (18 items) — gated on `viz`. Note the section is *not* uniformly viz-only: `GeoRegion`, `lookup_us_state_fips_code`, `get_us_fips_codes` and `add_fields` sit in the same range and are live, so only the unreachable items are gated.
- **`sortcheck`'s `record_count`** — had a `datapusher_plus`-only `= 0` assignment with no reader; the declaration is now gated alongside its readers and that block is gone.
- **`Config::set_write_buffer`** → its callers (`color`, `transpose`); **`ProgressDrawTarget`**'s import → the progressbar cfg.

## `scoresql`

38 of qsvdp's 69 were the entire `scoresql` module. Its gate in `cmd/mod.rs` claimed `datapusher_plus`, but `maindp.rs` never registered it — no `Command` variant, no dispatch arm, no usage-text line — making it the **only** dp-gated module in the tree that was not wired up. The gate now matches the binaries that actually expose the command.

**qsvdp's behavior is unchanged** — it never exposed `scoresql`; it was compiling ~1,700 unreachable lines. No doc or command count anywhere claimed `scoresql` for qsvdp.

## One deliberate exception

The three `flag_progressbar` fields stay **compiled**; only the lint is suppressed:

```rust
#[cfg_attr(not(any(feature = "feature_capable", feature = "lite")), allow(dead_code))]
flag_progressbar: bool,
```

The field is part of the docopt USAGE contract, so removing it would change CLI parsing. The precise per-field form is used in preference to `search.rs`'s struct-wide `#[allow(dead_code)]`, which would also mask a genuinely unused field added to `Args` later.

## Verification

- All four binaries build warning-free.
- `cargo test --no-run` passes for `lite`, `datapusher_plus`, `qsvmcp`, `all_features` — this matters: `cargo build` does not compile `#[cfg(test)]`, and it is what caught two `geocode` helpers that are reached only by in-crate unit tests (they carry `test` in their gate).
- Unit tests green: 143 (lite), 580 (qsvdp), 1150 (all_features). `sortcheck` integration green under qsvdp (30 passed) — that is the only real control-flow edit.
- `clippy` clean apart from three pre-existing warnings (two `viz.rs` doc-markdown, one `maindp.rs:4` lint block).
- Formatted with `cargo +nightly fmt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)