### PR TITLE
fix(pivotp): enforce the column cap unconditionally (#4589)

### DIFF
--- a/.claude/skills/qsv/qsv-pivotp.json
+++ b/.claude/skills/qsv/qsv-pivotp.json
@@ -69,6 +69,12 @@
         "description": "Maintain output order: preserve input column order in pivot mode, and preserve group/row order in group-by mode."
       },
       {
+        "flag": "--max-columns",
+        "type": "string",
+        "description": "Maximum number of columns the pivot may create before it is refused. Guards against pivoting on a high-cardinality column, which can exhaust memory. Unlike --validate, this ALWAYS runs. Set to 0 for no limit, for a deliberately wide pivot. (pivot mode only; ignored in group-by mode)",
+        "default": "100000"
+      },
+      {
         "flag": "--output",
         "type": "string",
         "description": "Write output to <file> instead of stdout."
@@ -97,7 +103,7 @@
       {
         "flag": "--validate",
         "type": "flag",
-        "description": "Validate a pivot by checking the pivot column(s)' cardinality. (pivot mode only)"
+        "description": "Report the pivot column(s)' cardinality before pivoting. Informational only - it does not refuse a pivot; --max-columns does that. (pivot mode only)"
       },
       {
         "flag": "--values",

--- a/docs/help/pivotp.md
+++ b/docs/help/pivotp.md
@@ -62,7 +62,8 @@ qsv pivotp --help
 | &nbsp;`‑‑sort‑columns`&nbsp; | flag | Sort the transposed columns by name. (pivot mode only) |  |
 | &nbsp;`‑‑maintain‑order`&nbsp; | flag | Maintain output order: preserve input column order in pivot mode, and preserve group/row order in group-by mode. |  |
 | &nbsp;`‑‑col‑separator`&nbsp; | string | The separator in generated column names in case of multiple --values columns. (pivot mode only; ignored in group-by mode) | `_` |
-| &nbsp;`‑‑validate`&nbsp; | flag | Validate a pivot by checking the pivot column(s)' cardinality. (pivot mode only) |  |
+| &nbsp;`‑‑validate`&nbsp; | flag | Report the pivot column(s)' cardinality before pivoting. Informational only - it does not refuse a pivot; --max-columns does that. (pivot mode only) |  |
+| &nbsp;`‑‑max‑columns`&nbsp; | integer | Maximum number of columns the pivot may create before it is refused. Guards against pivoting on a high-cardinality column, which can exhaust memory. Unlike --validate, this ALWAYS runs. Set to 0 for no limit, for a deliberately wide pivot. (pivot mode only; ignored in group-by mode) | `100000` |
 | &nbsp;`‑‑try‑parsedates`&nbsp; | flag | When set, will attempt to parse columns as dates. |  |
 | &nbsp;`‑‑infer‑len`&nbsp; | integer | Number of rows to scan when inferring schema. Set to 0 to scan entire file. | `10000` |
 | &nbsp;`‑‑decimal‑comma`&nbsp; | flag | Use comma as decimal separator when READING the input. Note that you will need to specify an alternate --delimiter. |  |

--- a/src/cmd/pivotp.rs
+++ b/src/cmd/pivotp.rs
@@ -79,7 +79,14 @@ pivotp options:
                             and preserve group/row order in group-by mode.
     --col-separator <arg>   The separator in generated column names in case of multiple --values columns.
                             (pivot mode only; ignored in group-by mode) [default: _]
-    --validate              Validate a pivot by checking the pivot column(s)' cardinality. (pivot mode only)
+    --validate              Report the pivot column(s)' cardinality before pivoting. Informational
+                            only - it does not refuse a pivot; --max-columns does that.
+                            (pivot mode only)
+    --max-columns <n>       Maximum number of columns the pivot may create before it is refused.
+                            Guards against pivoting on a high-cardinality column, which can
+                            exhaust memory. Unlike --validate, this ALWAYS runs.
+                            Set to 0 for no limit, for a deliberately wide pivot.
+                            (pivot mode only; ignored in group-by mode) [default: 100000]
     --try-parsedates        When set, will attempt to parse columns as dates.
     --infer-len <arg>       Number of rows to scan when inferring schema.
                             Set to 0 to scan entire file. [default: 10000]
@@ -199,6 +206,7 @@ struct Args {
     flag_maintain_order: bool,
     flag_col_separator:  String,
     flag_validate:       bool,
+    flag_max_columns:    u64,
     flag_try_parsedates: bool,
     flag_infer_len:      usize,
     flag_decimal_comma:  bool,
@@ -261,8 +269,12 @@ fn calculate_pivot_metadata(
     })
 }
 
-/// Validate pivot operation using metadata
-fn validate_pivot_operation(metadata: &PivotMetadata) -> CliResult<()> {
+/// Print the pivot's cardinality report. `--validate` only; purely informational.
+///
+/// `metadata.estimated_columns` is the PRODUCT of the per-column cardinalities, i.e. an upper
+/// bound - correlated <on-cols> produce far fewer real columns. That is fine for a warning, but
+/// it is why the hard cap lives in `enforce_max_columns` against the exact count instead.
+fn report_pivot_cardinality(metadata: &PivotMetadata) {
     const COLUMN_WARNING_THRESHOLD: u64 = 1000;
 
     // Print cardinality information
@@ -282,13 +294,37 @@ fn validate_pivot_operation(metadata: &PivotMetadata) -> CliResult<()> {
             HumanCount(metadata.estimated_columns)
         );
     }
+}
 
-    // Error if operation would create an unreasonable number of columns
-    if metadata.estimated_columns > 100_000 {
+/// Refuse a pivot whose output would be wider than `max_columns` (0 = no limit).
+///
+/// Enforced ALWAYS, not just under `--validate` (#4589): pivoting on a high-cardinality column
+/// otherwise grows memory until the OS kills the process, which is strictly worse than the error
+/// the command already knew how to emit.
+///
+/// `on_col_groups` is `unique_df.height()` - the EXACT number of distinct <on-cols> combinations,
+/// not the stats-derived product. That matters twice over: the exact count cannot false-positive
+/// on correlated <on-cols> (e.g. `state` x `state_abbrev`, where the product is quadratic but the
+/// width is linear), and it cannot fail open when the stats cache is unavailable, which the
+/// estimate silently does.
+fn enforce_max_columns(
+    on_col_groups: u64,
+    value_col_count: u64,
+    max_columns: u64,
+) -> CliResult<()> {
+    if max_columns == 0 {
+        return Ok(());
+    }
+
+    let actual = on_col_groups.saturating_mul(value_col_count);
+    if actual > max_columns {
+        // Name the remedy flag - an escape hatch nobody can discover is the same as none.
         return fail_clierror!(
-            "Pivot would create too many columns ({}). Consider reducing the number of pivot \
-             columns or using a different approach.",
-            HumanCount(metadata.estimated_columns)
+            "Pivot would create {} columns, exceeding the --max-columns limit of {}. Pivot on a \
+             lower-cardinality column, raise --max-columns, or set --max-columns 0 to disable \
+             this limit.",
+            HumanCount(actual),
+            HumanCount(max_columns)
         );
     }
 
@@ -1222,7 +1258,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         {
             // Validation uses cached stats records, not the DataFrame itself,
             // so we don't need to collect the LazyFrame here.
-            validate_pivot_operation(&metadata)?;
+            report_pivot_cardinality(&metadata);
         }
 
         // Compute unique values for the pivot columns to create on_columns DataFrame
@@ -1244,6 +1280,16 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                 .sort([row_order_col], SortMultipleOptions::default())
                 .drop(cols([row_order_col]))
                 .collect()?;
+
+            // Hard cap on output width (#4589). This is the earliest point where the EXACT
+            // column count is known, and it is still before the pivot itself - which is where
+            // the unbounded allocation happened. The `unique` above is bounded by the number of
+            // distinct <on-cols> combinations, so it cannot blow up the way the pivot can.
+            enforce_max_columns(
+                unique_df.height() as u64,
+                actual_value_cols.len() as u64,
+                args.flag_max_columns,
+            )?;
 
             Arc::new(unique_df)
         };

--- a/tests/test_pivotp.rs
+++ b/tests/test_pivotp.rs
@@ -847,6 +847,132 @@ pivotp_test!(
     }
 );
 
+// #4589 regression: the column cap must fire WITHOUT --validate. Before the fix the cap was
+// gated behind that opt-in flag, so the default path grew memory until the OS killed it.
+pivotp_test!(
+    pivotp_max_columns_exceeded,
+    |wrk: Workdir, mut cmd: process::Command| {
+        cmd.args([
+            "product",
+            "--index",
+            "date",
+            "--values",
+            "sales",
+            "--max-columns",
+            "1",
+            "sales.csv",
+        ]);
+
+        let stderr = wrk.stderr_on_error(&mut cmd);
+        assert!(
+            stderr.contains("exceeding the --max-columns limit"),
+            "expected the cap to fire without --validate, got: {stderr}"
+        );
+    }
+);
+
+// The escape hatch: a deliberately wide pivot stays possible. Before #4589 this was expressed
+// by simply omitting --validate, so without `0` the fix would remove a capability.
+pivotp_test!(
+    pivotp_max_columns_zero_unlimited,
+    |wrk: Workdir, mut cmd: process::Command| {
+        cmd.args([
+            "product",
+            "--index",
+            "date",
+            "--values",
+            "sales",
+            "--max-columns",
+            "0",
+            "sales.csv",
+        ]);
+
+        let got: Vec<Vec<String>> = wrk.read_stdout_on_success(&mut cmd);
+        // Values are smart-agg'd (--agg defaults to smart); what this test pins is that
+        // --max-columns 0 leaves the result identical to an uncapped pivot.
+        let expected = vec![
+            svec!["date", "A", "B"],
+            svec!["2023-01-01", "150.0", "150.0"],
+            svec!["2023-01-02", "300.0", "300.0"],
+        ];
+        assert_eq!(got, expected);
+    }
+);
+
+// --validate still reports, and the cap still aborts, and the report comes first.
+pivotp_test!(
+    pivotp_max_columns_with_validate,
+    |wrk: Workdir, mut cmd: process::Command| {
+        cmd.args([
+            "product",
+            "--index",
+            "date",
+            "--values",
+            "sales",
+            "--validate",
+            "--max-columns",
+            "1",
+            "sales.csv",
+        ]);
+
+        let stderr = wrk.stderr_on_error(&mut cmd);
+        assert!(
+            stderr.contains("Pivot on-column cardinality"),
+            "--validate report should still print, got: {stderr}"
+        );
+        assert!(
+            stderr.contains("exceeding the --max-columns limit"),
+            "cap should still abort under --validate, got: {stderr}"
+        );
+    }
+);
+
+// The cap measures the EXACT number of distinct <on-cols> combinations, not the product of the
+// per-column cardinalities. Here `product` and `region` are perfectly correlated: the product
+// estimate is 2 x 2 = 4, but only 2 combinations exist. Capping on the estimate would abort a
+// pivot that produces 2 columns - and because the cap is now always-on, that would break pivots
+// that worked before. Both halves matter: without the --max-columns 1 run this test would pass
+// even if the cap were removed entirely.
+#[test]
+fn pivotp_max_columns_uses_exact_count_not_estimate() {
+    let wrk = Workdir::new("pivotp_max_columns_uses_exact_count_not_estimate");
+    let data = vec![
+        svec!["date", "product", "region", "sales"],
+        svec!["2023-01-01", "A", "North", "100"],
+        svec!["2023-01-02", "A", "North", "200"],
+        svec!["2023-01-01", "B", "South", "150"],
+        svec!["2023-01-02", "B", "South", "250"],
+    ];
+    wrk.create("corr.csv", data);
+
+    let run = |max_columns: &str| {
+        let mut cmd = wrk.command("pivotp");
+        cmd.args([
+            "product,region",
+            "--index",
+            "date",
+            "--values",
+            "sales",
+            "--max-columns",
+            max_columns,
+            "corr.csv",
+        ]);
+        cmd
+    };
+
+    // 2 real columns <= 3, even though the cardinality product is 4.
+    let mut ok = run("3");
+    wrk.assert_success(&mut ok);
+
+    // ...and the cap is genuinely live on the same input.
+    let mut err = run("1");
+    let stderr = wrk.stderr_on_error(&mut err);
+    assert!(
+        stderr.contains("exceeding the --max-columns limit"),
+        "expected the cap to fire at 1, got: {stderr}"
+    );
+}
+
 // Test smart aggregation without moarstats — graceful degradation to existing behavior
 // Normal numeric data with CV > 1% should use Median (existing CV-based behavior)
 #[test]
@@ -2061,5 +2187,23 @@ pivotp_groupby_test!(
             stderr.contains("--agg item is not supported in group-by mode"),
             "Expected --agg item error, got: {stderr}"
         );
+    }
+);
+
+// The cap is pivot-mode only; group-by mode does not widen output per distinct value, so a
+// tiny --max-columns must not leak across and reject a valid group-by.
+pivotp_groupby_test!(
+    pivotp_groupby_max_columns_ignored,
+    |wrk: Workdir, mut cmd: process::Command| {
+        cmd.args([
+            "--index",
+            "GROUP",
+            "--agg",
+            "len",
+            "--max-columns",
+            "1",
+            "test.csv",
+        ]);
+        wrk.assert_success(&mut cmd);
     }
 );


### PR DESCRIPTION
Closes #4589.

## The bug

`pivotp` already knew how to refuse an unreasonable pivot — `validate_pivot_operation()`
hard-errored above 100,000 estimated output columns — but the guard only ran behind opt-in
`--validate`. So the **default** behaviour for a high-cardinality pivot column was not the clean
error the command could already emit; it was unbounded memory growth until the OS killed
something.

Measured on a 200k-row slice of the NYC 311 sample (pivot column cardinality 173,103), debug build:

| invocation | outcome |
| --- | --- |
| `pivotp … --validate` | exit 1 in seconds — *"Pivot would create too many columns (173,103)"* |
| `pivotp …` (no flag) | **12 GiB RSS in 40 s**, still climbing when a watchdog killed it |

Not hypothetical. This is what left 23.0.0 without its `x86_64-unknown-linux-gnu` asset:
`scripts/pgo-train.sh` pivoted on `Created Date` (841,014 distinct values) and OOM-killed the
publish runner VM three times in run 34670874141, surfacing as `exit 143` / *"the hosted runner
lost communication with the server"* with nothing memory-related in the log. That script is
already fixed (139c2ef33); this PR is the underlying command bug.

## The change

Split the guard into its two unrelated jobs:

| | |
| --- | --- |
| `report_pivot_cardinality()` | the cardinality dump and the >1,000-column warning. Still `--validate` only, byte-identical output. |
| `enforce_max_columns()` | the hard cap. **Runs always.** |

**The cap counts exactly rather than estimating.** `metadata.estimated_columns` is the *product*
of the per-column cardinalities — an upper bound — and capping on it is wrong twice over once the
cap is always-on:

- **False positives.** On correlated `<on-cols>` the product is quadratic while the real width is
  linear. Verified on a fixture where `product` and `region` are perfectly correlated: real output
  **2** columns, estimate **4**, and `--max-columns 3` aborted a pivot that works. That would have
  broken pivots which succeed in 23.0.0.
- **Fails open.** `calculate_pivot_metadata` returns `None` when stats are unavailable, so the
  guard would silently not run — the *second* gap #4589 documents, left wide open by the fix meant
  to close it.

`enforce_max_columns` takes `unique_df.height()` instead: the exact count of distinct `<on-cols>`
combinations, already computed unconditionally immediately before the pivot. It touches stats not
at all, so it can neither false-positive nor fail open, and an explicit non-`smart` `--agg` no
longer newly forces a stats run. **Both gaps in #4589 are closed, not deferred** — what still
degrades without stats is the `--validate` *report*, a missing report rather than a missing guard.

**New `--max-columns <n>`**, `[default: 100000]`, `0` = unlimited. Without an escape hatch this
would *remove* a capability: today omitting `--validate` is how you ask for a deliberately wide
pivot. The error names the flag, since an escape hatch nobody can discover is the same as none.

`--validate`'s own help text claimed it "validates" a pivot, which is now false — it reports and
nothing more. Reworded so `--help` does not point at the wrong flag; that is the same
discoverability failure this issue is about, moved one flag over.

## ⚠️ Breaking

A pivot wider than 100,000 columns that succeeded in 23.0.0 now aborts. `--max-columns 0`, or a
higher value, restores it. Belongs under **Breaking Changes** in the changelog, not just *Fixed*.

## Verification

```
$ qsv pivotp "Created Date" --index Borough --values "Complaint Type" NYC_311_...-1M.csv
exit=1  elapsed=7s
Pivot would create 841,014 columns, exceeding the --max-columns limit of 100,000.
Pivot on a lower-cardinality column, raise --max-columns, or set --max-columns 0 to disable this limit.
```

The exact command that killed three CI runners, now failing in 7 s.

- **Full suite: 5,041 passed, 0 failed.** clippy clean; `docs-drift-check`, `double-run-check` and
  `check-publish-matrix-sync` all green.
- 5 tests added. `pivotp_max_columns_uses_exact_count_not_estimate` runs the correlated fixture at
  `--max-columns 3` (must pass) **and** at `1` (must fail) — without the second half it would pass
  even with the guard removed entirely.
- `pivotp_validate`'s exact full-stderr `assert_eq!` is deliberately untouched: under this design
  its output is unchanged, so if it ever goes red the report path was modified by accident.
- `docs/help/pivotp.md` and `.claude/skills/qsv/qsv-pivotp.json` are regenerated via
  `--update-mcp-skills`, not hand-edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
